### PR TITLE
feat(Data): add zero value shortcut to FloatRange

### DIFF
--- a/Runtime/Data/Type/FloatRange.cs
+++ b/Runtime/Data/Type/FloatRange.cs
@@ -22,6 +22,11 @@
         public float maximum;
 
         /// <summary>
+        /// Shorthand for writing <c>FloatRange(0f, 0f)</c>.
+        /// </summary>
+        public static readonly FloatRange Zero = new FloatRange(0f, 0f);
+
+        /// <summary>
         /// Constructs a new range with the minimum value being <see cref="float.MinValue"/> and the maximum value being <see cref="float.MaxValue"/>.
         /// </summary>
         public FloatRange()
@@ -58,7 +63,7 @@
         /// <returns><see langword="true"/> if the value is found within the range.</returns>
         public bool Contains(float value)
         {
-            return (value >= minimum && value <= maximum);
+            return value >= minimum && value <= maximum;
         }
 
         /// <summary>

--- a/Tests/Editor/Data/Type/FloatRangeTest.cs
+++ b/Tests/Editor/Data/Type/FloatRangeTest.cs
@@ -32,6 +32,14 @@ namespace Test.Zinnia.Data.Type
         }
 
         [Test]
+        public void ConstructFromStaticZero()
+        {
+            FloatRange range = FloatRange.Zero;
+            Assert.AreEqual(0f, range.minimum);
+            Assert.AreEqual(0f, range.maximum);
+        }
+
+        [Test]
         public void Contains()
         {
             FloatRange range = new FloatRange(0.3f, 0.8f);


### PR DESCRIPTION
The default constructor of the FloatRange creates a FloatRange with a
float minimum and float maximum value, but on occasion it is useful to
set the default to zero (0f, 0f) without having to manually create the
constructor so a shorthand static FloatRange.Zero has been added.