### PR TITLE
feat(Collection): add extra functionality to ObservableList

### DIFF
--- a/Tests/Editor/Data/Collection/GameObjectObservableListTest.cs
+++ b/Tests/Editor/Data/Collection/GameObjectObservableListTest.cs
@@ -26,42 +26,48 @@ namespace Test.Zinnia.Data.Collection
         }
 
         [Test]
-        public void AddToStart()
+        public void ContainsFound()
         {
-            UnityEventListenerMock becamePopulatedMock = new UnityEventListenerMock();
-            UnityEventListenerMock elementAddedMock = new UnityEventListenerMock();
-            UnityEventListenerMock elementRemovedMock = new UnityEventListenerMock();
-            UnityEventListenerMock becameEmptyMock = new UnityEventListenerMock();
-            subject.BecamePopulated.AddListener(becamePopulatedMock.Listen);
-            subject.ElementAdded.AddListener(elementAddedMock.Listen);
-            subject.ElementRemoved.AddListener(elementRemovedMock.Listen);
-            subject.BecameEmpty.AddListener(becameEmptyMock.Listen);
+            UnityEventListenerMock elementFoundMock = new UnityEventListenerMock();
+            UnityEventListenerMock elementNotFoundMock = new UnityEventListenerMock();
+            subject.Found.AddListener(elementFoundMock.Listen);
+            subject.NotFound.AddListener(elementNotFoundMock.Listen);
+
+            GameObject elementOne = new GameObject();
+
+            subject.Add(elementOne);
+
+            Assert.IsFalse(elementFoundMock.Received);
+            Assert.IsFalse(elementNotFoundMock.Received);
+
+            subject.Contains(elementOne);
+
+            Assert.IsTrue(elementFoundMock.Received);
+            Assert.IsFalse(elementNotFoundMock.Received);
+
+            Object.DestroyImmediate(elementOne);
+        }
+
+        [Test]
+        public void ContainsNotFound()
+        {
+            UnityEventListenerMock elementFoundMock = new UnityEventListenerMock();
+            UnityEventListenerMock elementNotFoundMock = new UnityEventListenerMock();
+            subject.Found.AddListener(elementFoundMock.Listen);
+            subject.NotFound.AddListener(elementNotFoundMock.Listen);
+
             GameObject elementOne = new GameObject();
             GameObject elementTwo = new GameObject();
 
-            Assert.IsEmpty(subject.Elements);
+            subject.Add(elementOne);
 
-            subject.AddToStart(elementOne);
+            Assert.IsFalse(elementFoundMock.Received);
+            Assert.IsFalse(elementNotFoundMock.Received);
 
-            Assert.AreEqual(1, subject.Elements.Count);
-            Assert.IsTrue(becamePopulatedMock.Received);
-            Assert.IsTrue(elementAddedMock.Received);
-            Assert.IsFalse(elementRemovedMock.Received);
-            Assert.IsFalse(becameEmptyMock.Received);
+            subject.Contains(elementTwo);
 
-            becamePopulatedMock.Reset();
-            elementAddedMock.Reset();
-            elementRemovedMock.Reset();
-            becameEmptyMock.Reset();
-
-            subject.AddToStart(elementTwo);
-            Assert.AreEqual(2, subject.Elements.Count);
-            Assert.AreEqual(elementTwo, subject.Elements[0]);
-
-            Assert.IsFalse(becamePopulatedMock.Received);
-            Assert.IsTrue(elementAddedMock.Received);
-            Assert.IsFalse(elementRemovedMock.Received);
-            Assert.IsFalse(becameEmptyMock.Received);
+            Assert.IsFalse(elementFoundMock.Received);
+            Assert.IsTrue(elementNotFoundMock.Received);
 
             Object.DestroyImmediate(elementOne);
             Object.DestroyImmediate(elementTwo);
@@ -78,14 +84,15 @@ namespace Test.Zinnia.Data.Collection
             subject.ElementAdded.AddListener(elementAddedMock.Listen);
             subject.ElementRemoved.AddListener(elementRemovedMock.Listen);
             subject.BecameEmpty.AddListener(becameEmptyMock.Listen);
+
             GameObject elementOne = new GameObject();
             GameObject elementTwo = new GameObject();
 
-            Assert.IsEmpty(subject.Elements);
+            Assert.IsEmpty(subject.ReadOnlyElements);
 
-            subject.AddToEnd(elementOne);
+            subject.Add(elementOne);
 
-            Assert.AreEqual(1, subject.Elements.Count);
+            Assert.AreEqual(1, subject.ReadOnlyElements.Count);
             Assert.IsTrue(becamePopulatedMock.Received);
             Assert.IsTrue(elementAddedMock.Received);
             Assert.IsFalse(elementRemovedMock.Received);
@@ -96,9 +103,10 @@ namespace Test.Zinnia.Data.Collection
             elementRemovedMock.Reset();
             becameEmptyMock.Reset();
 
-            subject.AddToEnd(elementTwo);
-            Assert.AreEqual(2, subject.Elements.Count);
-            Assert.AreEqual(elementTwo, subject.Elements[1]);
+            subject.Add(elementTwo);
+
+            Assert.AreEqual(2, subject.ReadOnlyElements.Count);
+            Assert.AreEqual(elementTwo, subject.ReadOnlyElements[1]);
 
             Assert.IsFalse(becamePopulatedMock.Received);
             Assert.IsTrue(elementAddedMock.Received);
@@ -107,6 +115,175 @@ namespace Test.Zinnia.Data.Collection
 
             Object.DestroyImmediate(elementOne);
             Object.DestroyImmediate(elementTwo);
+        }
+
+        [Test]
+        public void AddToStart()
+        {
+            UnityEventListenerMock becamePopulatedMock = new UnityEventListenerMock();
+            UnityEventListenerMock elementAddedMock = new UnityEventListenerMock();
+            UnityEventListenerMock elementRemovedMock = new UnityEventListenerMock();
+            UnityEventListenerMock becameEmptyMock = new UnityEventListenerMock();
+            subject.BecamePopulated.AddListener(becamePopulatedMock.Listen);
+            subject.ElementAdded.AddListener(elementAddedMock.Listen);
+            subject.ElementRemoved.AddListener(elementRemovedMock.Listen);
+            subject.BecameEmpty.AddListener(becameEmptyMock.Listen);
+
+            GameObject elementOne = new GameObject();
+            GameObject elementTwo = new GameObject();
+
+            Assert.IsEmpty(subject.ReadOnlyElements);
+
+            subject.AddAt(elementOne, 0);
+
+            Assert.AreEqual(1, subject.ReadOnlyElements.Count);
+            Assert.IsTrue(becamePopulatedMock.Received);
+            Assert.IsTrue(elementAddedMock.Received);
+            Assert.IsFalse(elementRemovedMock.Received);
+            Assert.IsFalse(becameEmptyMock.Received);
+
+            becamePopulatedMock.Reset();
+            elementAddedMock.Reset();
+            elementRemovedMock.Reset();
+            becameEmptyMock.Reset();
+
+            subject.AddAt(elementTwo, 0);
+
+            Assert.AreEqual(2, subject.ReadOnlyElements.Count);
+            Assert.AreEqual(elementTwo, subject.ReadOnlyElements[0]);
+
+            Assert.IsFalse(becamePopulatedMock.Received);
+            Assert.IsTrue(elementAddedMock.Received);
+            Assert.IsFalse(elementRemovedMock.Received);
+            Assert.IsFalse(becameEmptyMock.Received);
+
+            Object.DestroyImmediate(elementOne);
+            Object.DestroyImmediate(elementTwo);
+        }
+
+        [Test]
+        public void AddAtCurrentIndex()
+        {
+            UnityEventListenerMock becamePopulatedMock = new UnityEventListenerMock();
+            UnityEventListenerMock elementAddedMock = new UnityEventListenerMock();
+            UnityEventListenerMock elementRemovedMock = new UnityEventListenerMock();
+            UnityEventListenerMock becameEmptyMock = new UnityEventListenerMock();
+            subject.BecamePopulated.AddListener(becamePopulatedMock.Listen);
+            subject.ElementAdded.AddListener(elementAddedMock.Listen);
+            subject.ElementRemoved.AddListener(elementRemovedMock.Listen);
+            subject.BecameEmpty.AddListener(becameEmptyMock.Listen);
+
+            subject.CurrentIndex = 0;
+
+            GameObject elementOne = new GameObject();
+            GameObject elementTwo = new GameObject();
+
+            Assert.IsEmpty(subject.ReadOnlyElements);
+
+            subject.AddAtCurrentIndex(elementOne);
+
+            Assert.AreEqual(1, subject.ReadOnlyElements.Count);
+            Assert.IsTrue(becamePopulatedMock.Received);
+            Assert.IsTrue(elementAddedMock.Received);
+            Assert.IsFalse(elementRemovedMock.Received);
+            Assert.IsFalse(becameEmptyMock.Received);
+
+            becamePopulatedMock.Reset();
+            elementAddedMock.Reset();
+            elementRemovedMock.Reset();
+            becameEmptyMock.Reset();
+
+            subject.AddAtCurrentIndex(elementTwo);
+            Assert.AreEqual(2, subject.ReadOnlyElements.Count);
+            Assert.AreEqual(elementTwo, subject.ReadOnlyElements[0]);
+
+            Assert.IsFalse(becamePopulatedMock.Received);
+            Assert.IsTrue(elementAddedMock.Received);
+            Assert.IsFalse(elementRemovedMock.Received);
+            Assert.IsFalse(becameEmptyMock.Received);
+
+            Object.DestroyImmediate(elementOne);
+            Object.DestroyImmediate(elementTwo);
+        }
+
+        [Test]
+        public void SetAt()
+        {
+            UnityEventListenerMock elementAddedMock = new UnityEventListenerMock();
+            UnityEventListenerMock elementRemovedMock = new UnityEventListenerMock();
+            subject.ElementAdded.AddListener(elementAddedMock.Listen);
+            subject.ElementRemoved.AddListener(elementRemovedMock.Listen);
+
+            GameObject elementOne = new GameObject();
+            GameObject elementTwo = new GameObject();
+            GameObject elementThree = new GameObject();
+            GameObject elementFour = new GameObject();
+
+            subject.Add(elementOne);
+            subject.Add(elementTwo);
+            subject.Add(elementThree);
+
+            elementAddedMock.Reset();
+            elementRemovedMock.Reset();
+
+            Assert.AreEqual(elementOne, subject.ReadOnlyElements[0]);
+            Assert.AreEqual(elementTwo, subject.ReadOnlyElements[1]);
+            Assert.AreEqual(elementThree, subject.ReadOnlyElements[2]);
+
+            subject.SetAt(elementFour, 1);
+
+            Assert.AreEqual(elementOne, subject.ReadOnlyElements[0]);
+            Assert.AreEqual(elementFour, subject.ReadOnlyElements[1]);
+            Assert.AreEqual(elementThree, subject.ReadOnlyElements[2]);
+
+            Assert.IsTrue(elementAddedMock.Received);
+            Assert.IsTrue(elementRemovedMock.Received);
+
+            Object.DestroyImmediate(elementOne);
+            Object.DestroyImmediate(elementTwo);
+            Object.DestroyImmediate(elementThree);
+            Object.DestroyImmediate(elementFour);
+        }
+
+        [Test]
+        public void SetAtCurrentIndex()
+        {
+            UnityEventListenerMock elementAddedMock = new UnityEventListenerMock();
+            UnityEventListenerMock elementRemovedMock = new UnityEventListenerMock();
+            subject.ElementAdded.AddListener(elementAddedMock.Listen);
+            subject.ElementRemoved.AddListener(elementRemovedMock.Listen);
+
+            subject.CurrentIndex = 1;
+
+            GameObject elementOne = new GameObject();
+            GameObject elementTwo = new GameObject();
+            GameObject elementThree = new GameObject();
+            GameObject elementFour = new GameObject();
+
+            subject.Add(elementOne);
+            subject.Add(elementTwo);
+            subject.Add(elementThree);
+
+            elementAddedMock.Reset();
+            elementRemovedMock.Reset();
+
+            Assert.AreEqual(elementOne, subject.ReadOnlyElements[0]);
+            Assert.AreEqual(elementTwo, subject.ReadOnlyElements[1]);
+            Assert.AreEqual(elementThree, subject.ReadOnlyElements[2]);
+
+            subject.SetAtCurrentIndex(elementFour);
+
+            Assert.AreEqual(elementOne, subject.ReadOnlyElements[0]);
+            Assert.AreEqual(elementFour, subject.ReadOnlyElements[1]);
+            Assert.AreEqual(elementThree, subject.ReadOnlyElements[2]);
+
+            Assert.IsTrue(elementAddedMock.Received);
+            Assert.IsTrue(elementRemovedMock.Received);
+
+            Object.DestroyImmediate(elementOne);
+            Object.DestroyImmediate(elementTwo);
+            Object.DestroyImmediate(elementThree);
+            Object.DestroyImmediate(elementFour);
         }
 
         [Test]
