### PR TITLE
chore(Tests): fix wrong attribute usage

### DIFF
--- a/Tests/Utility/TimeSettingOverride.cs
+++ b/Tests/Utility/TimeSettingOverride.cs
@@ -2,17 +2,12 @@
 {
     using UnityEngine;
 
-    [AddComponentMenu("")]
     public class TimeSettingOverride
     {
         private float savedFixedDeltaTime;
         private float savedMaximumDeltaTime;
         private float savedTimeScale;
         private float savedMaximumParticleDeltaTime;
-
-        public TimeSettingOverride()
-        {
-        }
 
         public TimeSettingOverride(float fixedDeltaTime, float maximumDeltaTime, float timeScale, float maximumParticleDeltaTime)
         {


### PR DESCRIPTION
`AddComponentMenu` is only usable on classes that inherit from
`MonoBehaviour`. This fix removes the attribute as well as the
default constructor as it's unused.