### PR TITLE
feat(Rule): allow rules to be ignored if the component is disabled

### DIFF
--- a/Runtime/Rule/AllRule.cs
+++ b/Runtime/Rule/AllRule.cs
@@ -3,6 +3,7 @@
     using UnityEngine;
     using System.Collections.Generic;
     using Malimbe.XmlDocumentationAttribute;
+    using Malimbe.BehaviourStateRequirementMethod;
     using Zinnia.Extension;
 
     /// <summary>
@@ -17,6 +18,7 @@
         public List<RuleContainer> rules = new List<RuleContainer>();
 
         /// <inheritdoc/>
+        [RequiresBehaviourState]
         public bool Accepts(object target)
         {
             if (rules == null || rules.Count == 0)

--- a/Runtime/Rule/AnyLayerRule.cs
+++ b/Runtime/Rule/AnyLayerRule.cs
@@ -1,7 +1,7 @@
 ﻿namespace Zinnia.Rule
 {
-    using Malimbe.XmlDocumentationAttribute;
     using UnityEngine;
+    using Malimbe.XmlDocumentationAttribute;
 
     /// <summary>
     /// Determines whether a <see cref="GameObject"/>'s <see cref="GameObject.layer"/> is part of a list.

--- a/Runtime/Rule/AnyRule.cs
+++ b/Runtime/Rule/AnyRule.cs
@@ -3,6 +3,7 @@
     using UnityEngine;
     using System.Collections.Generic;
     using Malimbe.XmlDocumentationAttribute;
+    using Malimbe.BehaviourStateRequirementMethod;
     using Zinnia.Extension;
 
     /// <summary>
@@ -17,6 +18,7 @@
         public List<RuleContainer> rules = new List<RuleContainer>();
 
         /// <inheritdoc />
+        [RequiresBehaviourState]
         public bool Accepts(object target)
         {
             foreach (RuleContainer rule in rules)

--- a/Runtime/Rule/GameObjectRule.cs
+++ b/Runtime/Rule/GameObjectRule.cs
@@ -1,6 +1,7 @@
 ﻿namespace Zinnia.Rule
 {
     using UnityEngine;
+    using Malimbe.BehaviourStateRequirementMethod;
 
     /// <summary>
     /// Simplifies implementing <see cref="IRule"/>s that only accept <see cref="GameObject"/>s.
@@ -8,6 +9,7 @@
     public abstract class GameObjectRule : MonoBehaviour, IRule
     {
         /// <inheritdoc />
+        [RequiresBehaviourState]
         public bool Accepts(object target)
         {
             GameObject targetGameObject = target as GameObject;

--- a/Runtime/Rule/ListContainsRule.cs
+++ b/Runtime/Rule/ListContainsRule.cs
@@ -3,6 +3,7 @@
     using UnityEngine;
     using System.Collections.Generic;
     using Malimbe.XmlDocumentationAttribute;
+    using Malimbe.BehaviourStateRequirementMethod;
 
     /// <summary>
     /// Determines whether an object is part of a list.
@@ -16,6 +17,7 @@
         public List<Object> objects = new List<Object>();
 
         /// <inheritdoc />
+        [RequiresBehaviourState]
         public virtual bool Accepts(object target)
         {
             Object targetObject = target as Object;

--- a/Runtime/Rule/NegationRule.cs
+++ b/Runtime/Rule/NegationRule.cs
@@ -1,7 +1,8 @@
 ﻿namespace Zinnia.Rule
 {
-    using Malimbe.XmlDocumentationAttribute;
     using UnityEngine;
+    using Malimbe.BehaviourStateRequirementMethod;
+    using Malimbe.XmlDocumentationAttribute;
     using Zinnia.Extension;
 
     /// <summary>
@@ -16,6 +17,7 @@
         public RuleContainer rule;
 
         /// <inheritdoc />
+        [RequiresBehaviourState]
         public bool Accepts(object target)
         {
             return !rule.Accepts(target);

--- a/Tests/Editor/Rule/ActiveInHierarchyRuleTest.cs
+++ b/Tests/Editor/Rule/ActiveInHierarchyRuleTest.cs
@@ -41,9 +41,25 @@ namespace Test.Zinnia.Rule
         }
 
         [Test]
-        public void RefusesInactive()
+        public void RefusesInactiveContainer()
         {
             containingObject.SetActive(false);
+            Assert.IsFalse(container.Accepts(containingObject));
+        }
+
+        [Test]
+        public void RefusesInactiveGameObject()
+        {
+            containingObject.SetActive(true);
+            subject.gameObject.SetActive(false);
+            Assert.IsFalse(container.Accepts(containingObject));
+        }
+
+        [Test]
+        public void RefusesInactiveComponent()
+        {
+            containingObject.SetActive(true);
+            subject.enabled = false;
             Assert.IsFalse(container.Accepts(containingObject));
         }
     }

--- a/Tests/Editor/Rule/AllRuleTest.cs
+++ b/Tests/Editor/Rule/AllRuleTest.cs
@@ -65,5 +65,39 @@ namespace Test.Zinnia.Rule
                 });
             Assert.IsFalse(container.Accepts(containingObject));
         }
+
+        [Test]
+        public void RefusesInactiveGameObject()
+        {
+            subject.rules.Add(
+                new RuleContainer
+                {
+                    Interface = new TrueRuleStub()
+                });
+            subject.rules.Add(
+                new RuleContainer
+                {
+                    Interface = new TrueRuleStub()
+                });
+            subject.gameObject.SetActive(false);
+            Assert.IsFalse(container.Accepts(containingObject));
+        }
+
+        [Test]
+        public void RefusesInactiveComponent()
+        {
+            subject.rules.Add(
+                new RuleContainer
+                {
+                    Interface = new TrueRuleStub()
+                });
+            subject.rules.Add(
+                new RuleContainer
+                {
+                    Interface = new TrueRuleStub()
+                });
+            subject.enabled = false;
+            Assert.IsFalse(container.Accepts(containingObject));
+        }
     }
 }

--- a/Tests/Editor/Rule/AnyComponentTypeRuleTest.cs
+++ b/Tests/Editor/Rule/AnyComponentTypeRuleTest.cs
@@ -51,6 +51,26 @@ namespace Test.Zinnia.Rule
             Assert.IsFalse(container.Accepts(containingObject));
         }
 
+        [Test]
+        public void RefusesInactiveGameObject()
+        {
+            containingObject.AddComponent<TestScript>();
+            subject.componentTypes.Add(typeof(TestScript));
+
+            subject.gameObject.SetActive(false);
+            Assert.IsFalse(container.Accepts(containingObject));
+        }
+
+        [Test]
+        public void RefusesInactiveComponent()
+        {
+            containingObject.AddComponent<TestScript>();
+            subject.componentTypes.Add(typeof(TestScript));
+
+            subject.enabled = false;
+            Assert.IsFalse(container.Accepts(containingObject));
+        }
+
         private class TestScript : MonoBehaviour
         {
         }

--- a/Tests/Editor/Rule/AnyLayerRuleTest.cs
+++ b/Tests/Editor/Rule/AnyLayerRuleTest.cs
@@ -49,5 +49,21 @@ namespace Test.Zinnia.Rule
             subject.layerMask = LayerMask.NameToLayer("Ignore Raycast");
             Assert.IsFalse(container.Accepts(containingObject));
         }