@@ -120,66 +297,67 @@ namespace Test.Zinnia.Data.Collection
             subject.ElementAdded.AddListener(elementAddedMock.Listen);
             subject.ElementRemoved.AddListener(elementRemovedMock.Listen);
             subject.BecameEmpty.AddListener(becameEmptyMock.Listen);
+
             GameObject elementOne = new GameObject();
             GameObject elementTwo = new GameObject();
 
-            subject.RemoveFirst(elementOne);
+            subject.Remove(elementOne);
 
             Assert.IsFalse(becamePopulatedMock.Received);
             Assert.IsFalse(elementAddedMock.Received);
             Assert.IsFalse(elementRemovedMock.Received);
             Assert.IsFalse(becameEmptyMock.Received);
 
-            subject.AddToEnd(elementOne);
-            subject.AddToEnd(elementTwo);
-            subject.AddToEnd(elementOne);
+            subject.Add(elementOne);
+            subject.Add(elementTwo);
+            subject.Add(elementOne);
 
             becamePopulatedMock.Reset();
             elementAddedMock.Reset();
             elementRemovedMock.Reset();
             becameEmptyMock.Reset();
 
-            Assert.AreEqual(3, subject.Elements.Count);
+            Assert.AreEqual(3, subject.ReadOnlyElements.Count);
 
