### PR TITLE
feat(Data): add shorthand Vector3State options

### DIFF
--- a/Runtime/Data/Type/Vector3State.cs
+++ b/Runtime/Data/Type/Vector3State.cs
@@ -26,14 +26,29 @@
         public bool zState;
 
         /// <summary>
-        /// Default Vector3State of all false.
+        /// Shorthand for writing <c>Vector3State(false, false, false)</c>.
         /// </summary>
         public static readonly Vector3State False = new Vector3State(false, false, false);
 
         /// <summary>
-        /// Default Vector3State of all true.
+        /// Shorthand for writing <c>Vector3State(true, true, true)</c>.
         /// </summary>
         public static readonly Vector3State True = new Vector3State(true, true, true);
+
+        /// <summary>
+        /// Shorthand for writing <c>Vector3State(true, false, false)</c>.
+        /// </summary>
+        public static readonly Vector3State XOnly = new Vector3State(true, false, false);
+
+        /// <summary>
+        /// Shorthand for writing <c>Vector3State(false, true, false)</c>.
+        /// </summary>
+        public static readonly Vector3State YOnly = new Vector3State(false, true, false);
+
+        /// <summary>
+        /// Shorthand for writing <c>Vector3State(false, false, true)</c>.
+        /// </summary>
+        public static readonly Vector3State ZOnly = new Vector3State(false, false, true);
 
         /// <summary>
         /// The Constructor that allows setting the individual states at instantiation.

--- a/Tests/Editor/Data/Type/Vector3StateTest.cs
+++ b/Tests/Editor/Data/Type/Vector3StateTest.cs
@@ -25,6 +25,33 @@ namespace Test.Zinnia.Data.Type
         }
 
         [Test]
+        public void DefaultStateXAxis()
+        {
+            Vector3State actualResult = Vector3State.XOnly;
+            Assert.IsTrue(actualResult.xState);
+            Assert.IsFalse(actualResult.yState);
+            Assert.IsFalse(actualResult.zState);
+        }
+
+        [Test]
+        public void DefaultStateYAxis()
+        {
+            Vector3State actualResult = Vector3State.YOnly;
+            Assert.IsFalse(actualResult.xState);
+            Assert.IsTrue(actualResult.yState);
+            Assert.IsFalse(actualResult.zState);
+        }
+
+        [Test]
+        public void DefaultStateZAxis()
+        {
+            Vector3State actualResult = Vector3State.ZOnly;
+            Assert.IsFalse(actualResult.xState);
+            Assert.IsFalse(actualResult.yState);
+            Assert.IsTrue(actualResult.zState);
+        }
+
+        [Test]
         public void CustomInitialState()
         {
             Vector3State actualResult = new Vector3State(false, true, false);


### PR DESCRIPTION
The Vector3State has some additional shorthand options for setting
states that represent the x, y, z coordinate.