### PR TITLE
fix(Data): convert FloatRange to struct to prevent instancing issues - fixes #291

### DIFF
--- a/Runtime/Data/Type/FloatRange.cs
+++ b/Runtime/Data/Type/FloatRange.cs
@@ -5,10 +5,10 @@
     using Malimbe.XmlDocumentationAttribute;
 
     /// <summary>
-    /// Specifies a range of float values.
+    /// Specifies a valid range between a lower and upper float value limit.
     /// </summary>
     [Serializable]
-    public class FloatRange
+    public struct FloatRange
     {
         /// <summary>
         /// The inclusive minimum value of the range.
@@ -22,18 +22,9 @@
         public float maximum;
 
         /// <summary>
-        /// Shorthand for writing <c>FloatRange(0f, 0f)</c>.
+        /// Shorthand for writing <c>FloatRange(float.MinValue, float.MaxValue)</c>.
         /// </summary>
-        public static readonly FloatRange Zero = new FloatRange(0f, 0f);
-
-        /// <summary>
-        /// Constructs a new range with the minimum value being <see cref="float.MinValue"/> and the maximum value being <see cref="float.MaxValue"/>.
-        /// </summary>
-        public FloatRange()
-        {
-            minimum = float.MinValue;
-            maximum = float.MaxValue;
-        }
+        public static readonly FloatRange MinMax = new FloatRange(float.MinValue, float.MaxValue);
 
         /// <summary>
         /// Constructs a new range with the given minimum and maximum values.

--- a/Runtime/Data/Type/Transformation/Vector3Restrictor.cs
+++ b/Runtime/Data/Type/Transformation/Vector3Restrictor.cs
@@ -26,17 +26,17 @@
         /// The minimum and maximum values that the x coordinate can be.
         /// </summary>
         [DocumentedByXml]
-        public FloatRange xBounds = new FloatRange();
+        public FloatRange xBounds = FloatRange.MinMax;
         /// <summary>
         /// The minimum and maximum values that the y coordinate can be.
         /// </summary>
         [DocumentedByXml]
-        public FloatRange yBounds = new FloatRange();
+        public FloatRange yBounds = FloatRange.MinMax;
         /// <summary>
         /// The minimum and maximum values that the z coordinate can be.
         /// </summary>
         [DocumentedByXml]
-        public FloatRange zBounds = new FloatRange();
+        public FloatRange zBounds = FloatRange.MinMax;
 
         /// <summary>
         /// Transforms the given input by clamping it within the specified bounds.

--- a/Tests/Editor/Data/Type/FloatRangeTest.cs
+++ b/Tests/Editor/Data/Type/FloatRangeTest.cs
@@ -11,8 +11,8 @@ namespace Test.Zinnia.Data.Type
         public void DefaultConstructor()
         {
             FloatRange range = new FloatRange();
-            Assert.AreEqual(float.MinValue, range.minimum);
-            Assert.AreEqual(float.MaxValue, range.maximum);
+            Assert.AreEqual(0f, range.minimum);
+            Assert.AreEqual(0f, range.maximum);
         }
 
         [Test]
@@ -32,11 +32,11 @@ namespace Test.Zinnia.Data.Type
         }
 
         [Test]
-        public void ConstructFromStaticZero()
+        public void ConstructFromStaticMinMax()
         {
-            FloatRange range = FloatRange.Zero;
-            Assert.AreEqual(0f, range.minimum);
-            Assert.AreEqual(0f, range.maximum);
+            FloatRange range = FloatRange.MinMax;
+            Assert.AreEqual(float.MinValue, range.minimum);
+            Assert.AreEqual(float.MaxValue, range.maximum);
         }
 
         [Test]

--- a/Tests/Editor/Data/Type/Transformation/Vector3RestrictorTest.cs
+++ b/Tests/Editor/Data/Type/Transformation/Vector3RestrictorTest.cs
@@ -60,7 +60,7 @@ namespace Test.Zinnia.Data.Type.Transformation
 
             transformedListenerMock.Reset();
 
-            subject.yBounds = new FloatRange(float.MinValue, float.MaxValue);
+            subject.yBounds = FloatRange.MinMax;
 
             expected = new Vector3(2f, -5f, 2f);
 


### PR DESCRIPTION
There were times where using the FloatRange.Zero helper would return
the same instance across different instantiations which won't happen
if the FloatRange is a struct instead of a class.

It makes more sense for the FloatRange to be a struct as other custom
Types included are structs unless a class is required.

Due to the FloatRange becoming a struct means a default constructor
is no longer provided which set the value to float.MinValue and
float.MaxValue so a new static helper called FloatRange.MinMax has been
added that returns the same data. Whereas a `new FloatRange()` now will
return the default values for min, max (which is 0f, 0f) so there is no
need to use the `FloatRange.Zero` helper now so that has been removed.