-            subject.RemoveFirst(elementOne);
+            subject.Remove(elementOne);
 
             Assert.IsFalse(becamePopulatedMock.Received);
             Assert.IsFalse(elementAddedMock.Received);
             Assert.IsTrue(elementRemovedMock.Received);
             Assert.IsFalse(becameEmptyMock.Received);
 
-            Assert.AreEqual(2, subject.Elements.Count);
-            Assert.AreEqual(elementTwo, subject.Elements[0]);
-            Assert.AreEqual(elementOne, subject.Elements[1]);
+            Assert.AreEqual(2, subject.ReadOnlyElements.Count);
+            Assert.AreEqual(elementTwo, subject.ReadOnlyElements[0]);
+            Assert.AreEqual(elementOne, subject.ReadOnlyElements[1]);
 
             becamePopulatedMock.Reset();
             elementAddedMock.Reset();
             elementRemovedMock.Reset();
             becameEmptyMock.Reset();
 
-            subject.RemoveFirst(elementOne);
+            subject.Remove(elementOne);
 
             Assert.IsFalse(becamePopulatedMock.Received);
             Assert.IsFalse(elementAddedMock.Received);
             Assert.IsTrue(elementRemovedMock.Received);
             Assert.IsFalse(becameEmptyMock.Received);
 
