### PR TITLE
feat(Utility): update all fields to be serialized properties

### DIFF
--- a/Runtime/Utility/CountdownTimer.cs
+++ b/Runtime/Utility/CountdownTimer.cs
@@ -1,9 +1,10 @@
 ﻿namespace Zinnia.Utility
 {
-    using Malimbe.BehaviourStateRequirementMethod;
-    using Malimbe.XmlDocumentationAttribute;
     using UnityEngine;
     using UnityEngine.Events;
+    using Malimbe.BehaviourStateRequirementMethod;
+    using Malimbe.PropertySerializationAttribute;
+    using Malimbe.XmlDocumentationAttribute;
 
     /// <summary>
     /// Counts down from a given start time until zero and emits appropriate events throughout the process.
@@ -13,8 +14,9 @@
         /// <summary>
         /// The time to start the countdown at.
         /// </summary>
-        [DocumentedByXml]
-        public float startTime = 1f;
+        [Serialized]
+        [field: DocumentedByXml]
+        public float StartTime { get; set; } = 1f;
 
         /// <summary>
         /// Emitted when the countdown starts.
@@ -58,7 +60,7 @@
         public virtual void Begin()
         {
             IsRunning = true;
-            Invoke(nameof(Complete), startTime);
+            Invoke(nameof(Complete), StartTime);
             Started?.Invoke();
         }
 
@@ -67,9 +69,12 @@
         /// </summary>
         public virtual void Cancel()
         {
-            IsRunning = false;
             CancelInvoke(nameof(Complete));
-            Cancelled?.Invoke();
+            if (IsRunning)
+            {
+                Cancelled?.Invoke();
+                IsRunning = false;
+            }
         }
 
         /// <summary>

--- a/Runtime/Utility/InterfaceContainer.cs
+++ b/Runtime/Utility/InterfaceContainer.cs
@@ -1,10 +1,9 @@
 ﻿namespace Zinnia.Utility
 {
-    using Malimbe.PropertySerializationAttribute;
-    /*using Malimbe.PropertySetterMethod;*/
-    /*using Malimbe.PropertyValidationMethod;*/
-    using Malimbe.XmlDocumentationAttribute;
     using UnityEngine;
+    using Malimbe.MemberChangeMethod;
+    using Malimbe.PropertySerializationAttribute;
+    using Malimbe.XmlDocumentationAttribute;
 
     /// <summary>
     /// A container for an <see cref="Object"/> that implements an interface that can be utilized within a Unity Inspector.
@@ -14,19 +13,15 @@
         /// <summary>
         /// The contained object.
         /// </summary>
-        [Serialized, /*Validated*/]
+        [Serialized]
         [field: DocumentedByXml]
         protected Object Field { get; set; }
 
         /// <summary>
-        /// Handles changes to <see cref="Field"/>.
+        /// Called after <see cref="Field"/> has been changed.
         /// </summary>
-        /// <param name="previousValue">The previous value.</param>
-        /// <param name="newValue">The new value.</param>
-        /*[CalledBySetter(nameof(Field))]*/
-        protected virtual void OnFieldChange(Object previousValue, ref Object newValue)
-        {
-        }
+        [CalledAfterChangeOf(nameof(Field))]
+        protected virtual void OnAfterFieldChange() { }
     }
 
     /// <summary>
@@ -35,6 +30,9 @@
     /// <typeparam name="TInterface">The interface type to contain.</typeparam>
     public abstract class InterfaceContainer<TInterface> : InterfaceContainer, ISerializationCallbackReceiver
     {
+        /// <summary>
+        /// The contained interface.
+        /// </summary>
         public TInterface Interface
         {
             get
@@ -59,19 +57,6 @@
         private TInterface _interface;
 
         /// <inheritdoc />
-        protected override void OnFieldChange(Object previousValue, ref Object newValue)
-        {
-            if (newValue is TInterface @interface)
-            {
-                _interface = @interface;
-            }
-            else
-            {
-                newValue = null;
-            }
-        }
-
-        /// <inheritdoc />
         public void OnBeforeSerialize()
         {
         }
@@ -79,7 +64,20 @@
         /// <inheritdoc />
         public void OnAfterDeserialize()
         {
-            Field = Field;
+            OnAfterFieldChange();
+        }
+
+        /// <inheritdoc />
+        protected override void OnAfterFieldChange()
+        {
+            if (Field is TInterface @interface)
+            {
+                _interface = @interface;
+            }
+            else if (Field != null)
+            {
+                Field = null;
+            }
         }
     }
 }

--- a/Tests/Editor/Utility/CountdownTimerTest.cs
+++ b/Tests/Editor/Utility/CountdownTimerTest.cs
@@ -1,0 +1,321 @@
+﻿using Zinnia.Utility;
+
+namespace Test.Zinnia.Utility
+{
+    using UnityEngine;
+    using UnityEngine.TestTools;
+    using System.Collections;
+    using NUnit.Framework;
+    using Test.Zinnia.Utility.Mock;
+
+    public class CountdownTimerTest
+    {
+        private GameObject containingObject;
+        private CountdownTimer subject;
+
+        [SetUp]
+        public void SetUp()
+        {
+            containingObject = new GameObject();
+            subject = containingObject.AddComponent<CountdownTimer>();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            Object.Destroy(containingObject);
+        }
+
+        [UnityTest]
+        public IEnumerator TimerComplete()
+        {
+            UnityEventListenerMock timerStartedMock = new UnityEventListenerMock();
+            UnityEventListenerMock timerCancelledMock = new UnityEventListenerMock();
+            UnityEventListenerMock timerCompleteMock = new UnityEventListenerMock();
+            UnityEventListenerMock timerStillRunningMock = new UnityEventListenerMock();
+            UnityEventListenerMock timerNotRunningMock = new UnityEventListenerMock();
+
+            subject.Started.AddListener(timerStartedMock.Listen);
+            subject.Cancelled.AddListener(timerCancelledMock.Listen);
+            subject.Completed.AddListener(timerCompleteMock.Listen);
+            subject.StillRunning.AddListener(timerStillRunningMock.Listen);
+            subject.NotRunning.AddListener(timerNotRunningMock.Listen);
+
+            subject.StartTime = 0.1f;
+
+            Assert.IsFalse(timerStartedMock.Received);
+            Assert.IsFalse(timerCancelledMock.Received);
+            Assert.IsFalse(timerCompleteMock.Received);
+            Assert.IsFalse(timerStillRunningMock.Received);
+            Assert.IsFalse(timerNotRunningMock.Received);
+
+            subject.Begin();
+
+            Assert.IsTrue(timerStartedMock.Received);
+            Assert.IsFalse(timerCancelledMock.Received);
+            Assert.IsFalse(timerCompleteMock.Received);
+
+            subject.EmitStatus();
+
+            Assert.IsTrue(timerStillRunningMock.Received);
+            Assert.IsFalse(timerNotRunningMock.Received);
+
+            yield return new WaitForSeconds(0.1f);
+
+            Assert.IsFalse(timerCancelledMock.Received);
+            Assert.IsTrue(timerCompleteMock.Received);
+
+            timerStillRunningMock.Reset();
+            timerNotRunningMock.Reset();
+
+            subject.EmitStatus();
+
+            Assert.IsFalse(timerStillRunningMock.Received);
+            Assert.IsTrue(timerNotRunningMock.Received);
+        }
+
+        [UnityTest]
+        public IEnumerator TimerCancelled()
+        {
+            UnityEventListenerMock timerStartedMock = new UnityEventListenerMock();
+            UnityEventListenerMock timerCancelledMock = new UnityEventListenerMock();
+            UnityEventListenerMock timerCompleteMock = new UnityEventListenerMock();
+            UnityEventListenerMock timerStillRunningMock = new UnityEventListenerMock();
+            UnityEventListenerMock timerNotRunningMock = new UnityEventListenerMock();
+
+            subject.Started.AddListener(timerStartedMock.Listen);
+            subject.Cancelled.AddListener(timerCancelledMock.Listen);
+            subject.Completed.AddListener(timerCompleteMock.Listen);
+            subject.StillRunning.AddListener(timerStillRunningMock.Listen);
+            subject.NotRunning.AddListener(timerNotRunningMock.Listen);
+
+            subject.StartTime = 0.2f;
+
+            Assert.IsFalse(timerStartedMock.Received);
+            Assert.IsFalse(timerCancelledMock.Received);
+            Assert.IsFalse(timerCompleteMock.Received);
+
+            subject.Begin();
+
+            Assert.IsTrue(timerStartedMock.Received);
+            Assert.IsFalse(timerCancelledMock.Received);
+            Assert.IsFalse(timerCompleteMock.Received);
+
+            subject.EmitStatus();
+
+            Assert.IsTrue(timerStillRunningMock.Received);
+            Assert.IsFalse(timerNotRunningMock.Received);
+
+            yield return new WaitForSeconds(0.1f);
+
+            subject.Cancel();
+
+            Assert.IsTrue(timerCancelledMock.Received);
+            Assert.IsFalse(timerCompleteMock.Received);
+
+            timerStillRunningMock.Reset();
+            timerNotRunningMock.Reset();
+
+            subject.EmitStatus();
+
+            Assert.IsFalse(timerStillRunningMock.Received);
+            Assert.IsTrue(timerNotRunningMock.Received);
+        }
+
+        [UnityTest]
+        public IEnumerator TimerDoesNotCompleteOnInactiveGameObject()
+        {
+            UnityEventListenerMock timerStartedMock = new UnityEventListenerMock();
+            UnityEventListenerMock timerCancelledMock = new UnityEventListenerMock();
+            UnityEventListenerMock timerCompleteMock = new UnityEventListenerMock();
+            UnityEventListenerMock timerStillRunningMock = new UnityEventListenerMock();
+            UnityEventListenerMock timerNotRunningMock = new UnityEventListenerMock();
+
+            subject.Started.AddListener(timerStartedMock.Listen);
+            subject.Cancelled.AddListener(timerCancelledMock.Listen);
+            subject.Completed.AddListener(timerCompleteMock.Listen);
+            subject.StillRunning.AddListener(timerStillRunningMock.Listen);
+            subject.NotRunning.AddListener(timerNotRunningMock.Listen);
+
+            subject.gameObject.SetActive(false);
+
+            subject.StartTime = 0.1f;
+
+            Assert.IsFalse(timerStartedMock.Received);
+            Assert.IsFalse(timerCancelledMock.Received);
+            Assert.IsFalse(timerCompleteMock.Received);
+            Assert.IsFalse(timerStillRunningMock.Received);
+            Assert.IsFalse(timerNotRunningMock.Received);
+
+            subject.Begin();
+
+            Assert.IsFalse(timerStartedMock.Received);
+            Assert.IsFalse(timerCancelledMock.Received);
+            Assert.IsFalse(timerCompleteMock.Received);
+
+            subject.EmitStatus();
+
+            Assert.IsFalse(timerStillRunningMock.Received);
+            Assert.IsFalse(timerNotRunningMock.Received);
+
+            yield return new WaitForSeconds(0.1f);
+
+            Assert.IsFalse(timerCancelledMock.Received);
+            Assert.IsFalse(timerCompleteMock.Received);
+
+            timerStillRunningMock.Reset();
+            timerNotRunningMock.Reset();
+
+            subject.EmitStatus();
+
+            Assert.IsFalse(timerStillRunningMock.Received);
+            Assert.IsFalse(timerNotRunningMock.Received);
+        }
+
+        [UnityTest]
+        public IEnumerator TimerDoesNotCompleteOnInactiveComponent()
+        {
+            UnityEventListenerMock timerStartedMock = new UnityEventListenerMock();
+            UnityEventListenerMock timerCancelledMock = new UnityEventListenerMock();
+            UnityEventListenerMock timerCompleteMock = new UnityEventListenerMock();
+            UnityEventListenerMock timerStillRunningMock = new UnityEventListenerMock();
+            UnityEventListenerMock timerNotRunningMock = new UnityEventListenerMock();
+
+            subject.Started.AddListener(timerStartedMock.Listen);
+            subject.Cancelled.AddListener(timerCancelledMock.Listen);
+            subject.Completed.AddListener(timerCompleteMock.Listen);
+            subject.StillRunning.AddListener(timerStillRunningMock.Listen);
+            subject.NotRunning.AddListener(timerNotRunningMock.Listen);
+
+            subject.enabled = false;
+
+            subject.StartTime = 0.1f;
+
+            Assert.IsFalse(timerStartedMock.Received);
+            Assert.IsFalse(timerCancelledMock.Received);
+            Assert.IsFalse(timerCompleteMock.Received);
+            Assert.IsFalse(timerStillRunningMock.Received);
+            Assert.IsFalse(timerNotRunningMock.Received);
+
+            subject.Begin();
+
+            Assert.IsFalse(timerStartedMock.Received);
+            Assert.IsFalse(timerCancelledMock.Received);
+            Assert.IsFalse(timerCompleteMock.Received);
+
+            subject.EmitStatus();
+
+            Assert.IsFalse(timerStillRunningMock.Received);
+            Assert.IsFalse(timerNotRunningMock.Received);
+
+            yield return new WaitForSeconds(0.1f);
+
+            Assert.IsFalse(timerCancelledMock.Received);
+            Assert.IsFalse(timerCompleteMock.Received);
+
+            timerStillRunningMock.Reset();
+            timerNotRunningMock.Reset();
+
+            subject.EmitStatus();
+
+            Assert.IsFalse(timerStillRunningMock.Received);
+            Assert.IsFalse(timerNotRunningMock.Received);
+        }
+
+        [UnityTest]
+        public IEnumerator TimerCancelledOnDisableGameObject()
+        {
+            UnityEventListenerMock timerStartedMock = new UnityEventListenerMock();
+            UnityEventListenerMock timerCancelledMock = new UnityEventListenerMock();
+            UnityEventListenerMock timerCompleteMock = new UnityEventListenerMock();
+            UnityEventListenerMock timerStillRunningMock = new UnityEventListenerMock();
+            UnityEventListenerMock timerNotRunningMock = new UnityEventListenerMock();
+
+            subject.Started.AddListener(timerStartedMock.Listen);
+            subject.Cancelled.AddListener(timerCancelledMock.Listen);
+            subject.Completed.AddListener(timerCompleteMock.Listen);
+            subject.StillRunning.AddListener(timerStillRunningMock.Listen);
+            subject.NotRunning.AddListener(timerNotRunningMock.Listen);
+
+            subject.StartTime = 0.2f;
+
+            Assert.IsFalse(timerStartedMock.Received);
+            Assert.IsFalse(timerCancelledMock.Received);
+            Assert.IsFalse(timerCompleteMock.Received);
+
+            subject.Begin();
+
+            Assert.IsTrue(timerStartedMock.Received);
+            Assert.IsFalse(timerCancelledMock.Received);
+            Assert.IsFalse(timerCompleteMock.Received);
+
+            subject.EmitStatus();
+
+            Assert.IsTrue(timerStillRunningMock.Received);
+            Assert.IsFalse(timerNotRunningMock.Received);
+
+            yield return new WaitForSeconds(0.1f);
+
+            subject.gameObject.SetActive(false);
+
+            Assert.IsTrue(timerCancelledMock.Received);
+            Assert.IsFalse(timerCompleteMock.Received);
+
+            timerStillRunningMock.Reset();
+            timerNotRunningMock.Reset();
+
+            subject.EmitStatus();
+
+            Assert.IsFalse(timerStillRunningMock.Received);
+            Assert.IsFalse(timerNotRunningMock.Received);
+        }
+
+        [UnityTest]
+        public IEnumerator TimerCancelledOnDisableComponent()
+        {
+            UnityEventListenerMock timerStartedMock = new UnityEventListenerMock();
+            UnityEventListenerMock timerCancelledMock = new UnityEventListenerMock();
+            UnityEventListenerMock timerCompleteMock = new UnityEventListenerMock();
+            UnityEventListenerMock timerStillRunningMock = new UnityEventListenerMock();
+            UnityEventListenerMock timerNotRunningMock = new UnityEventListenerMock();
+
+            subject.Started.AddListener(timerStartedMock.Listen);
+            subject.Cancelled.AddListener(timerCancelledMock.Listen);
+            subject.Completed.AddListener(timerCompleteMock.Listen);
+            subject.StillRunning.AddListener(timerStillRunningMock.Listen);
+            subject.NotRunning.AddListener(timerNotRunningMock.Listen);
+
+            subject.StartTime = 0.2f;
+
+            Assert.IsFalse(timerStartedMock.Received);
+            Assert.IsFalse(timerCancelledMock.Received);
+            Assert.IsFalse(timerCompleteMock.Received);
+
+            subject.Begin();
+
+            Assert.IsTrue(timerStartedMock.Received);
+            Assert.IsFalse(timerCancelledMock.Received);
+            Assert.IsFalse(timerCompleteMock.Received);
+
+            subject.EmitStatus();
+
+            Assert.IsTrue(timerStillRunningMock.Received);
+            Assert.IsFalse(timerNotRunningMock.Received);
+
+            yield return new WaitForSeconds(0.1f);
+
+            subject.enabled = false;
+
+            Assert.IsTrue(timerCancelledMock.Received);
+            Assert.IsFalse(timerCompleteMock.Received);
+
+            timerStillRunningMock.Reset();
+            timerNotRunningMock.Reset();
+
+            subject.EmitStatus();
+
+            Assert.IsFalse(timerStillRunningMock.Received);
+            Assert.IsFalse(timerNotRunningMock.Received);
+        }
+    }
+}

--- a/Tests/Editor/Utility/CountdownTimerTest.cs.meta
+++ b/Tests/Editor/Utility/CountdownTimerTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7e9a8555496ce1f428ff7e4709dbbcb6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
All usages of fields have now been switched to properties that
are serialized with Malimbe to create an appropriate backing field
to display in the Unity Inspector.

New helper methods have been implemented to allow changes to
properties via code or the inspector to react to the changes and
update any relevant components as required.

Also, now the tests run in play mode, the CountdownTimer can be
tested so a new test has been added to unit test the functions
of the CountdownTimer component.