### PR TITLE
feat(Data): add GameObject cloner

### DIFF
--- a/Runtime/Data/Operation/GameObjectCloner.cs
+++ b/Runtime/Data/Operation/GameObjectCloner.cs
@@ -1,0 +1,89 @@
+﻿namespace Zinnia.Data.Operation
+{
+    using UnityEngine;
+    using UnityEngine.Events;
+    using System;
+    using Malimbe.BehaviourStateRequirementMethod;
+    using Malimbe.MemberClearanceMethod;
+    using Malimbe.PropertySerializationAttribute;
+    using Malimbe.PropertyValidationMethod;
+    using Malimbe.XmlDocumentationAttribute;
+
+    /// <summary>
+    /// Duplicates a <see cref="GameObject"/> by cloning it.
+    /// </summary>
+    public class GameObjectCloner : MonoBehaviour
+    {
+        /// <summary>
+        /// Defines the event with the <see cref="GameObject"/>.
+        /// </summary>
+        [Serializable]
+        public class UnityEvent : UnityEvent<GameObject>
+        {
+        }
+
+        /// <summary>
+        /// The object to clone.
+        /// </summary>
+        [Serialized, Validated, Cleared]
+        [field: DocumentedByXml]
+        public GameObject Source { get; set; }
+        /// <summary>
+        /// An optional object to parent the cloned objects to.
+        /// </summary>
+        [Serialized, Validated, Cleared]
+        [field: DocumentedByXml]
+        public GameObject Parent { get; set; }
+
+        /// <summary>
+        /// Emitted when an object has been cloned.
+        /// </summary>
+        [DocumentedByXml]
+        public UnityEvent Cloned = new UnityEvent();
+
+        /// <summary>
+        /// Duplicates <see cref="Source"/> by cloning it and optionally parents the cloned object to <see cref="Parent"/>.
+        /// </summary>
+        /// <returns>The cloned object, or <see langword="null"/> if no clone has been created.</returns>
+        [RequiresBehaviourState]
+        public virtual GameObject Clone()
+        {
+            return Clone(Source);
+        }
+
+        /// <summary>
+        /// Duplicates a <see cref="GameObject"/> by cloning it and optionally parents the cloned object to <see cref="Parent"/>.
+        /// </summary>
+        /// <param name="source">The object to clone.</param>
+        /// <returns>The cloned object, or <see langword="null"/> if no clone has been created.</returns>
+        [RequiresBehaviourState]
+        public virtual GameObject Clone(GameObject source)
+        {
+            if (source == null)
+            {
+                return null;
+            }
+
+            GameObject clone = Instantiate(source, Parent == null ? null : Parent.transform);
+            Cloned?.Invoke(clone);
+            return clone;
+        }
+
+        /// <summary>
+        /// Duplicates <see cref="Source"/> by cloning it and parents the cloned object to <see cref="Parent"/>.
+        /// </summary>
+        public virtual void DoClone()
+        {
+            Clone();
+        }
+
+        /// <summary>
+        /// Duplicates <see cref="Source"/> by cloning it and parents the cloned object to <see cref="Parent"/>.
+        /// </summary>
+        /// <param name="source">The object to clone.</param>
+        public virtual void DoClone(GameObject source)
+        {
+            Clone(source);
+        }
+    }
+}

--- a/Runtime/Data/Operation/GameObjectCloner.cs.meta
+++ b/Runtime/Data/Operation/GameObjectCloner.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: a7cb0e1c66ee4bdc91473bed747606b0
+timeCreated: 1550327791