-            Assert.AreEqual(1, subject.Elements.Count);
-            Assert.AreEqual(elementTwo, subject.Elements[0]);
+            Assert.AreEqual(1, subject.ReadOnlyElements.Count);
+            Assert.AreEqual(elementTwo, subject.ReadOnlyElements[0]);
 
             becamePopulatedMock.Reset();
             elementAddedMock.Reset();
             elementRemovedMock.Reset();
             becameEmptyMock.Reset();
 
-            subject.RemoveFirst(elementTwo);
+            subject.Remove(elementTwo);
 
             Assert.IsFalse(becamePopulatedMock.Received);
             Assert.IsFalse(elementAddedMock.Received);
             Assert.IsTrue(elementRemovedMock.Received);
             Assert.IsTrue(becameEmptyMock.Received);
 
-            Assert.AreEqual(0, subject.Elements.Count);
+            Assert.AreEqual(0, subject.ReadOnlyElements.Count);
 
             becamePopulatedMock.Reset();
             elementAddedMock.Reset();
@@ -201,66 +379,67 @@ namespace Test.Zinnia.Data.Collection
             subject.ElementAdded.AddListener(elementAddedMock.Listen);
             subject.ElementRemoved.AddListener(elementRemovedMock.Listen);
             subject.BecameEmpty.AddListener(becameEmptyMock.Listen);
