### PR TITLE
feat(Collision): add ability to ignore collisions between GameObjects

### DIFF
--- a/Runtime/Tracking/Collision/CollisionIgnorer.cs
+++ b/Runtime/Tracking/Collision/CollisionIgnorer.cs
@@ -1,0 +1,222 @@
+﻿namespace Zinnia.Tracking.Collision
+{
+    using UnityEngine;
+    using System.Collections.Generic;
+    using Malimbe.MemberChangeMethod;
+    using Malimbe.XmlDocumentationAttribute;
+    using Malimbe.PropertySerializationAttribute;
+    using Zinnia.Data.Collection;
+
+    /// <summary>
+    /// Ignores the collisions between the source <see cref="GameObject"/> colliders and the target <see cref="GameObject"/> colliders.
+    /// </summary>
+    public class CollisionIgnorer : MonoBehaviour
+    {
+        /// <summary>
+        /// The sources to ignore colliders from.
+        /// </summary>
+        [Serialized]
+        [field: DocumentedByXml]
+        public GameObjectObservableList Sources { get; set; }
+        /// <summary>
+        /// The targets to ignore colliders with.
+        /// </summary>
+        [Serialized]
+        [field: DocumentedByXml]
+        public GameObjectObservableList Targets { get; set; }
+
+        /// <summary>
+        /// A reused instance to store the <see cref="Collider"/> collection belonging to the <see cref="Sources"/>.
+        /// </summary>
+        List<Collider> sourceColliders = new List<Collider>();
+        /// <summary>
+        /// A reused instance to store the <see cref="Collider"/> collection belonging to the <see cref="Targets"/>.
+        /// </summary>
+        List<Collider> targetColliders = new List<Collider>();
+
+        protected virtual void OnEnable()
+        {
+            RegisterSourceListeners();
+            RegisterTargetListeners();
+            ToggleCollisions(true);
+        }
+
+        protected virtual void OnDisable()
+        {
+            UnregisterSourceListeners();
+            UnregisterTargetListeners();
+            ToggleCollisions(false);
+        }
+
+        /// <summary>
+        /// Registers the listeners for elements that are added or removed from <see cref="Sources"/>.
+        /// </summary>
+        protected virtual void RegisterSourceListeners()
+        {
+            Sources.ElementAdded.AddListener(OnSourceAdded);
+            Sources.ElementRemoved.AddListener(OnSourceRemoved);
+        }
+
+        /// <summary>
+        /// Unregisters the listeners for elements that are added or removed from <see cref="Sources"/>.
+        /// </summary>
+        protected virtual void UnregisterSourceListeners()
+        {
+            Sources.ElementAdded.RemoveListener(OnSourceAdded);
+            Sources.ElementRemoved.RemoveListener(OnSourceRemoved);
+        }
+
+        /// <summary>
+        /// Registers the listeners for elements that are added or removed from <see cref="Targets"/>.
+        /// </summary>
+        protected virtual void RegisterTargetListeners()
+        {
+            Targets.ElementAdded.AddListener(OnTargetAdded);
+            Targets.ElementRemoved.AddListener(OnTargetRemoved);
+        }
+
+        /// <summary>
+        /// Unregisters the listeners for elements that are added or removed from <see cref="Targets"/>.
+        /// </summary>
+        protected virtual void UnregisterTargetListeners()
+        {
+            Targets.ElementAdded.RemoveListener(OnTargetAdded);
+            Targets.ElementRemoved.RemoveListener(OnTargetRemoved);
+        }
+
+        /// <summary>
+        /// Responds to a <see cref="GameObject"/> being added to <see cref="Sources"/> and ignores all collisions against <see cref="Targets"/>.
+        /// </summary>
+        /// <param name="source">The source to ignore collisions from.</param>
+        protected virtual void OnSourceAdded(GameObject source)
+        {
+            ToggleCollisions(source, Sources, Targets, true);
+        }
+
+        /// <summary>
+        /// Responds to a <see cref="GameObject"/> being removed from <see cref="Sources"/> and resumes all collisions against <see cref="Targets"/>.
+        /// </summary>
+        /// <param name="source">The source to restore collisions with.</param>
+        protected virtual void OnSourceRemoved(GameObject source)
+        {
+            ToggleCollisions(source, Sources, Targets, false);
+        }
+
+        /// <summary>
+        /// Responds to a <see cref="GameObject"/> being added to <see cref="Targets"/> and ignores all collisions against <see cref="Sources"/>.
+        /// </summary>
+        /// <param name="target">The target to ignore collisions on.</param>
+        protected virtual void OnTargetAdded(GameObject target)
+        {
+            ToggleCollisions(target, Targets, Sources, true);
+        }
+
+        /// <summary>
+        /// Responds to a <see cref="GameObject"/> being removed from <see cref="Targets"/> and resumes all collisions against <see cref="Sources"/>.
+        /// </summary>
+        /// <param name="target">The target to restore collisions on.</param>
+        protected virtual void OnTargetRemoved(GameObject target)
+        {
+            ToggleCollisions(target, Targets, Sources, false);
+        }
+
+        /// <summary>
+        /// Sets the collision state between <see cref="Sources"/> and <see cref="Targets"/>.
+        /// </summary>
+        /// <param name="state">Whether to ignore collisions or not.</param>
+        protected virtual void ToggleCollisions(bool state)
+        {
+            foreach (GameObject source in Sources.SubscribableElements)
+            {
+                ToggleCollisions(source, Sources, Targets, state);
+            }
+        }
+
+        /// <summary>
+        /// Sets the collision state between the source and targets.
+        /// </summary>
+        /// <param name="source">The source to set the collision state on.</param>
+        /// <param name="sources">A collection of sources to check if the given <see cref="source"/> belongs to.</param>
+        /// <param name="targets">A collection of targets to set the collision state on.</param>
+        /// <param name="state">Whether to ignore collisions or not.</param>
+        protected virtual void ToggleCollisions(GameObject source, GameObjectObservableList sources, GameObjectObservableList targets, bool state)
+        {
+            if (source == null || (!state && sources.Contains(source)))
+            {
+                return;
+            }
+
+            source.GetComponentsInChildren(sourceColliders);
+
+            foreach (GameObject target in targets.SubscribableElements)
+            {
+                if (target == null)
+                {
+                    continue;
+                }
+
+                target.GetComponentsInChildren(targetColliders);
+
+                foreach (Collider sourceCollider in sourceColliders)
+                {
+                    foreach (Collider targetCollider in targetColliders)
+                    {
+                        Physics.IgnoreCollision(sourceCollider, targetCollider, state);
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Called before <see cref="Sources"/> has been changed.
+        /// </summary>
+        [CalledBeforeChangeOf(nameof(Sources))]
+        protected virtual void OnBeforeSourcesChange()
+        {
+            if (Sources != null)
+            {
+                UnregisterSourceListeners();
+                ToggleCollisions(false);
+            }
+        }
+
+        /// <summary>
+        /// Called after <see cref="Sources"/> has been changed.
+        /// </summary>
+        [CalledAfterChangeOf(nameof(Sources))]
+        protected virtual void OnAfterSourcesChange()
+        {
+            if (Sources != null)
+            {
+                RegisterSourceListeners();
+                ToggleCollisions(true);
+            }
+        }
+
+        /// <summary>
+        /// Called before <see cref="Targets"/> has been changed.
+        /// </summary>
+        [CalledBeforeChangeOf(nameof(Targets))]
+        protected virtual void OnBeforeTargetsChange()
+        {
+            if (Targets != null)
+            {
+                UnregisterTargetListeners();
+                ToggleCollisions(false);
+            }
+        }
+
+        /// <summary>
+        /// Called after <see cref="Targets"/> has been changed.
+        /// </summary>
+        [CalledAfterChangeOf(nameof(Targets))]
+        protected virtual void OnAfterTargetsChange()
+        {
+            if (Targets != null)
+            {
+                RegisterTargetListeners();
+                ToggleCollisions(true);
+            }
+        }
+    }
+}

--- a/Runtime/Tracking/Collision/CollisionIgnorer.cs.meta
+++ b/Runtime/Tracking/Collision/CollisionIgnorer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d28135ccdf6492447b269e0d277b842f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Editor/Tracking/Collision/CollisionIgnorerTest.cs
+++ b/Tests/Editor/Tracking/Collision/CollisionIgnorerTest.cs
@@ -1,0 +1,193 @@
+﻿using Zinnia.Tracking.Collision;
+using Zinnia.Data.Collection;
+
+namespace Test.Zinnia.Tracking.Collision
+{
+    using UnityEngine;
+    using UnityEngine.TestTools;
+    using System.Collections;
+    using NUnit.Framework;
+
+    public class CollisionIgnorerTest
+    {
+        private GameObject containingObject;
+        private CollisionIgnorer subject;
+
+        [SetUp]
+        public void SetUp()
+        {
+            containingObject = new GameObject();
+            containingObject.SetActive(false);
+            subject = containingObject.AddComponent<CollisionIgnorer>();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            Object.DestroyImmediate(containingObject);
+        }
+
+        [UnityTest]
+        public IEnumerator CollisionsIgnored()
+        {
+            WaitForFixedUpdate waitForFixedUpdate = new WaitForFixedUpdate();
+            GameObject source1 = CreateCollidable("source1");
+            GameObject source2 = CreateCollidable("source2");
+            GameObject target1 = CreateCollidable("target1");
+            GameObject target2 = CreateCollidable("target2");
+
+            Vector3 source1Origin = Vector3.left + Vector3.forward;
+            Vector3 source2Origin = Vector3.left + Vector3.back;
+            Vector3 target1Origin = Vector3.right + Vector3.forward;
+            Vector3 target2Origin = Vector3.right + Vector3.back;
+
+            source1.transform.position = source1Origin;
+            source2.transform.position = source2Origin;
+            target1.transform.position = target1Origin;
+            target2.transform.position = target2Origin;
+
+            CollisionChecker source1Collisions = source1.AddComponent<CollisionChecker>();
+            CollisionChecker source2Collisions = source2.AddComponent<CollisionChecker>();
+
+            subject.Sources = containingObject.AddComponent<GameObjectObservableList>();
+            subject.Targets = containingObject.AddComponent<GameObjectObservableList>();
+
+            containingObject.SetActive(true);
+
+            subject.Sources.Add(source1);
+            subject.Targets.Add(target1);
+            yield return waitForFixedUpdate;
+            Assert.IsFalse(source1Collisions.isColliding);
+
+            //make source1 touch target1 -> no collision
+            source1.transform.position = target1Origin;
+            yield return waitForFixedUpdate;
+            Assert.IsFalse(source1Collisions.isColliding);
+
+            ///make source1 touch target2 -> collision
+            source1.transform.position = target2Origin;
+            yield return waitForFixedUpdate;
+            Assert.IsTrue(source1Collisions.isColliding);
+
+            //move source1 out
+            source1.transform.position = source1Origin;
+
+            //add target2
+            subject.Targets.Add(target1);
+            subject.Targets.SetAt(target2, 1);
+
+            //make source1 touch target2 -> no collision
+            source1.transform.position = target2Origin;
+            yield return waitForFixedUpdate;
+            Assert.IsFalse(source1Collisions.isColliding);
+
+            //move source1 out
+            source1.transform.position = source1Origin;
+
+            //make source2 touch target1 -> collision
+            source2.transform.position = target1Origin;
+            yield return waitForFixedUpdate;
+            Assert.IsTrue(source2Collisions.isColliding);
+
+            //make source2 touch target2->collision
+            source2.transform.position = target2Origin;
+            yield return waitForFixedUpdate;
+            Assert.IsTrue(source2Collisions.isColliding);
+
+            //move source 2 out
+            source2.transform.position = source2Origin;
+
+            //add source2
+            subject.Sources.Add(source1);
+            subject.Sources.SetAt(source2, 1);
+
+            //make source2 touch target1 -> no collision
+            source2.transform.position = target1Origin;
+            yield return waitForFixedUpdate;
+            Assert.IsFalse(source2Collisions.isColliding);
+
+            //make source2 touch target2 -> no collision
+            source2.transform.position = target2Origin;
+            yield return waitForFixedUpdate;
+            Assert.IsFalse(source2Collisions.isColliding);
+
+            //move source 2 out
+            source2.transform.position = source2Origin;
+
+            //remove source2
+            subject.Sources.Remove(source2);
+
+            //make source2 touch target1 -> collision
+            source2.transform.position = target1Origin;
+            yield return waitForFixedUpdate;
+            Assert.IsTrue(source2Collisions.isColliding);
+
+            //make source2 touch target2->collision
+            source2.transform.position = target2Origin;
+            yield return waitForFixedUpdate;
+            Assert.IsTrue(source2Collisions.isColliding);
+
+            //move source 2 out
+            source2.transform.position = source2Origin;
+
+            //remove target2
+            subject.Targets.Remove(target2);
+
+            //make source1 touch target1 -> no collision
+            source1.transform.position = target1Origin;
+            yield return waitForFixedUpdate;
+            Assert.IsFalse(source1Collisions.isColliding);
+
+            //make source1 touch target2 -> collision
+            source1.transform.position = target2Origin;
+            yield return waitForFixedUpdate;
+            Assert.IsTrue(source1Collisions.isColliding);
+
+            //move source 1 out
+            source1.transform.position = source1Origin;
+
+            //remove target1
+            subject.Targets.Remove(target1);
+
+            //make source1 touch target1 -> collision
+            source1.transform.position = target1Origin;
+            yield return waitForFixedUpdate;
+            Assert.IsTrue(source1Collisions.isColliding);
+
+            //make source1 touch target2->collision
+            source1.transform.position = target2Origin;
+            yield return waitForFixedUpdate;
+            Assert.IsTrue(source1Collisions.isColliding);
+
+            Object.Destroy(source1);
+            Object.Destroy(source2);
+            Object.Destroy(target1);
+            Object.Destroy(target2);
+        }
+
+        protected GameObject CreateCollidable(string name)
+        {
+            GameObject obj = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            obj.name = name;
+            obj.GetComponent<Collider>().isTrigger = true;
+            Rigidbody rb = obj.AddComponent<Rigidbody>();
+            rb.isKinematic = true;
+            return obj;
+        }
+
+        protected class CollisionChecker : MonoBehaviour
+        {
+            public bool isColliding;
+
+            public void OnTriggerEnter(Collider other)
+            {
+                isColliding = true;
+            }
+
+            public void OnTriggerExit(Collider other)
+            {
+                isColliding = false;
+            }
+        }
+    }
+}

--- a/Tests/Editor/Tracking/Collision/CollisionIgnorerTest.cs.meta
+++ b/Tests/Editor/Tracking/Collision/CollisionIgnorerTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e6b3ca75d6eb32f41a13cde0a6b9ca9c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
The CollisionIgnorer component takes a list of source GameObjects
and a list of target GameObjects and ignores all source colliders
from colliding with all target colliders.

The CollisionIgnorer ignores the collisions on enable and restores
the collisions on disable.

There is no direct access to the lists via code and new items must
be added via methods and removed via methods.

Adding new items to the list at runtime via the inspector yields no
changes to the collision detection.