### PR TITLE
feat(Tracking): add extractor for collision target

### DIFF
--- a/Runtime/Tracking/Collision/Active/Operation/NotifierTargetExtractor.cs
+++ b/Runtime/Tracking/Collision/Active/Operation/NotifierTargetExtractor.cs
@@ -1,0 +1,37 @@
+﻿namespace Zinnia.Tracking.Collision.Active.Operation
+{
+    using UnityEngine;
+    using Zinnia.Event;
+
+    /// <summary>
+    /// Extracts the <see cref="GameObject"/> of the <see cref="Collider"/> from a given <see cref="CollisionNotifier.EventData"/>.
+    /// </summary>
+    public class NotifierTargetExtractor : GameObjectEmitter
+    {
+        /// <summary>
+        /// Extracts the <see cref="GameObject"/> of the <see cref="Collider"/> from the given <see cref="CollisionNotifier.EventData"/>.
+        /// </summary>
+        /// <param name="eventData">The notifier event data to extract from.</param>
+        /// <returns>The <see cref="GameObject"/> of the <see cref="Collider"/> within the event data.</returns>
+        public virtual GameObject Extract(CollisionNotifier.EventData eventData)
+        {
+            if (eventData == null || eventData.collider == null)
+            {
+                Result = null;
+                return null;
+            }
+
+            Result = eventData.collider.gameObject;
+            return base.Extract();
+        }
+
+        /// <summary>
+        /// Extracts the <see cref="GameObject"/> of the <see cref="Collider"/> from the given <see cref="CollisionNotifier.EventData"/>.
+        /// </summary>
+        /// <param name="notifier">The notifier event data to extract from.</param>
+        public virtual void DoExtract(CollisionNotifier.EventData notifier)
+        {
+            Extract(notifier);
+        }
+    }
+}

--- a/Runtime/Tracking/Collision/Active/Operation/NotifierTargetExtractor.cs.meta
+++ b/Runtime/Tracking/Collision/Active/Operation/NotifierTargetExtractor.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 6ba768ecdd7b4b2e99b76e6ee4960c23
+timeCreated: 1550322816

--- a/Tests/Editor/Tracking/Collision/Active/Operation/NotifierTargetExtractorTest.cs
+++ b/Tests/Editor/Tracking/Collision/Active/Operation/NotifierTargetExtractorTest.cs
@@ -1,0 +1,115 @@
+﻿using Zinnia.Tracking.Collision;
+using Zinnia.Tracking.Collision.Active.Operation;
+
+namespace Test.Zinnia.Tracking.Collision.Active.Operation
+{
+    using UnityEngine;
+    using NUnit.Framework;
+    using Test.Zinnia.Utility.Mock;
+
+    public class NotifierTargetExtractorTest
+    {
+        private GameObject containingObject;
+        private NotifierTargetExtractor subject;
+
+        [SetUp]
+        public void SetUp()
+        {
+            containingObject = new GameObject();
+            subject = containingObject.AddComponent<NotifierTargetExtractor>();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            Object.DestroyImmediate(subject);
+            Object.DestroyImmediate(containingObject);
+        }
+
+        [Test]
+        public void Extract()
+        {
+            UnityEventListenerMock extractedMock = new UnityEventListenerMock();
+            subject.Extracted.AddListener(extractedMock.Listen);
+
+            Collider collider = new GameObject().AddComponent<BoxCollider>();
+            CollisionNotifier.EventData eventData = new CollisionNotifier.EventData
+            {
+                collider = collider
+            };
+
+            Assert.IsNull(subject.Result);
+            Assert.IsFalse(extractedMock.Received);
+
+            subject.Extract(eventData);
+
+            Assert.AreEqual(collider.gameObject, subject.Result);
+            Assert.IsTrue(extractedMock.Received);
+
+            Object.DestroyImmediate(collider.gameObject);
+        }
+
+        [Test]
+        public void ExtractInactiveGameObject()
+        {
+            UnityEventListenerMock extractedMock = new UnityEventListenerMock();
+            subject.Extracted.AddListener(extractedMock.Listen);
+
+            Collider collider = new GameObject().AddComponent<BoxCollider>();
+            CollisionNotifier.EventData eventData = new CollisionNotifier.EventData
+            {
+                collider = collider
+            };
+
+            Assert.IsNull(subject.Result);
+            Assert.IsFalse(extractedMock.Received);
+
+            subject.gameObject.SetActive(false);
+            subject.Extract(eventData);
+
+            Assert.IsNull(subject.Result);
+            Assert.IsFalse(extractedMock.Received);
+
+            Object.DestroyImmediate(collider.gameObject);
+        }
+
+        [Test]
+        public void ExtractInactiveComponent()
+        {
+            UnityEventListenerMock extractedMock = new UnityEventListenerMock();
+            subject.Extracted.AddListener(extractedMock.Listen);
+
+            Collider collider = new GameObject().AddComponent<BoxCollider>();
+            CollisionNotifier.EventData eventData = new CollisionNotifier.EventData
+            {
+                collider = collider
+            };
+
+            Assert.IsNull(subject.Result);
+            Assert.IsFalse(extractedMock.Received);
+
+            subject.enabled = false;
+            subject.Extract(eventData);
+
+            Assert.IsNull(subject.Result);
+            Assert.IsFalse(extractedMock.Received);
+
+            Object.DestroyImmediate(collider.gameObject);
+        }
+
+        [Test]
+        public void ExtractInvalidNotifier()
+        {
+            UnityEventListenerMock extractedMock = new UnityEventListenerMock();
+            subject.Extracted.AddListener(extractedMock.Listen);
+
+            Assert.IsNull(subject.Result);
+            Assert.IsFalse(extractedMock.Received);
+
+            subject.Extract(null);
+
+            Assert.IsNull(subject.Result);
+            Assert.IsFalse(extractedMock.Received);
+        }
+    }
+}

--- a/Tests/Editor/Tracking/Collision/Active/Operation/NotifierTargetExtractorTest.cs.meta
+++ b/Tests/Editor/Tracking/Collision/Active/Operation/NotifierTargetExtractorTest.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 16af9e59a1a847378233d703dbded158
+timeCreated: 1550491115


### PR DESCRIPTION
`NotifierTargetExtractor` allows extracting the collision **target**
out of a `CollisionNotifier`'s event data. This new component can
prevent writing tiny components to deal with the other end of a
collision happening on a known collider that is observed via
`CollisionNotifier`.