+
             GameObject elementOne = new GameObject();
             GameObject elementTwo = new GameObject();
 
-            subject.RemoveLast(elementOne);
+            subject.RemoveLastOccurrence(elementOne);
 
             Assert.IsFalse(becamePopulatedMock.Received);
             Assert.IsFalse(elementAddedMock.Received);
             Assert.IsFalse(elementRemovedMock.Received);
             Assert.IsFalse(becameEmptyMock.Received);
 
-            subject.AddToEnd(elementOne);
-            subject.AddToEnd(elementTwo);
-            subject.AddToEnd(elementOne);
+            subject.Add(elementOne);
+            subject.Add(elementTwo);
+            subject.Add(elementOne);
 
             becamePopulatedMock.Reset();
             elementAddedMock.Reset();
             elementRemovedMock.Reset();
             becameEmptyMock.Reset();
 
-            Assert.AreEqual(3, subject.Elements.Count);
+            Assert.AreEqual(3, subject.ReadOnlyElements.Count);
 
-            subject.RemoveLast(elementOne);
+            subject.RemoveLastOccurrence(elementOne);
 
             Assert.IsFalse(becamePopulatedMock.Received);
             Assert.IsFalse(elementAddedMock.Received);
             Assert.IsTrue(elementRemovedMock.Received);
             Assert.IsFalse(becameEmptyMock.Received);
 
-            Assert.AreEqual(2, subject.Elements.Count);
-            Assert.AreEqual(elementOne, subject.Elements[0]);
-            Assert.AreEqual(elementTwo, subject.Elements[1]);
+            Assert.AreEqual(2, subject.ReadOnlyElements.Count);
+            Assert.AreEqual(elementOne, subject.ReadOnlyElements[0]);
+            Assert.AreEqual(elementTwo, subject.ReadOnlyElements[1]);
 
             becamePopulatedMock.Reset();
             elementAddedMock.Reset();
             elementRemovedMock.Reset();
             becameEmptyMock.Reset();
 
-            subject.RemoveLast(elementOne);
+            subject.RemoveLastOccurrence(elementOne);
 
             Assert.IsFalse(becamePopulatedMock.Received);
             Assert.IsFalse(elementAddedMock.Received);
             Assert.IsTrue(elementRemovedMock.Received);
             Assert.IsFalse(becameEmptyMock.Received);
 
-            Assert.AreEqual(1, subject.Elements.Count);
-            Assert.AreEqual(elementTwo, subject.Elements[0]);
+            Assert.AreEqual(1, subject.ReadOnlyElements.Count);
+            Assert.AreEqual(elementTwo, subject.ReadOnlyElements[0]);
 
             becamePopulatedMock.Reset();
             elementAddedMock.Reset();
             elementRemovedMock.Reset();
             becameEmptyMock.Reset();
 
-            subject.RemoveLast(elementTwo);
+            subject.RemoveLastOccurrence(elementTwo);
 
             Assert.IsFalse(becamePopulatedMock.Received);
             Assert.IsFalse(elementAddedMock.Received);
             Assert.IsTrue(elementRemovedMock.Received);
             Assert.IsTrue(becameEmptyMock.Received);
 
-            Assert.AreEqual(0, subject.Elements.Count);
+            Assert.AreEqual(0, subject.ReadOnlyElements.Count);
 
             becamePopulatedMock.Reset();
             elementAddedMock.Reset();
@@ -269,6 +448,118 @@ namespace Test.Zinnia.Data.Collection
 
             Object.DestroyImmediate(elementOne);
             Object.DestroyImmediate(elementTwo);
