### PR TITLE
chore(structure): fix invalid XML documentation comments

### DIFF
--- a/Runtime/Tracking/Velocity/ArtificialVelocityApplier.cs
+++ b/Runtime/Tracking/Velocity/ArtificialVelocityApplier.cs
@@ -67,7 +67,7 @@
         private Coroutine decelerationRoutine;
 
         /// <summary>
-        /// Applies the velocity data to the <see cref="target"/>.
+        /// Applies the velocity data to the <see cref="Target"/>.
         /// </summary>
         public virtual void Apply()
         {


### PR DESCRIPTION
XML documentation comments that reference an identifier were updated
to ensure they reference identifiers by their correct name.