### PR TITLE
chore(tests): fix warning log for Vector3RestrictorTest

### DIFF
--- a/Tests/Editor/Data/Type/Transformation/Vector3RestrictorTest.cs
+++ b/Tests/Editor/Data/Type/Transformation/Vector3RestrictorTest.cs
@@ -7,7 +7,7 @@ namespace Test.Zinnia.Data.Type.Transformation
     using NUnit.Framework;
     using Test.Zinnia.Utility.Mock;
 
-    public class Vector3RestrictorTest : MonoBehaviour
+    public class Vector3RestrictorTest
     {
         private GameObject containingObject;
         private Vector3Restrictor subject;
@@ -22,8 +22,8 @@ namespace Test.Zinnia.Data.Type.Transformation
         [TearDown]
         public void TearDown()
         {
-            DestroyImmediate(subject);
-            DestroyImmediate(containingObject);
+            Object.DestroyImmediate(subject);
+            Object.DestroyImmediate(containingObject);
         }
 
         [Test]


### PR DESCRIPTION
`Vector3RestrictorTest` was a `MonoBehaviour` which is wrong and
results in warnings being logged by Unity when running the test as
creation of behaviours isn't possible in the Unity test runner this
way. The fix is to make `Vector3RestrictorTest` a regular C# class.