+        }
+
+        [Test]
+        public void RemoveAt()
+        {
+            UnityEventListenerMock becamePopulatedMock = new UnityEventListenerMock();
+            UnityEventListenerMock elementAddedMock = new UnityEventListenerMock();
+            UnityEventListenerMock elementRemovedMock = new UnityEventListenerMock();
+            UnityEventListenerMock becameEmptyMock = new UnityEventListenerMock();
+            subject.BecamePopulated.AddListener(becamePopulatedMock.Listen);
+            subject.ElementAdded.AddListener(elementAddedMock.Listen);
+            subject.ElementRemoved.AddListener(elementRemovedMock.Listen);
+            subject.BecameEmpty.AddListener(becameEmptyMock.Listen);
+
+            GameObject elementOne = new GameObject();
+            GameObject elementTwo = new GameObject();
+            GameObject elementThree = new GameObject();
+
+            Assert.AreEqual(0, subject.ReadOnlyElements.Count);
+
+            Assert.IsFalse(becamePopulatedMock.Received);
+            Assert.IsFalse(elementAddedMock.Received);
+            Assert.IsFalse(elementRemovedMock.Received);
+            Assert.IsFalse(becameEmptyMock.Received);
+
+            subject.Add(elementOne);
+            subject.Add(elementTwo);
+            subject.Add(elementThree);
+
+            becamePopulatedMock.Reset();
+            elementAddedMock.Reset();
+            elementRemovedMock.Reset();
+            becameEmptyMock.Reset();
+
+            Assert.AreEqual(3, subject.ReadOnlyElements.Count);
+
+            subject.RemoveAt(1);
+
+            Assert.IsFalse(becamePopulatedMock.Received);
+            Assert.IsFalse(elementAddedMock.Received);
+            Assert.IsTrue(elementRemovedMock.Received);
+            Assert.IsFalse(becameEmptyMock.Received);
+
+            Assert.AreEqual(2, subject.ReadOnlyElements.Count);
+            Assert.AreEqual(elementOne, subject.ReadOnlyElements[0]);
+            Assert.AreEqual(elementThree, subject.ReadOnlyElements[1]);
+
+            becamePopulatedMock.Reset();
+            elementAddedMock.Reset();
+            elementRemovedMock.Reset();
+            becameEmptyMock.Reset();
+
+            Object.DestroyImmediate(elementOne);
+            Object.DestroyImmediate(elementTwo);
+            Object.DestroyImmediate(elementThree);
+        }
+
+        [Test]
+        public void RemoveAtCurrentIndex()
+        {
+            UnityEventListenerMock becamePopulatedMock = new UnityEventListenerMock();
+            UnityEventListenerMock elementAddedMock = new UnityEventListenerMock();
+            UnityEventListenerMock elementRemovedMock = new UnityEventListenerMock();
+            UnityEventListenerMock becameEmptyMock = new UnityEventListenerMock();
+            subject.BecamePopulated.AddListener(becamePopulatedMock.Listen);
+            subject.ElementAdded.AddListener(elementAddedMock.Listen);
+            subject.ElementRemoved.AddListener(elementRemovedMock.Listen);
+            subject.BecameEmpty.AddListener(becameEmptyMock.Listen);
+
+            subject.CurrentIndex = 1;
+
+            GameObject elementOne = new GameObject();
+            GameObject elementTwo = new GameObject();
+            GameObject elementThree = new GameObject();
+
+            Assert.AreEqual(0, subject.ReadOnlyElements.Count);
+
+            Assert.IsFalse(becamePopulatedMock.Received);
+            Assert.IsFalse(elementAddedMock.Received);
+            Assert.IsFalse(elementRemovedMock.Received);
+            Assert.IsFalse(becameEmptyMock.Received);
+
+            subject.Add(elementOne);
+            subject.Add(elementTwo);
+            subject.Add(elementThree);
+
+            becamePopulatedMock.Reset();
+            elementAddedMock.Reset();
+            elementRemovedMock.Reset();
+            becameEmptyMock.Reset();
+
+            Assert.AreEqual(3, subject.ReadOnlyElements.Count);
+
+            subject.RemoveAtCurrentIndex();
+
+            Assert.IsFalse(becamePopulatedMock.Received);
+            Assert.IsFalse(elementAddedMock.Received);
+            Assert.IsTrue(elementRemovedMock.Received);
+            Assert.IsFalse(becameEmptyMock.Received);
+
+            Assert.AreEqual(2, subject.ReadOnlyElements.Count);
+            Assert.AreEqual(elementOne, subject.ReadOnlyElements[0]);
+            Assert.AreEqual(elementThree, subject.ReadOnlyElements[1]);
+
+            becamePopulatedMock.Reset();
+            elementAddedMock.Reset();
+            elementRemovedMock.Reset();
+            becameEmptyMock.Reset();
+
+            Object.DestroyImmediate(elementOne);
+            Object.DestroyImmediate(elementTwo);
+            Object.DestroyImmediate(elementThree);
         }
 
         [Test]