+
+        [Test]
+        public void RefusesInactiveGameObject()
+        {
+            subject.layerMask = LayerMask.NameToLayer("UI");
+            subject.gameObject.SetActive(false);
+            Assert.IsFalse(container.Accepts(containingObject));
+        }
+
+        [Test]
+        public void RefusesInactiveComponent()
+        {
+            subject.layerMask = LayerMask.NameToLayer("UI");
+            subject.enabled = false;
+            Assert.IsFalse(container.Accepts(containingObject));
+        }
     }
 }

--- a/Tests/Editor/Rule/AnyRuleTest.cs
+++ b/Tests/Editor/Rule/AnyRuleTest.cs
@@ -65,5 +65,39 @@ namespace Test.Zinnia.Rule
                 });
             Assert.IsFalse(container.Accepts(containingObject));
         }
+
+        [Test]
+        public void RefusesInactiveGameObject()
+        {
+            subject.rules.Add(
+                new RuleContainer
+                {
+                    Interface = new TrueRuleStub()
+                });
+            subject.rules.Add(
+                new RuleContainer
+                {
+                    Interface = new FalseRuleStub()
+                });
+            subject.gameObject.SetActive(false);
+            Assert.IsFalse(container.Accepts(containingObject));
+        }
+
+        [Test]
+        public void RefusesInactiveComponent()
+        {
+            subject.rules.Add(
+                new RuleContainer
+                {
+                    Interface = new TrueRuleStub()
+                });
+            subject.rules.Add(
+                new RuleContainer
+                {
+                    Interface = new FalseRuleStub()
+                });
+            subject.enabled = false;
+            Assert.IsFalse(container.Accepts(containingObject));
+        }
     }
 }

--- a/Tests/Editor/Rule/ListContainsRuleTest.cs
+++ b/Tests/Editor/Rule/ListContainsRuleTest.cs
@@ -49,5 +49,21 @@ namespace Test.Zinnia.Rule
 
             Object.DestroyImmediate(wrongGameObject);
         }
+
+        [Test]
+        public void RefusesInactiveGameObject()
+        {
+            subject.objects.Add(containingObject);
+            subject.gameObject.SetActive(false);
+            Assert.IsFalse(container.Accepts(containingObject));
+        }
+
+        [Test]
+        public void RefusesInactiveComponent()
+        {
+            subject.objects.Add(containingObject);
+            subject.enabled = false;
+            Assert.IsFalse(container.Accepts(containingObject));
+        }
     }
 }

--- a/Tests/Editor/Rule/NegationRuleTest.cs
+++ b/Tests/Editor/Rule/NegationRuleTest.cs
@@ -53,5 +53,27 @@ namespace Test.Zinnia.Rule
             };
             Assert.IsFalse(container.Accepts(containingObject));
         }
+
+        [Test]
+        public void RefusesInactiveGameObject()
+        {
+            subject.rule = new RuleContainer
+            {
+                Interface = new FalseRuleStub()
+            };
+            subject.gameObject.SetActive(false);
+            Assert.IsFalse(container.Accepts(containingObject));
+        }
+
+        [Test]
+        public void RefusesInactiveComponent()
+        {
+            subject.rule = new RuleContainer
+            {
+                Interface = new FalseRuleStub()
+            };
+            subject.enabled = false;
+            Assert.IsFalse(container.Accepts(containingObject));
+        }
     }
 }


### PR DESCRIPTION
All rules now implement the `[RequiresBehaviourState]` attribute so
if the component or GameObject that the rule is on is disabled then
the rule will be ignored.