### PR TITLE
fix(Tracking): float comparisons

### DIFF
--- a/Runtime/Tracking/Follow/Modifier/Property/Rotation/RigidbodyAngularVelocity.cs
+++ b/Runtime/Tracking/Follow/Modifier/Property/Rotation/RigidbodyAngularVelocity.cs
@@ -45,7 +45,7 @@
             {
                 Vector3 angularTarget = angle * axis;
                 Vector3 calculatedAngularVelocity = Vector3.MoveTowards(cachedTargetRigidbody.angularVelocity, angularTarget, maxDistanceDelta);
-                if (angularVelocityLimit == float.PositiveInfinity || calculatedAngularVelocity.sqrMagnitude < angularVelocityLimit)
+                if (float.IsPositiveInfinity(angularVelocityLimit) || calculatedAngularVelocity.sqrMagnitude < angularVelocityLimit)
                 {
                     cachedTargetRigidbody.angularVelocity = calculatedAngularVelocity;
                 }

--- a/Runtime/Tracking/Modification/DirectionModifier.cs
+++ b/Runtime/Tracking/Modification/DirectionModifier.cs
@@ -8,6 +8,7 @@
     using Malimbe.PropertySerializationAttribute;
     using Malimbe.PropertyValidationMethod;
     using Malimbe.XmlDocumentationAttribute;
+    using Zinnia.Extension;
     using Zinnia.Process;
 
     /// <summary>
@@ -112,7 +113,7 @@
             {
                 resetOrientationRoutine = StartCoroutine(ResetOrientationRoutine());
             }
-            else if (resetOrientationSpeed == 0f)
+            else if (resetOrientationSpeed.ApproxEquals(0f))
             {
                 SetOrientationToSaved();
             }


### PR DESCRIPTION
floats can't be compared via `==`, thus this fix ensures they are
done using the appropriate method.