@@ -282,6 +573,7 @@ namespace Test.Zinnia.Data.Collection
             subject.ElementAdded.AddListener(elementAddedMock.Listen);
             subject.ElementRemoved.AddListener(elementRemovedMock.Listen);
             subject.BecameEmpty.AddListener(becameEmptyMock.Listen);
+
             GameObject elementOne = new GameObject();
             GameObject elementTwo = new GameObject();
 
@@ -292,16 +584,16 @@ namespace Test.Zinnia.Data.Collection
             Assert.IsFalse(elementRemovedMock.Received);
             Assert.IsFalse(becameEmptyMock.Received);
 
-            subject.AddToEnd(elementOne);
-            subject.AddToEnd(elementTwo);
-            subject.AddToEnd(elementOne);
+            subject.Add(elementOne);
+            subject.Add(elementTwo);
+            subject.Add(elementOne);
 
             becamePopulatedMock.Reset();
             elementAddedMock.Reset();
             elementRemovedMock.Reset();
             becameEmptyMock.Reset();
 
-            Assert.AreEqual(3, subject.Elements.Count);
+            Assert.AreEqual(3, subject.ReadOnlyElements.Count);
 
             subject.Clear(false);
 
@@ -310,7 +602,7 @@ namespace Test.Zinnia.Data.Collection
             Assert.IsTrue(elementRemovedMock.Received);
             Assert.IsTrue(becameEmptyMock.Received);
 
-            Assert.AreEqual(0, subject.Elements.Count);
+            Assert.AreEqual(0, subject.ReadOnlyElements.Count);
 
             Object.DestroyImmediate(elementOne);
             Object.DestroyImmediate(elementTwo);
@@ -327,6 +619,7 @@ namespace Test.Zinnia.Data.Collection
             subject.ElementAdded.AddListener(elementAddedMock.Listen);
             subject.ElementRemoved.AddListener(elementRemovedMock.Listen);
             subject.BecameEmpty.AddListener(becameEmptyMock.Listen);
+
             GameObject elementOne = new GameObject();
             GameObject elementTwo = new GameObject();
 
@@ -337,16 +630,16 @@ namespace Test.Zinnia.Data.Collection
             Assert.IsFalse(elementRemovedMock.Received);
             Assert.IsFalse(becameEmptyMock.Received);
 
-            subject.AddToEnd(elementOne);
-            subject.AddToEnd(elementTwo);
-            subject.AddToEnd(elementOne);
+            subject.Add(elementOne);
+            subject.Add(elementTwo);
+            subject.Add(elementOne);
 
             becamePopulatedMock.Reset();
             elementAddedMock.Reset();
             elementRemovedMock.Reset();
             becameEmptyMock.Reset();
 
-            Assert.AreEqual(3, subject.Elements.Count);
+            Assert.AreEqual(3, subject.ReadOnlyElements.Count);
 
             subject.Clear(true);
 
@@ -355,7 +648,7 @@ namespace Test.Zinnia.Data.Collection
             Assert.IsTrue(elementRemovedMock.Received);
             Assert.IsTrue(becameEmptyMock.Received);
 
-            Assert.AreEqual(0, subject.Elements.Count);
+            Assert.AreEqual(0, subject.ReadOnlyElements.Count);
 
             Object.DestroyImmediate(elementOne);
             Object.DestroyImmediate(elementTwo);
@@ -367,8 +660,8 @@ namespace Test.Zinnia.Data.Collection
             GameObjectObservableListMock mock = containingObject.AddComponent<GameObjectObservableListMock>();
             GameObject elementOne = new GameObject();
             GameObject elementTwo = new GameObject();
-            mock.AddToStart(elementOne);
-            mock.AddToEnd(elementTwo);
+            mock.Add(elementOne);
+            mock.Add(elementTwo);
 
             UnityEventListenerMock becamePopulatedMock = new UnityEventListenerMock();
             UnityEventListenerMock elementAddedMock = new UnityEventListenerMock();


### PR DESCRIPTION
The ObservableList component now has additional functionality like
being able to check if the collection contains a given item and
set an element value at a specific index.

The fields have now been converted to properties and a new CurrentIndex
field has been added that allows methods that require an index to
still function if called via the limitations of a UnityEvent (which
only allows one parameter type).