### PR TITLE
chore(Tracking): fix case of property name

### DIFF
--- a/Runtime/Tracking/Follow/Modifier/Property/PropertyModifier.cs
+++ b/Runtime/Tracking/Follow/Modifier/Property/PropertyModifier.cs
@@ -14,7 +14,7 @@
         /// </summary>
         [Serialized, Validated]
         [field: DocumentedByXml]
-        public bool applyOffset { get; set; } = true;
+        public bool ApplyOffset { get; set; } = true;
 
         /// <summary>
         /// Emitted before the property is modified.
@@ -43,7 +43,7 @@
                 return;
             }
 
-            offset = (applyOffset ? offset : null);
+            offset = (ApplyOffset ? offset : null);
 
             Premodified?.Invoke(eventData.Set(source, target, offset));
             DoModify(source, target, offset);

--- a/Tests/Editor/Tracking/Follow/Modifier/Property/Position/RigidbodyVelocityTest.cs
+++ b/Tests/Editor/Tracking/Follow/Modifier/Property/Position/RigidbodyVelocityTest.cs
@@ -101,7 +101,7 @@ namespace Test.Zinnia.Tracking.Follow.Modifier.Property.Position
             Assert.AreEqual(Vector3.zero, subjectRigidbody.velocity);
             Assert.AreEqual(Vector3.zero, subjectRigidbody.angularVelocity);
 
-            subject.applyOffset = false;
+            subject.ApplyOffset = false;
             subject.Modify(source, target, offset);
 
             Assert.AreEqual(expectedVelocity.ToString(), subjectRigidbody.velocity.ToString());

--- a/Tests/Editor/Tracking/Follow/Modifier/Property/Position/TransformPositionTest.cs
+++ b/Tests/Editor/Tracking/Follow/Modifier/Property/Position/TransformPositionTest.cs
@@ -74,7 +74,7 @@ namespace Test.Zinnia.Tracking.Follow.Modifier.Property.Position
             target.transform.position = Vector3.zero;
             offset.transform.position = Vector3.one * 0.5f;
 
-            subject.applyOffset = false;
+            subject.ApplyOffset = false;
             subject.Modify(source, target, offset);
 
             Assert.AreEqual(Vector3.one, source.transform.position);

--- a/Tests/Editor/Tracking/Follow/Modifier/Property/Rotation/RigidbodyAngularVelocityTest.cs
+++ b/Tests/Editor/Tracking/Follow/Modifier/Property/Rotation/RigidbodyAngularVelocityTest.cs
@@ -101,7 +101,7 @@ namespace Test.Zinnia.Tracking.Follow.Modifier.Property.Rotation
             Assert.AreEqual(Vector3.zero, subjectRigidbody.velocity);
             Assert.AreEqual(Vector3.zero, subjectRigidbody.angularVelocity);
 
-            subject.applyOffset = false;
+            subject.ApplyOffset = false;
             subject.Modify(source, target, offset);
 
             Assert.AreEqual(expectedVelocity.ToString(), subjectRigidbody.velocity.ToString());

--- a/Tests/Editor/Tracking/Follow/Modifier/Property/Rotation/TransformRotationTest.cs
+++ b/Tests/Editor/Tracking/Follow/Modifier/Property/Rotation/TransformRotationTest.cs
@@ -79,7 +79,7 @@ namespace Test.Zinnia.Tracking.Follow.Modifier.Property.Rotation
             target.transform.rotation = Quaternion.identity;
             offset.transform.rotation = Quaternion.Euler(0f, 45f, 0f);
 
-            subject.applyOffset = false;
+            subject.ApplyOffset = false;
             subject.Modify(source, target, offset);
 
             Assert.AreEqual(sourceRotation, source.transform.rotation);

--- a/Tests/Editor/Tracking/Follow/Modifier/Property/Scale/TransformScaleTest.cs
+++ b/Tests/Editor/Tracking/Follow/Modifier/Property/Scale/TransformScaleTest.cs
@@ -74,7 +74,7 @@ namespace Test.Zinnia.Tracking.Follow.Modifier.Property.Scale
             source.transform.localScale = Vector3.one;
             offset.transform.localScale = Vector3.one * 0.5f;
 
-            subject.applyOffset = false;
+            subject.ApplyOffset = false;
             subject.Modify(source, target, offset);
 
             Assert.AreEqual(Vector3.one, source.transform.localScale);


### PR DESCRIPTION
According to the code conventions properties should use PascalCase,
not camelCase.