--- a/Tests/Editor/Data/Operation/GameObjectClonerTest.cs
+++ b/Tests/Editor/Data/Operation/GameObjectClonerTest.cs
@@ -1,0 +1,126 @@
+﻿using Zinnia.Data.Operation;
+
+namespace Test.Zinnia.Data.Operation
+{
+    using UnityEngine;
+    using NUnit.Framework;
+    using Test.Zinnia.Utility.Mock;
+
+    public class GameObjectClonerTest
+    {
+        private GameObject containingObject;
+        private GameObjectCloner subject;
+
+        [SetUp]
+        public void SetUp()
+        {
+            containingObject = new GameObject();
+            subject = containingObject.AddComponent<GameObjectCloner>();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            Object.DestroyImmediate(subject);
+            Object.DestroyImmediate(containingObject);
+        }
+
+        [Test]
+        public void DoesNotCloneNullSource()
+        {
+            UnityEventValueListenerMock<GameObject> clonedMock = new UnityEventValueListenerMock<GameObject>();
+            subject.Cloned.AddListener(clonedMock.Listen);
+
+            subject.Source = null;
+            GameObject actual = subject.Clone();
+
+            Assert.IsNull(actual);
+            Assert.IsFalse(clonedMock.Received);
+            Assert.IsNull(clonedMock.Value);
+
+            clonedMock.Reset();
+
+            actual = subject.Clone(null);
+
+            Assert.IsNull(actual);
+            Assert.IsFalse(clonedMock.Received);
+            Assert.IsNull(clonedMock.Value);
+        }
+
+        [Test]
+        public void CreatesSourceClone()
+        {
+            UnityEventValueListenerMock<GameObject> clonedMock = new UnityEventValueListenerMock<GameObject>();
+            subject.Cloned.AddListener(clonedMock.Listen);
+            GameObject expected = new GameObject();
+
+            subject.Source = expected;
+            GameObject actual = subject.Clone();
+
+            Assert.IsNotNull(actual);
+            Assert.AreNotEqual(expected, actual);
+            Assert.IsTrue(clonedMock.Received);
+            Assert.AreEqual(actual, clonedMock.Value);
+
+            clonedMock.Reset();
+            Object.DestroyImmediate(actual);
+
+            subject.Source = null;
+            actual = subject.Clone(expected);
+
+            Assert.IsNotNull(actual);
+            Assert.AreNotEqual(expected, actual);
+            Assert.IsTrue(clonedMock.Received);
+            Assert.AreEqual(actual, clonedMock.Value);
+
+            Object.DestroyImmediate(actual);
+            Object.DestroyImmediate(expected);
+        }
+
+        [Test]
+        public void ParentsCloneToParent()
+        {
+            UnityEventValueListenerMock<GameObject> clonedMock = new UnityEventValueListenerMock<GameObject>();
+            subject.Cloned.AddListener(clonedMock.Listen);
+            GameObject source = new GameObject();
+            GameObject expected = new GameObject();
+            subject.Parent = expected;
+
+            subject.Source = source;
+            GameObject actual = subject.Clone();
+            Assert.AreEqual(expected, actual.transform.parent.gameObject);
+
+            clonedMock.Reset();
+            Object.DestroyImmediate(actual);
+
+            subject.Source = null;
+            actual = subject.Clone(source);
+            Assert.AreEqual(expected, actual.transform.parent.gameObject);
+
+            Object.DestroyImmediate(actual);
+            Object.DestroyImmediate(source);
+        }
+
+        [Test]
+        public void DoesNotChangeSource()
+        {
+            UnityEventValueListenerMock<GameObject> clonedMock = new UnityEventValueListenerMock<GameObject>();
+            subject.Cloned.AddListener(clonedMock.Listen);
+            GameObject gameObject = new GameObject();
+
+            subject.Source = gameObject;
+            GameObject actual = subject.Clone();
+            Assert.AreEqual(gameObject, subject.Source);
+
+            clonedMock.Reset();
+            Object.DestroyImmediate(actual);
+
+            subject.Source = null;
+            actual = subject.Clone(gameObject);
+            Assert.AreEqual(null, subject.Source);
+
+            Object.DestroyImmediate(actual);
+            Object.DestroyImmediate(gameObject);
+        }
+    }
+}

--- a/Tests/Editor/Data/Operation/GameObjectClonerTest.cs.meta
+++ b/Tests/Editor/Data/Operation/GameObjectClonerTest.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 45d003bcc2c743f0accff0a3a8388fef
+timeCreated: 1550491906

