### PR TITLE
fix(Type): simplify SerializableType serialization

### DIFF
--- a/Editor/Data/Attribute/TypePickerAttributeDrawer.cs
+++ b/Editor/Data/Attribute/TypePickerAttributeDrawer.cs
@@ -8,7 +8,6 @@
     [CustomPropertyDrawer(typeof(TypePickerAttribute))]
     public class TypePickerAttributeDrawer : PropertyDrawer
     {
-        private const string collectionLabelText = "Selected Type";
         private Type type;
 
         public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
@@ -18,7 +17,9 @@
             using (new EditorGUI.PropertyScope(position, label, property))
             {
                 SerializedProperty assemblyQualifiedTypeNameProperty = property.FindPropertyRelative("assemblyQualifiedTypeName");
-                label.text = label.text == assemblyQualifiedTypeNameProperty.stringValue ? collectionLabelText : label.text;
+                int? index = property.TryGetIndex();
+
+                label.text = index == null ? label.text : $"Element {index}";
                 Rect buttonPosition = EditorGUI.PrefixLabel(position, label);
 
                 if (type?.AssemblyQualifiedName != assemblyQualifiedTypeNameProperty.stringValue)

--- a/Editor/Utility/SerializedPropertyExtensions.cs
+++ b/Editor/Utility/SerializedPropertyExtensions.cs
@@ -1,0 +1,27 @@
+﻿namespace Zinnia.Utility
+{
+    using UnityEditor;
+    using System.Text.RegularExpressions;
+
+    /// <summary>
+    /// Extension methods for <see cref="SerializedProperty"/>.
+    /// </summary>
+    public static class SerializedPropertyExtensions
+    {
+        /// <summary>
+        /// Matches the index found in <see cref="SerializedProperty.propertyPath"/> if it exists.
+        /// </summary>
+        private static readonly Regex indexRegex = new Regex(@"\.Array\.data\[(?'index'\d*)\]$", RegexOptions.Compiled);
+
+        /// <summary>
+        /// The index found in <see cref="SerializedProperty.propertyPath"/> if it exists.
+        /// </summary>
+        /// <param name="property">The property to search on.</param>
+        /// <returns>The index if found, otherwise <see langword="null"/>.</returns>
+        public static int? TryGetIndex(this SerializedProperty property)
+        {
+            Match match = indexRegex.Match(property.propertyPath);
+            return match.Success ? int.Parse(match.Groups["index"].Value) : (int?)null;
+        }
+    }
+}

--- a/Editor/Utility/SerializedPropertyExtensions.cs.meta
+++ b/Editor/Utility/SerializedPropertyExtensions.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 2d7f632d807d42d38ccf3b67de6f8583
+timeCreated: 1551987588

--- a/Runtime/Data/Type/SerializableType.cs
+++ b/Runtime/Data/Type/SerializableType.cs
@@ -7,43 +7,21 @@
     /// Specifies a serializable data type.
     /// </summary>
     [Serializable]
-    public class SerializableType
+    public class SerializableType : ISerializationCallbackReceiver
     {
         /// <summary>
         /// The actual <see cref="Type"/> of the held serializable type.
         /// </summary>
-        public Type ActualType
-        {
-            get
-            {
-                if (!string.IsNullOrWhiteSpace(assemblyQualifiedTypeName) && !assemblyQualifiedTypeName.Equals(currentAssemblyQualifiedTypeName))
-                {
-                    ActualType = Type.GetType(assemblyQualifiedTypeName);
-                    currentAssemblyQualifiedTypeName = assemblyQualifiedTypeName;
-                }
-
-                return actualType;
-            }
-            protected set
-            {
-                actualType = value;
-                assemblyQualifiedTypeName = value.AssemblyQualifiedName;
-            }
-        }
-        private Type actualType;
+        public Type ActualType { get; set; }
 
         /// <summary>
-        /// The string equivalent of the type name in full assembly qualified format.
+        /// The name of the type in full assembly qualified format.
         /// </summary>
         [SerializeField]
         private string assemblyQualifiedTypeName;
-        /// <summary>
-        /// The current set string equivalent of the type name.
-        /// </summary>
-        private string currentAssemblyQualifiedTypeName;
 
         /// <summary>
-        /// Allows conversion of <see cref="SerializableType"/> to <see cref="Type"/>.
+        /// Converts from <see cref="SerializableType"/> to <see cref="Type"/>.
         /// </summary>
         /// <param name="serializableType">The item to convert.</param>
         public static implicit operator Type(SerializableType serializableType)
@@ -52,16 +30,36 @@
         }
 
         /// <summary>
-        /// Allows conversion of <see cref="Type"/> to <see cref="SerializableType"/>.
+        /// Converts from <see cref="Type"/> to <see cref="SerializableType"/>.
         /// </summary>
         /// <param name="type">The item to convert.</param>
         public static implicit operator SerializableType(Type type)
         {
             return new SerializableType
             {
-                actualType = type,
+                ActualType = type,
                 assemblyQualifiedTypeName = type.AssemblyQualifiedName
             };
+        }
+
+        /// <inheritdoc />
+        public void OnBeforeSerialize()
+        {
+            assemblyQualifiedTypeName = ActualType?.AssemblyQualifiedName;
+        }
+
+        /// <inheritdoc />
+        public void OnAfterDeserialize()
+        {
+            try
+            {
+                ActualType = Type.GetType(assemblyQualifiedTypeName);
+            }
+            catch (Exception exception)
+            {
+                Debug.LogException(exception);
+                ActualType = null;
+            }
         }
     }
 }

--- a/Tests/Editor/Data/Type/SerializableTypeTest.cs
+++ b/Tests/Editor/Data/Type/SerializableTypeTest.cs
@@ -9,35 +9,11 @@ namespace Test.Zinnia.Data.Type
     public class SerializableTypeTest
     {
         [Test]
-        public void ConstructFromType()
+        public void ConvertFromType()
         {
             Component componentType = new Component();
             SerializableType subject = componentType.GetType();
             Assert.AreEqual(componentType.GetType(), subject.ActualType);
-        }
-
-        [Test]
-        public void ConstructFromString()
-        {
-            Component componentType = new Component();
-            SerializableType subject = Type.GetType("UnityEngine.Component, UnityEngine.CoreModule, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null");
-            Assert.AreEqual(componentType.GetType(), subject.ActualType);
-        }
-
-        [Test]
-        public void ChangeAssemblyQualifiedTypeName()
-        {
-            Component componentType = new Component();
-            FloatRange altType = new FloatRange();
-
-            SerializableType subject = componentType.GetType();
-
-            Assert.AreEqual(componentType.GetType(), subject.ActualType);
-
-            var prop = subject.GetType().GetField("assemblyQualifiedTypeName", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
-            prop.SetValue(subject, altType.GetType().AssemblyQualifiedName);
-
-            Assert.AreEqual(altType.GetType(), subject.ActualType);
         }
 
         [Test]


### PR DESCRIPTION
Instead of handling potentially changed data in the getter of the
actual type this fix ensures changes to `SerializableType` are
serialized by using the callback methods Unity offers for this
purpose. This fix simplifies the change handling but also improves
performance as the actual type can now just be returned directly
instead of having a potentially costly lookup.

The tests for this type have been updated to only test the remaining
actual logic.