--- a/Tests/Editor/Tracking/Follow/ObjectDistanceComparatorEventDataExtractorTest.cs
+++ b/Tests/Editor/Tracking/Follow/ObjectDistanceComparatorEventDataExtractorTest.cs
@@ -25,9 +25,9 @@ namespace Test.Zinnia.Tracking.Follow
         [Test]
         public void Extract()
         {
-            Vector3UnityEventListenerMock differenceExtractedMock = new Vector3UnityEventListenerMock();
+            UnityEventValueListenerMock<Vector3> differenceExtractedMock = new UnityEventValueListenerMock<Vector3>();
             subject.DifferenceExtracted.AddListener(differenceExtractedMock.Listen);
-            FloatUnityEventListenerMock distanceExtractedMock = new FloatUnityEventListenerMock();
+            UnityEventValueListenerMock<float> distanceExtractedMock = new UnityEventValueListenerMock<float>();
             subject.DistanceExtracted.AddListener(distanceExtractedMock.Listen);
 
             ObjectDistanceComparator.EventData eventData = new ObjectDistanceComparator.EventData
@@ -41,28 +41,8 @@ namespace Test.Zinnia.Tracking.Follow
 
             subject.Extract(eventData);
 
-            Assert.AreEqual(eventData.difference, differenceExtractedMock.value);
-            Assert.AreEqual(eventData.distance, distanceExtractedMock.value);
-        }
-
-        private class Vector3UnityEventListenerMock : UnityEventListenerMock
-        {
-            public Vector3 value;
-
-            public void Listen(Vector3 value)
-            {
-                this.value = value;
-            }
-        }
-
-        private class FloatUnityEventListenerMock : UnityEventListenerMock
-        {
-            public float value;
-
-            public void Listen(float value)
-            {
-                this.value = value;
-            }
+            Assert.AreEqual(eventData.difference, differenceExtractedMock.Value);
+            Assert.AreEqual(eventData.distance, distanceExtractedMock.Value);
         }
     }
 }

--- a/Tests/Utility/Mock/UnityEventListenerMock.cs
+++ b/Tests/Utility/Mock/UnityEventListenerMock.cs
@@ -1,11 +1,8 @@
 ﻿namespace Test.Zinnia.Utility.Mock
 {
-    using UnityEngine;
-
     /// <summary>
     /// The UnityEventListenerMock creates a simple mechanism of registering a listener with a UnityEvent and checking if the event was emitted.
     /// </summary>
-    [AddComponentMenu("")]
     public class UnityEventListenerMock
     {
         /// <summary>

--- a/Tests/Utility/Mock/UnityEventValueListenerMock.cs
+++ b/Tests/Utility/Mock/UnityEventValueListenerMock.cs
@@ -1,0 +1,37 @@
+﻿namespace Test.Zinnia.Utility.Mock
+{
+    /// <summary>
+    /// Allows listening to a UnityEvent that emits a value and checking if the event was emitted as well as the value that was emitted.
+    /// </summary>
+    /// <typeparam name="T">The type of the emitted value.</typeparam>
+    public class UnityEventValueListenerMock<T>
+    {
+        /// <summary>
+        /// Whether the event emitted was received by the listener.
+        /// </summary>
+        public bool Received { get; private set; }
+        /// <summary>
+        /// The received event value.
+        /// </summary>
+        public T Value { get; private set; }
+
+        /// <summary>
+        /// The Reset method resets the listener state.
+        /// </summary>
+        public virtual void Reset()
+        {
+            Received = false;
+            Value = default;
+        }
+
+        /// <summary>
+        /// The callback for the event.
+        /// </summary>
+        /// <param name="value">The event's value.</param>
+        public virtual void Listen(T value)
+        {
+            Received = true;
+            Value = value;
+        }
+    }
+}

--- a/Tests/Utility/Mock/UnityEventValueListenerMock.cs.meta
+++ b/Tests/Utility/Mock/UnityEventValueListenerMock.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: facaa115e52a4403a4e2a7318a141ad1
+timeCreated: 1550493058


### PR DESCRIPTION
`GameObjectCloner` allows duplicating a `GameObject` by cloning it.
The component allows to optionally specify which `GameObject` to
parent the cloned object to and raises an event with the cloned
object.