### PR TITLE
feat(Rule): update fields to properties and lists to observable

### DIFF
--- a/Runtime/Data/Collection/DefaultObservableList.cs
+++ b/Runtime/Data/Collection/DefaultObservableList.cs
@@ -1,0 +1,22 @@
+﻿namespace Zinnia.Data.Collection
+{
+    using UnityEngine.Events;
+    using System.Collections.Generic;
+    using Malimbe.XmlDocumentationAttribute;
+    using Malimbe.PropertySerializationAttribute;
+
+    /// <summary>
+    /// An intermediate that defines the <see cref="Elements"/> collection to prevent needing to redefine in every concrete class.
+    /// </summary>
+    /// <typeparam name="TElement">The type of the elements in the <see cref="List{T}"/>.</typeparam>
+    /// <typeparam name="TEvent">The <see cref="UnityEvent"/> type to use.</typeparam>
+    public abstract class DefaultObservableList<TElement, TEvent> : ObservableList<TElement, TEvent> where TEvent : UnityEvent<TElement>, new()
+    {
+        /// <summary>
+        /// The collection to observe changes of.
+        /// </summary>
+        [Serialized]
+        [field: DocumentedByXml]
+        protected override List<TElement> Elements { get; set; } = new List<TElement>();
+    }
+}

--- a/Runtime/Data/Collection/DefaultObservableList.cs.meta
+++ b/Runtime/Data/Collection/DefaultObservableList.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c026d817f65f5c04aa62528e9a334952
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Data/Collection/GameObjectObservableList.cs
+++ b/Runtime/Data/Collection/GameObjectObservableList.cs
@@ -8,7 +8,7 @@
     /// <summary>
     /// Allows observing changes to a <see cref="List{T}"/> of <see cref="GameObject"/>s.
     /// </summary>
-    public class GameObjectObservableList : ObservableList<GameObject, GameObjectObservableList.UnityEvent>
+    public class GameObjectObservableList : DefaultObservableList<GameObject, GameObjectObservableList.UnityEvent>
     {
         /// <summary>
         /// Defines the event with the <see cref="GameObject"/>.

--- a/Runtime/Data/Collection/ObservableList.cs
+++ b/Runtime/Data/Collection/ObservableList.cs
@@ -16,23 +16,9 @@
     public abstract class ObservableList<TElement, TEvent> : MonoBehaviour where TEvent : UnityEvent<TElement>, new()
     {
         /// <summary>
-        /// The collection to observe changes of.
-        /// </summary>
-        [Serialized]
-        [field: DocumentedByXml]
-        protected List<TElement> Elements { get; set; } = new List<TElement>();
-
-        /// <summary>
-        /// The index to use in methods specifically specifying to use it. In case this index is out of bounds for the collection it will wrap around.
-        /// </summary>
-        [Serialized]
-        [field: DocumentedByXml]
-        public int CurrentIndex { get; set; }
-
-        /// <summary>
         /// Emitted when the searched element is found.
         /// </summary>
-        [DocumentedByXml]
+        [Header("List Events"), DocumentedByXml]
         public TEvent Found = new TEvent();
         /// <summary>
         /// Emitted when the searched element is not found.
@@ -60,10 +46,23 @@
         [DocumentedByXml]
         public TEvent BecameEmpty = new TEvent();
 
+
+        /// <summary>
+        /// The index to use in methods specifically specifying to use it. In case this index is out of bounds for the collection it will wrap around.
+        /// </summary>
+        [Serialized]
+        [field: Header("List Settings"), DocumentedByXml]
+        public int CurrentIndex { get; set; }
+
         /// <summary>
         /// The collection to observe changes of.
         /// </summary>
         public IReadOnlyList<TElement> ReadOnlyElements => Elements;
+
+        /// <summary>
+        /// The collection to observe changes of.
+        /// </summary>
+        protected abstract List<TElement> Elements { get; set; }
 
         /// <summary>
         /// Checks to see if the collection contains the given element.
@@ -256,9 +255,19 @@
 
         protected virtual void Start()
         {
+            if (ReadOnlyElements == null)
+            {
+                return;
+            }
+
             for (int index = 0; index < ReadOnlyElements.Count; index++)
             {
                 TElement element = ReadOnlyElements[index];
+                if (element == null)
+                {
+                    continue;
+                }
+
                 ElementAdded?.Invoke(element);
 
                 if (index == 0)

--- a/Runtime/Data/Collection/RuleContainerObservableList.cs
+++ b/Runtime/Data/Collection/RuleContainerObservableList.cs
@@ -1,0 +1,21 @@
+﻿namespace Zinnia.Data.Collection
+{
+    using UnityEngine.Events;
+    using System;
+    using System.Collections.Generic;
+    using Zinnia.Rule;
+
+    /// <summary>
+    /// Allows observing changes to a <see cref="List{T}"/> of <see cref="RuleContainer"/>s.
+    /// </summary>
+    public class RuleContainerObservableList : DefaultObservableList<RuleContainer, RuleContainerObservableList.UnityEvent>
+    {
+        /// <summary>
+        /// Defines the event with the <see cref="RuleContainer"/>.
+        /// </summary>
+        [Serializable]
+        public class UnityEvent : UnityEvent<RuleContainer>
+        {
+        }
+    }
+}

--- a/Runtime/Data/Collection/RuleContainerObservableList.cs.meta
+++ b/Runtime/Data/Collection/RuleContainerObservableList.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 098fc6c54c3792e49837be0f531aa588
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Data/Collection/SerializableTypeObservableList.cs
+++ b/Runtime/Data/Collection/SerializableTypeObservableList.cs
@@ -1,0 +1,32 @@
+﻿namespace Zinnia.Data.Collection
+{
+    using UnityEngine;
+    using UnityEngine.Events;
+    using System;
+    using System.Collections.Generic;
+    using Malimbe.XmlDocumentationAttribute;
+    using Malimbe.PropertySerializationAttribute;
+    using Zinnia.Data.Type;
+    using Zinnia.Data.Attribute;
+
+    /// <summary>
+    /// Allows observing changes to a <see cref="List{T}"/> of <see cref="SerializableType"/>s.
+    /// </summary>
+    public class SerializableTypeObservableList : ObservableList<SerializableType, SerializableTypeObservableList.UnityEvent>
+    {
+        /// <summary>
+        /// The collection to observe changes of.
+        /// </summary>
+        [Serialized]
+        [field: DocumentedByXml, TypePicker(typeof(Component))]
+        protected override List<SerializableType> Elements { get; set; } = new List<SerializableType>();
+
+        /// <summary>
+        /// Defines the event with the <see cref="SerializableType"/>.
+        /// </summary>
+        [Serializable]
+        public class UnityEvent : UnityEvent<SerializableType>
+        {
+        }
+    }
+}

--- a/Runtime/Data/Collection/SerializableTypeObservableList.cs.meta
+++ b/Runtime/Data/Collection/SerializableTypeObservableList.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7d01a890104495a49a7a72c5733174ec
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Data/Collection/StringObservableList.cs
+++ b/Runtime/Data/Collection/StringObservableList.cs
@@ -1,0 +1,20 @@
+﻿namespace Zinnia.Data.Collection
+{
+    using UnityEngine.Events;
+    using System;
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// Allows observing changes to a <see cref="List{T}"/> of <see cref="string"/>s.
+    /// </summary>
+    public class StringObservableList : DefaultObservableList<string, StringObservableList.UnityEvent>
+    {
+        /// <summary>
+        /// Defines the event with the <see cref="string"/>.
+        /// </summary>
+        [Serializable]
+        public class UnityEvent : UnityEvent<string>
+        {
+        }
+    }
+}

--- a/Runtime/Data/Collection/StringObservableList.cs.meta
+++ b/Runtime/Data/Collection/StringObservableList.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 38ffc1a377d081a40bde29f8795f595e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Data/Collection/UnityObjectObservableList.cs
+++ b/Runtime/Data/Collection/UnityObjectObservableList.cs
@@ -1,0 +1,21 @@
+﻿namespace Zinnia.Data.Collection
+{
+    using Object = UnityEngine.Object;
+    using UnityEngine.Events;
+    using System;
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// Allows observing changes to a <see cref="List{T}"/> of <see cref="Object"/>s.
+    /// </summary>
+    public class UnityObjectObservableList : DefaultObservableList<Object, UnityObjectObservableList.UnityEvent>
+    {
+        /// <summary>
+        /// Defines the event with the <see cref="Object"/>.
+        /// </summary>
+        [Serializable]
+        public class UnityEvent : UnityEvent<Object>
+        {
+        }
+    }
+}

--- a/Runtime/Data/Collection/UnityObjectObservableList.cs.meta
+++ b/Runtime/Data/Collection/UnityObjectObservableList.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7a6b6179884db4f45985375ba8170f77
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Rule/AllRule.cs
+++ b/Runtime/Rule/AllRule.cs
@@ -1,10 +1,11 @@
 ﻿namespace Zinnia.Rule
 {
     using UnityEngine;
-    using System.Collections.Generic;
     using Malimbe.XmlDocumentationAttribute;
     using Malimbe.BehaviourStateRequirementMethod;
+    using Malimbe.PropertySerializationAttribute;
     using Zinnia.Extension;
+    using Zinnia.Data.Collection;
 
     /// <summary>
     /// Determines whether all <see cref="IRule"/>s in a list are accepting an object.
@@ -14,19 +15,20 @@
         /// <summary>
         /// The <see cref="IRule"/>s to check against.
         /// </summary>
-        [DocumentedByXml]
-        public List<RuleContainer> rules = new List<RuleContainer>();
+        [Serialized]
+        [field: DocumentedByXml]
+        public RuleContainerObservableList Rules { get; set; }
 
         /// <inheritdoc/>
         [RequiresBehaviourState]
         public bool Accepts(object target)
         {
-            if (rules == null || rules.Count == 0)
+            if (Rules == null || Rules.ReadOnlyElements.Count == 0)
             {
                 return false;
             }
 
-            foreach (RuleContainer rule in rules)
+            foreach (RuleContainer rule in Rules.ReadOnlyElements)
             {
                 if (!rule.Accepts(target))
                 {

--- a/Runtime/Rule/AnyComponentTypeRule.cs
+++ b/Runtime/Rule/AnyComponentTypeRule.cs
@@ -1,10 +1,10 @@
 ﻿namespace Zinnia.Rule
 {
     using UnityEngine;
-    using System.Collections.Generic;
     using Malimbe.XmlDocumentationAttribute;
-    using Zinnia.Data.Attribute;
+    using Malimbe.PropertySerializationAttribute;
     using Zinnia.Data.Type;
+    using Zinnia.Data.Collection;
 
     /// <summary>
     /// Determines whether a <see cref="GameObject"/> has any component found in a list.
@@ -14,13 +14,19 @@
         /// <summary>
         /// The component types to look for.
         /// </summary>
-        [TypePicker(typeof(Component)), DocumentedByXml]
-        public List<SerializableType> componentTypes = new List<SerializableType>();
+        [Serialized]
+        [field: DocumentedByXml]
+        public SerializableTypeObservableList ComponentTypes { get; set; }
 
         /// <inheritdoc/>
         protected override bool Accepts(GameObject targetGameObject)
         {
-            foreach (SerializableType serializedType in componentTypes)
+            if (ComponentTypes == null)
+            {
+                return false;
+            }
+
+            foreach (SerializableType serializedType in ComponentTypes.ReadOnlyElements)
             {
                 if (serializedType.ActualType != null && targetGameObject.GetComponent(serializedType) != null)
                 {

--- a/Runtime/Rule/AnyLayerRule.cs
+++ b/Runtime/Rule/AnyLayerRule.cs
@@ -2,6 +2,7 @@
 {
     using UnityEngine;
     using Malimbe.XmlDocumentationAttribute;
+    using Malimbe.PropertySerializationAttribute;
 
     /// <summary>
     /// Determines whether a <see cref="GameObject"/>'s <see cref="GameObject.layer"/> is part of a list.
@@ -11,13 +12,14 @@
         /// <summary>
         /// The layers to check against.
         /// </summary>
-        [DocumentedByXml]
-        public LayerMask layerMask;
+        [Serialized]
+        [field: DocumentedByXml]
+        public LayerMask LayerMask { get; set; }
 
         /// <inheritdoc />
         protected override bool Accepts(GameObject targetGameObject)
         {
-            return (targetGameObject.layer & layerMask.value) != 0;
+            return (targetGameObject.layer & LayerMask.value) != 0;
         }
     }
 }

--- a/Runtime/Rule/AnyRule.cs
+++ b/Runtime/Rule/AnyRule.cs
@@ -1,10 +1,11 @@
 ﻿namespace Zinnia.Rule
 {
     using UnityEngine;
-    using System.Collections.Generic;
     using Malimbe.XmlDocumentationAttribute;
     using Malimbe.BehaviourStateRequirementMethod;
+    using Malimbe.PropertySerializationAttribute;
     using Zinnia.Extension;
+    using Zinnia.Data.Collection;
 
     /// <summary>
     /// Determines whether any <see cref="IRule"/> in a list is accepting an object.
@@ -14,14 +15,20 @@
         /// <summary>
         /// The <see cref="IRule"/>s to check against.
         /// </summary>
-        [DocumentedByXml]
-        public List<RuleContainer> rules = new List<RuleContainer>();
+        [Serialized]
+        [field: DocumentedByXml]
+        public RuleContainerObservableList Rules { get; set; }
 
         /// <inheritdoc />
         [RequiresBehaviourState]
         public bool Accepts(object target)
         {
-            foreach (RuleContainer rule in rules)
+            if (Rules == null)
+            {
+                return false;
+            }
+
+            foreach (RuleContainer rule in Rules.ReadOnlyElements)
             {
                 if (rule.Accepts(target))
                 {

--- a/Runtime/Rule/AnyTagRule.cs
+++ b/Runtime/Rule/AnyTagRule.cs
@@ -1,8 +1,9 @@
 ﻿namespace Zinnia.Rule
 {
     using UnityEngine;
-    using System.Collections.Generic;
     using Malimbe.XmlDocumentationAttribute;
+    using Malimbe.PropertySerializationAttribute;
+    using Zinnia.Data.Collection;
 
     /// <summary>
     /// Determines whether a <see cref="GameObject"/>'s <see cref="GameObject.tag"/> is part of a list.
@@ -12,13 +13,19 @@
         /// <summary>
         /// The tags to check against.
         /// </summary>
-        [DocumentedByXml]
-        public List<string> tags = new List<string>();
+        [Serialized]
+        [field: DocumentedByXml]
+        public StringObservableList Tags { get; set; }
 
         /// <inheritdoc />
         protected override bool Accepts(GameObject targetGameObject)
         {
-            foreach (string testedTag in tags)
+            if (Tags == null)
+            {
+                return false;
+            }
+
+            foreach (string testedTag in Tags.ReadOnlyElements)
             {
                 if (targetGameObject.CompareTag(testedTag))
                 {

--- a/Runtime/Rule/ListContainsRule.cs
+++ b/Runtime/Rule/ListContainsRule.cs
@@ -1,9 +1,10 @@
 ﻿namespace Zinnia.Rule
 {
     using UnityEngine;
-    using System.Collections.Generic;
     using Malimbe.XmlDocumentationAttribute;
     using Malimbe.BehaviourStateRequirementMethod;
+    using Malimbe.PropertySerializationAttribute;
+    using Zinnia.Data.Collection;
 
     /// <summary>
     /// Determines whether an object is part of a list.
@@ -13,15 +14,21 @@
         /// <summary>
         /// The objects to check against.
         /// </summary>
-        [DocumentedByXml]
-        public List<Object> objects = new List<Object>();
+        [Serialized]
+        [field: DocumentedByXml]
+        public UnityObjectObservableList Objects { get; set; }
 
         /// <inheritdoc />
         [RequiresBehaviourState]
         public virtual bool Accepts(object target)
         {
+            if (Objects == null)
+            {
+                return false;
+            }
+
             Object targetObject = target as Object;
-            return targetObject != null && objects.Contains(targetObject);
+            return targetObject != null && Objects.Contains(targetObject);
         }
     }
 }

--- a/Runtime/Rule/NegationRule.cs
+++ b/Runtime/Rule/NegationRule.cs
@@ -1,8 +1,9 @@
 ﻿namespace Zinnia.Rule
 {
     using UnityEngine;
-    using Malimbe.BehaviourStateRequirementMethod;
     using Malimbe.XmlDocumentationAttribute;
+    using Malimbe.PropertySerializationAttribute;
+    using Malimbe.BehaviourStateRequirementMethod;
     using Zinnia.Extension;
 
     /// <summary>
@@ -13,14 +14,15 @@
         /// <summary>
         /// The <see cref="IRule"/> to negate.
         /// </summary>
-        [DocumentedByXml]
-        public RuleContainer rule;
+        [Serialized]
+        [field: DocumentedByXml]
+        public RuleContainer Rule { get; set; }
 
         /// <inheritdoc />
         [RequiresBehaviourState]
         public bool Accepts(object target)
         {
-            return !rule.Accepts(target);
+            return !Rule.Accepts(target);
         }
     }
 }

--- a/Runtime/Rule/RulesMatcher.cs
+++ b/Runtime/Rule/RulesMatcher.cs
@@ -3,9 +3,9 @@
     using UnityEngine;
     using UnityEngine.Events;
     using System;
-    using System.Collections.Generic;
-    using Malimbe.BehaviourStateRequirementMethod;
     using Malimbe.XmlDocumentationAttribute;
+    using Malimbe.PropertySerializationAttribute;
+    using Malimbe.BehaviourStateRequirementMethod;
     using Zinnia.Extension;
 
     /// <summary>
@@ -22,8 +22,10 @@
             /// <summary>
             /// The rule to match against.
             /// </summary>
-            [DocumentedByXml]
-            public RuleContainer rule;
+            [Serialized]
+            [field: DocumentedByXml]
+            public RuleContainer Rule { get; set; }
+
             /// <summary>
             /// Emitted when the <see cref="rule"/> is valid.
             /// </summary>
@@ -34,8 +36,9 @@
         /// <summary>
         /// A collection of rules to potentially match against.
         /// </summary>
-        [DocumentedByXml]
-        public List<Element> elements = new List<Element>();
+        [Serialized]
+        [field: DocumentedByXml]
+        public RulesMatcherElementObservableList Elements { get; set; }
 
         /// <summary>
         /// Attempts to match the given object to the rules within the <see cref="elements"/> collection. If a match occurs then the appropriate event is emitted.
@@ -44,9 +47,14 @@
         [RequiresBehaviourState]
         public virtual void Match(object source)
         {
-            foreach (Element element in elements)
+            if (Elements == null)
             {
-                if (element.rule.Accepts(source))
+                return;
+            }
+
+            foreach (Element element in Elements.ReadOnlyElements)
+            {
+                if (element.Rule.Accepts(source))
                 {
                     element.Matched?.Invoke();
                 }

--- a/Runtime/Rule/RulesMatcherElementObservableList.cs
+++ b/Runtime/Rule/RulesMatcherElementObservableList.cs
@@ -1,0 +1,20 @@
+﻿namespace Zinnia.Rule
+{
+    using UnityEngine.Events;
+    using System;
+    using Zinnia.Data.Collection;
+
+    /// <summary>
+    /// Allows observing changes to a <see cref="List{T}"/> of <see cref="RulesMatcher.Element"/>s.
+    /// </summary>
+    public class RulesMatcherElementObservableList : DefaultObservableList<RulesMatcher.Element, RulesMatcherElementObservableList.UnityEvent>
+    {
+        /// <summary>
+        /// Defines the event with the <see cref="RulesMatcher.Element"/>.
+        /// </summary>
+        [Serializable]
+        public class UnityEvent : UnityEvent<RulesMatcher.Element>
+        {
+        }
+    }
+}

--- a/Runtime/Rule/RulesMatcherElementObservableList.cs.meta
+++ b/Runtime/Rule/RulesMatcherElementObservableList.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 170d7cd8ade42fc48b934dd3527bc7fc
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Utility/InterfaceContainer.cs
+++ b/Runtime/Utility/InterfaceContainer.cs
@@ -2,7 +2,6 @@
 {
     using UnityEngine;
     using Malimbe.MemberChangeMethod;
-    using Malimbe.PropertySerializationAttribute;
     using Malimbe.XmlDocumentationAttribute;
 
     /// <summary>
@@ -13,9 +12,16 @@
         /// <summary>
         /// The contained object.
         /// </summary>
-        [Serialized]
-        [field: DocumentedByXml]
-        protected Object Field { get; set; }
+        [SerializeField, DocumentedByXml]
+        protected Object field;
+        /// <summary>
+        /// The contained object.
+        /// </summary>
+        protected Object Field
+        {
+            get => field;
+            set => field = value;
+        }
 
         /// <summary>
         /// Called after <see cref="Field"/> has been changed.
@@ -64,7 +70,14 @@
         /// <inheritdoc />
         public void OnAfterDeserialize()
         {
-            OnAfterFieldChange();
+            if (Field is TInterface @interface)
+            {
+                _interface = @interface;
+            }
+            else
+            {
+                Field = null;
+            }
         }
 
         /// <inheritdoc />

--- a/Tests/Editor/Cast/ParabolicLineCastTest.cs
+++ b/Tests/Editor/Cast/ParabolicLineCastTest.cs
@@ -1,5 +1,6 @@
 ﻿using Zinnia.Cast;
 using Zinnia.Rule;
+using Zinnia.Data.Collection;
 
 namespace Test.Zinnia.Cast
 {
@@ -142,8 +143,11 @@ namespace Test.Zinnia.Cast
             validSurface.AddComponent<RuleStub>();
             NegationRule negationRule = validSurface.AddComponent<NegationRule>();
             AnyComponentTypeRule anyComponentTypeRule = validSurface.AddComponent<AnyComponentTypeRule>();
-            anyComponentTypeRule.componentTypes.Add(typeof(RuleStub));
-            negationRule.rule = new RuleContainer
+            SerializableTypeObservableList rules = containingObject.AddComponent<SerializableTypeObservableList>();
+            anyComponentTypeRule.ComponentTypes = rules;
+            rules.Add(typeof(RuleStub));
+
+            negationRule.Rule = new RuleContainer
             {
                 Interface = anyComponentTypeRule
             };

--- a/Tests/Editor/Cast/StraightLineCastTest.cs
+++ b/Tests/Editor/Cast/StraightLineCastTest.cs
@@ -1,5 +1,6 @@
 ﻿using Zinnia.Cast;
 using Zinnia.Rule;
+using Zinnia.Data.Collection;
 
 namespace Test.Zinnia.Cast
 {
@@ -88,8 +89,11 @@ namespace Test.Zinnia.Cast
             validSurface.AddComponent<RuleStub>();
             NegationRule negationRule = validSurface.AddComponent<NegationRule>();
             AnyComponentTypeRule anyComponentTypeRule = validSurface.AddComponent<AnyComponentTypeRule>();
-            anyComponentTypeRule.componentTypes.Add(typeof(RuleStub));
-            negationRule.rule = new RuleContainer
+            SerializableTypeObservableList rules = containingObject.AddComponent<SerializableTypeObservableList>();
+            anyComponentTypeRule.ComponentTypes = rules;
+            rules.Add(typeof(RuleStub));
+
+            negationRule.Rule = new RuleContainer
             {
                 Interface = anyComponentTypeRule
             };

--- a/Tests/Editor/Event/GameObjectEventProxyEmitterTest.cs
+++ b/Tests/Editor/Event/GameObjectEventProxyEmitterTest.cs
@@ -1,5 +1,6 @@
-﻿using Zinnia.Event;
-using Zinnia.Rule;
+﻿using Zinnia.Rule;
+using Zinnia.Event;
+using Zinnia.Data.Collection;
 
 namespace Test.Zinnia.Event
 {
@@ -50,7 +51,10 @@ namespace Test.Zinnia.Event
             GameObject digestInvalid = new GameObject();
 
             ListContainsRule rule = subject.gameObject.AddComponent<ListContainsRule>();
-            rule.objects.Add(digestValid);
+            UnityObjectObservableList objects = containingObject.AddComponent<UnityObjectObservableList>();
+            rule.Objects = objects;
+
+            objects.Add(digestValid);
             subject.receiveValidity = new RuleContainer
             {
                 Interface = rule

--- a/Tests/Editor/Rule/AllRuleTest.cs
+++ b/Tests/Editor/Rule/AllRuleTest.cs
@@ -1,5 +1,6 @@
 ﻿using Zinnia.Extension;
 using Zinnia.Rule;
+using Zinnia.Data.Collection;
 
 namespace Test.Zinnia.Rule
 {
@@ -31,21 +32,34 @@ namespace Test.Zinnia.Rule
         [Test]
         public void AcceptsMatch()
         {
-            subject.rules.Add(
+            RuleContainerObservableList rules = containingObject.AddComponent<RuleContainerObservableList>();
+            subject.Rules = rules;
+
+            rules.Add(
                 new RuleContainer
                 {
                     Interface = new TrueRuleStub()
                 });
-            subject.rules.Add(
+            rules.Add(
                 new RuleContainer
                 {
                     Interface = new TrueRuleStub()
                 });
+
             Assert.IsTrue(container.Accepts(containingObject));
         }
 
         [Test]
         public void RefusesEmpty()
+        {
+            RuleContainerObservableList rules = containingObject.AddComponent<RuleContainerObservableList>();
+            subject.Rules = rules;
+
+            Assert.IsFalse(container.Accepts(containingObject));
+        }
+
+        [Test]
+        public void RefusesNullRules()
         {
             Assert.IsFalse(container.Accepts(containingObject));
         }
@@ -53,50 +67,64 @@ namespace Test.Zinnia.Rule
         [Test]
         public void RefusesDifferent()
         {
-            subject.rules.Add(
+            RuleContainerObservableList rules = containingObject.AddComponent<RuleContainerObservableList>();
+            subject.Rules = rules;
+
+            rules.Add(
                 new RuleContainer
                 {
                     Interface = new TrueRuleStub()
                 });
-            subject.rules.Add(
+            rules.Add(
                 new RuleContainer
                 {
                     Interface = new FalseRuleStub()
                 });
+
             Assert.IsFalse(container.Accepts(containingObject));
         }
 
         [Test]
         public void RefusesInactiveGameObject()
         {
-            subject.rules.Add(
+            RuleContainerObservableList rules = containingObject.AddComponent<RuleContainerObservableList>();
+            subject.Rules = rules;
+
+            rules.Add(
                 new RuleContainer
                 {
                     Interface = new TrueRuleStub()
                 });
-            subject.rules.Add(
+            rules.Add(
                 new RuleContainer
                 {
                     Interface = new TrueRuleStub()
                 });
+
             subject.gameObject.SetActive(false);
+
             Assert.IsFalse(container.Accepts(containingObject));
         }
 
         [Test]
         public void RefusesInactiveComponent()
         {
-            subject.rules.Add(
+            RuleContainerObservableList rules = containingObject.AddComponent<RuleContainerObservableList>();
+            subject.Rules = rules;
+
+            rules.Add(
                 new RuleContainer
                 {
                     Interface = new TrueRuleStub()
                 });
-            subject.rules.Add(
+            rules.Add(
                 new RuleContainer
                 {
                     Interface = new TrueRuleStub()
                 });
+
             subject.enabled = false;
+
             Assert.IsFalse(container.Accepts(containingObject));
         }
     }

--- a/Tests/Editor/Rule/AnyComponentTypeRuleTest.cs
+++ b/Tests/Editor/Rule/AnyComponentTypeRuleTest.cs
@@ -1,5 +1,6 @@
-﻿using Zinnia.Extension;
-using Zinnia.Rule;
+﻿using Zinnia.Rule;
+using Zinnia.Extension;
+using Zinnia.Data.Collection;
 
 namespace Test.Zinnia.Rule
 {
@@ -32,13 +33,24 @@ namespace Test.Zinnia.Rule
         public void AcceptsMatch()
         {
             containingObject.AddComponent<TestScript>();
-            subject.componentTypes.Add(typeof(TestScript));
+            SerializableTypeObservableList componentTypes = containingObject.AddComponent<SerializableTypeObservableList>();
+            subject.ComponentTypes = componentTypes;
+            componentTypes.Add(typeof(TestScript));
 
             Assert.IsTrue(container.Accepts(containingObject));
         }
 
         [Test]
         public void RefusesEmpty()
+        {
+            SerializableTypeObservableList componentTypes = containingObject.AddComponent<SerializableTypeObservableList>();
+            subject.ComponentTypes = componentTypes;
+
+            Assert.IsFalse(container.Accepts(containingObject));
+        }
+
+        [Test]
+        public void RefusesNullComponentTypes()
         {
             Assert.IsFalse(container.Accepts(containingObject));
         }
@@ -47,7 +59,10 @@ namespace Test.Zinnia.Rule
         public void RefusesDifferent()
         {
             containingObject.AddComponent<Light>();
-            subject.componentTypes.Add(typeof(TestScript));
+            SerializableTypeObservableList componentTypes = containingObject.AddComponent<SerializableTypeObservableList>();
+            subject.ComponentTypes = componentTypes;
+            componentTypes.Add(typeof(TestScript));
+
             Assert.IsFalse(container.Accepts(containingObject));
         }
 
@@ -55,7 +70,9 @@ namespace Test.Zinnia.Rule
         public void RefusesInactiveGameObject()
         {
             containingObject.AddComponent<TestScript>();
-            subject.componentTypes.Add(typeof(TestScript));
+            SerializableTypeObservableList componentTypes = containingObject.AddComponent<SerializableTypeObservableList>();
+            subject.ComponentTypes = componentTypes;
+            componentTypes.Add(typeof(TestScript));
 
             subject.gameObject.SetActive(false);
             Assert.IsFalse(container.Accepts(containingObject));
@@ -65,7 +82,9 @@ namespace Test.Zinnia.Rule
         public void RefusesInactiveComponent()
         {
             containingObject.AddComponent<TestScript>();
-            subject.componentTypes.Add(typeof(TestScript));
+            SerializableTypeObservableList componentTypes = containingObject.AddComponent<SerializableTypeObservableList>();
+            subject.ComponentTypes = componentTypes;
+            componentTypes.Add(typeof(TestScript));
 
             subject.enabled = false;
             Assert.IsFalse(container.Accepts(containingObject));

--- a/Tests/Editor/Rule/AnyLayerRuleTest.cs
+++ b/Tests/Editor/Rule/AnyLayerRuleTest.cs
@@ -33,7 +33,7 @@ namespace Test.Zinnia.Rule
         [Test]
         public void AcceptsMatch()
         {
-            subject.layerMask = LayerMask.NameToLayer("UI");
+            subject.LayerMask = LayerMask.NameToLayer("UI");
             Assert.IsTrue(container.Accepts(containingObject));
         }
 
@@ -46,14 +46,14 @@ namespace Test.Zinnia.Rule
         [Test]
         public void RefusesDifferent()
         {
-            subject.layerMask = LayerMask.NameToLayer("Ignore Raycast");
+            subject.LayerMask = LayerMask.NameToLayer("Ignore Raycast");
             Assert.IsFalse(container.Accepts(containingObject));
         }
 
         [Test]
         public void RefusesInactiveGameObject()
         {
-            subject.layerMask = LayerMask.NameToLayer("UI");
+            subject.LayerMask = LayerMask.NameToLayer("UI");
             subject.gameObject.SetActive(false);
             Assert.IsFalse(container.Accepts(containingObject));
         }
@@ -61,7 +61,7 @@ namespace Test.Zinnia.Rule
         [Test]
         public void RefusesInactiveComponent()
         {
-            subject.layerMask = LayerMask.NameToLayer("UI");
+            subject.LayerMask = LayerMask.NameToLayer("UI");
             subject.enabled = false;
             Assert.IsFalse(container.Accepts(containingObject));
         }

--- a/Tests/Editor/Rule/AnyRuleTest.cs
+++ b/Tests/Editor/Rule/AnyRuleTest.cs
@@ -1,5 +1,6 @@
-﻿using Zinnia.Extension;
-using Zinnia.Rule;
+﻿using Zinnia.Rule;
+using Zinnia.Extension;
+using Zinnia.Data.Collection;
 
 namespace Test.Zinnia.Rule
 {
@@ -31,21 +32,34 @@ namespace Test.Zinnia.Rule
         [Test]
         public void AcceptsMatch()
         {
-            subject.rules.Add(
+            RuleContainerObservableList rules = containingObject.AddComponent<RuleContainerObservableList>();
+            subject.Rules = rules;
+
+            rules.Add(
                 new RuleContainer
                 {
                     Interface = new TrueRuleStub()
                 });
-            subject.rules.Add(
+            rules.Add(
                 new RuleContainer
                 {
                     Interface = new FalseRuleStub()
                 });
+
             Assert.IsTrue(container.Accepts(containingObject));
         }
 
         [Test]
         public void RefusesEmpty()
+        {
+            RuleContainerObservableList rules = containingObject.AddComponent<RuleContainerObservableList>();
+            subject.Rules = rules;
+
+            Assert.IsFalse(container.Accepts(containingObject));
+        }
+
+        [Test]
+        public void RefusesNullRules()
         {
             Assert.IsFalse(container.Accepts(containingObject));
         }
@@ -53,50 +67,64 @@ namespace Test.Zinnia.Rule
         [Test]
         public void RefusesNonEmpty()
         {
-            subject.rules.Add(
+            RuleContainerObservableList rules = containingObject.AddComponent<RuleContainerObservableList>();
+            subject.Rules = rules;
+
+            rules.Add(
                 new RuleContainer
                 {
                     Interface = new FalseRuleStub()
                 });
-            subject.rules.Add(
+            rules.Add(
                 new RuleContainer
                 {
                     Interface = new FalseRuleStub()
                 });
+
             Assert.IsFalse(container.Accepts(containingObject));
         }
 
         [Test]
         public void RefusesInactiveGameObject()
         {
-            subject.rules.Add(
+            RuleContainerObservableList rules = containingObject.AddComponent<RuleContainerObservableList>();
+            subject.Rules = rules;
+
+            rules.Add(
                 new RuleContainer
                 {
                     Interface = new TrueRuleStub()
                 });
-            subject.rules.Add(
+            rules.Add(
                 new RuleContainer
                 {
                     Interface = new FalseRuleStub()
                 });
+
             subject.gameObject.SetActive(false);
+
             Assert.IsFalse(container.Accepts(containingObject));
         }
 
         [Test]
         public void RefusesInactiveComponent()
         {
-            subject.rules.Add(
+            RuleContainerObservableList rules = containingObject.AddComponent<RuleContainerObservableList>();
+            subject.Rules = rules;
+
+            rules.Add(
                 new RuleContainer
                 {
                     Interface = new TrueRuleStub()
                 });
-            subject.rules.Add(
+            rules.Add(
                 new RuleContainer
                 {
                     Interface = new FalseRuleStub()
                 });
+
             subject.enabled = false;
+
             Assert.IsFalse(container.Accepts(containingObject));
         }
     }

--- a/Tests/Editor/Rule/AnyTagRuleTest.cs
+++ b/Tests/Editor/Rule/AnyTagRuleTest.cs
@@ -1,6 +1,7 @@
-﻿using Zinnia.Extension;
-using Zinnia.Rule;
+﻿using Zinnia.Rule;
 using Zinnia.Utility;
+using Zinnia.Extension;
+using Zinnia.Data.Collection;
 
 namespace Test.Zinnia.Rule
 {
@@ -57,12 +58,24 @@ namespace Test.Zinnia.Rule
         [Test]
         public void AcceptsMatch()
         {
-            subject.tags.Add(validTag);
+            StringObservableList tags = containingObject.AddComponent<StringObservableList>();
+            subject.Tags = tags;
+            tags.Add(validTag);
+
             Assert.IsTrue(container.Accepts(containingObject));
         }
 
         [Test]
         public void RefusesEmpty()
+        {
+            StringObservableList tags = containingObject.AddComponent<StringObservableList>();
+            subject.Tags = tags;
+
+            Assert.IsFalse(container.Accepts(containingObject));
+        }
+
+        [Test]
+        public void RefusesNullTags()
         {
             Assert.IsFalse(container.Accepts(containingObject));
         }
@@ -70,7 +83,10 @@ namespace Test.Zinnia.Rule
         [Test]
         public void RefusesDifferent()
         {
-            subject.tags.Add(invalidTag);
+            StringObservableList tags = containingObject.AddComponent<StringObservableList>();
+            subject.Tags = tags;
+            tags.Add(invalidTag);
+
             Assert.IsFalse(container.Accepts(containingObject));
         }
     }

--- a/Tests/Editor/Rule/ListContainsRuleTest.cs
+++ b/Tests/Editor/Rule/ListContainsRuleTest.cs
@@ -1,5 +1,6 @@
-﻿using Zinnia.Extension;
-using Zinnia.Rule;
+﻿using Zinnia.Rule;
+using Zinnia.Extension;
+using Zinnia.Data.Collection;
 
 namespace Test.Zinnia.Rule
 {
@@ -30,12 +31,24 @@ namespace Test.Zinnia.Rule
         [Test]
         public void AcceptsMatch()
         {
-            subject.objects.Add(containingObject);
+            UnityObjectObservableList objects = containingObject.AddComponent<UnityObjectObservableList>();
+            subject.Objects = objects;
+            objects.Add(containingObject);
+
             Assert.IsTrue(container.Accepts(containingObject));
         }
 
         [Test]
         public void RefusesEmpty()
+        {
+            UnityObjectObservableList objects = containingObject.AddComponent<UnityObjectObservableList>();
+            subject.Objects = objects;
+
+            Assert.IsFalse(container.Accepts(containingObject));
+        }
+
+        [Test]
+        public void RefusesNullObjects()
         {
             Assert.IsFalse(container.Accepts(containingObject));
         }
@@ -44,7 +57,10 @@ namespace Test.Zinnia.Rule
         public void RefusesDifferent()
         {
             GameObject wrongGameObject = new GameObject();
-            subject.objects.Add(wrongGameObject);
+            UnityObjectObservableList objects = containingObject.AddComponent<UnityObjectObservableList>();
+            subject.Objects = objects;
+            objects.Add(wrongGameObject);
+
             Assert.IsFalse(container.Accepts(containingObject));
 
             Object.DestroyImmediate(wrongGameObject);
@@ -53,7 +69,10 @@ namespace Test.Zinnia.Rule
         [Test]
         public void RefusesInactiveGameObject()
         {
-            subject.objects.Add(containingObject);
+            UnityObjectObservableList objects = containingObject.AddComponent<UnityObjectObservableList>();
+            subject.Objects = objects;
+            objects.Add(containingObject);
+
             subject.gameObject.SetActive(false);
             Assert.IsFalse(container.Accepts(containingObject));
         }
@@ -61,7 +80,10 @@ namespace Test.Zinnia.Rule
         [Test]
         public void RefusesInactiveComponent()
         {
-            subject.objects.Add(containingObject);
+            UnityObjectObservableList objects = containingObject.AddComponent<UnityObjectObservableList>();
+            subject.Objects = objects;
+            objects.Add(containingObject);
+
             subject.enabled = false;
             Assert.IsFalse(container.Accepts(containingObject));
         }

--- a/Tests/Editor/Rule/NegationRuleTest.cs
+++ b/Tests/Editor/Rule/NegationRuleTest.cs
@@ -31,7 +31,7 @@ namespace Test.Zinnia.Rule
         [Test]
         public void AcceptsFalse()
         {
-            subject.rule = new RuleContainer
+            subject.Rule = new RuleContainer
             {
                 Interface = new FalseRuleStub()
             };
@@ -47,7 +47,7 @@ namespace Test.Zinnia.Rule
         [Test]
         public void RefusesTrue()
         {
-            subject.rule = new RuleContainer
+            subject.Rule = new RuleContainer
             {
                 Interface = new TrueRuleStub()
             };
@@ -57,7 +57,7 @@ namespace Test.Zinnia.Rule
         [Test]
         public void RefusesInactiveGameObject()
         {
-            subject.rule = new RuleContainer
+            subject.Rule = new RuleContainer
             {
                 Interface = new FalseRuleStub()
             };
@@ -68,7 +68,7 @@ namespace Test.Zinnia.Rule
         [Test]
         public void RefusesInactiveComponent()
         {
-            subject.rule = new RuleContainer
+            subject.Rule = new RuleContainer
             {
                 Interface = new FalseRuleStub()
             };

--- a/Tests/Editor/Rule/RulesMatcherTest.cs
+++ b/Tests/Editor/Rule/RulesMatcherTest.cs
@@ -1,4 +1,5 @@
 ﻿using Zinnia.Rule;
+using Zinnia.Data.Collection;
 
 namespace Test.Zinnia.Rule
 {
@@ -32,14 +33,16 @@ namespace Test.Zinnia.Rule
             UnityEventListenerMock ruleOneMatched = new UnityEventListenerMock();
             UnityEventListenerMock ruleTwoMatched = new UnityEventListenerMock();
 
-            RulesMatcher.Element elementOne = new RulesMatcher.Element() { rule = CreateRule(objectOne) };
-            RulesMatcher.Element elementTwo = new RulesMatcher.Element() { rule = CreateRule(objectTwo) };
+            RulesMatcher.Element elementOne = new RulesMatcher.Element() { Rule = CreateRule(objectOne) };
+            RulesMatcher.Element elementTwo = new RulesMatcher.Element() { Rule = CreateRule(objectTwo) };
 
             elementOne.Matched.AddListener(ruleOneMatched.Listen);
             elementTwo.Matched.AddListener(ruleTwoMatched.Listen);
 
-            subject.elements.Add(elementOne);
-            subject.elements.Add(elementTwo);
+            RulesMatcherElementObservableList elements = containingObject.AddComponent<RulesMatcherElementObservableList>();
+            subject.Elements = elements;
+            elements.Add(elementOne);
+            elements.Add(elementTwo);
 
             Assert.IsFalse(ruleOneMatched.Received);
             Assert.IsFalse(ruleTwoMatched.Received);
@@ -70,17 +73,19 @@ namespace Test.Zinnia.Rule
             UnityEventListenerMock ruleTwoMatched = new UnityEventListenerMock();
             UnityEventListenerMock ruleThreeMatched = new UnityEventListenerMock();
 
-            RulesMatcher.Element elementOne = new RulesMatcher.Element() { rule = CreateRule(objectOne) };
-            RulesMatcher.Element elementTwo = new RulesMatcher.Element() { rule = CreateRule(objectTwo) };
-            RulesMatcher.Element elementThree = new RulesMatcher.Element() { rule = CreateRule(objectOne) };
+            RulesMatcher.Element elementOne = new RulesMatcher.Element() { Rule = CreateRule(objectOne) };
+            RulesMatcher.Element elementTwo = new RulesMatcher.Element() { Rule = CreateRule(objectTwo) };
+            RulesMatcher.Element elementThree = new RulesMatcher.Element() { Rule = CreateRule(objectOne) };
 
             elementOne.Matched.AddListener(ruleOneMatched.Listen);
             elementTwo.Matched.AddListener(ruleTwoMatched.Listen);
             elementThree.Matched.AddListener(ruleThreeMatched.Listen);
 
-            subject.elements.Add(elementOne);
-            subject.elements.Add(elementTwo);
-            subject.elements.Add(elementThree);
+            RulesMatcherElementObservableList elements = containingObject.AddComponent<RulesMatcherElementObservableList>();
+            subject.Elements = elements;
+            elements.Add(elementOne);
+            elements.Add(elementTwo);
+            elements.Add(elementThree);
 
             Assert.IsFalse(ruleOneMatched.Received);
             Assert.IsFalse(ruleTwoMatched.Received);
@@ -104,14 +109,16 @@ namespace Test.Zinnia.Rule
             UnityEventListenerMock ruleOneMatched = new UnityEventListenerMock();
             UnityEventListenerMock ruleTwoMatched = new UnityEventListenerMock();
 
-            RulesMatcher.Element elementOne = new RulesMatcher.Element() { rule = CreateRule(objectOne) };
-            RulesMatcher.Element elementTwo = new RulesMatcher.Element() { rule = CreateRule(objectTwo) };
+            RulesMatcher.Element elementOne = new RulesMatcher.Element() { Rule = CreateRule(objectOne) };
+            RulesMatcher.Element elementTwo = new RulesMatcher.Element() { Rule = CreateRule(objectTwo) };
 
             elementOne.Matched.AddListener(ruleOneMatched.Listen);
             elementTwo.Matched.AddListener(ruleTwoMatched.Listen);
 
-            subject.elements.Add(elementOne);
-            subject.elements.Add(elementTwo);
+            RulesMatcherElementObservableList elements = containingObject.AddComponent<RulesMatcherElementObservableList>();
+            subject.Elements = elements;
+            elements.Add(elementOne);
+            elements.Add(elementTwo);
 
             subject.gameObject.SetActive(false);
 
@@ -135,14 +142,16 @@ namespace Test.Zinnia.Rule
             UnityEventListenerMock ruleOneMatched = new UnityEventListenerMock();
             UnityEventListenerMock ruleTwoMatched = new UnityEventListenerMock();
 
-            RulesMatcher.Element elementOne = new RulesMatcher.Element() { rule = CreateRule(objectOne) };
-            RulesMatcher.Element elementTwo = new RulesMatcher.Element() { rule = CreateRule(objectTwo) };
+            RulesMatcher.Element elementOne = new RulesMatcher.Element() { Rule = CreateRule(objectOne) };
+            RulesMatcher.Element elementTwo = new RulesMatcher.Element() { Rule = CreateRule(objectTwo) };
 
             elementOne.Matched.AddListener(ruleOneMatched.Listen);
             elementTwo.Matched.AddListener(ruleTwoMatched.Listen);
 
-            subject.elements.Add(elementOne);
-            subject.elements.Add(elementTwo);
+            RulesMatcherElementObservableList elements = containingObject.AddComponent<RulesMatcherElementObservableList>();
+            subject.Elements = elements;
+            elements.Add(elementOne);
+            elements.Add(elementTwo);
 
             subject.enabled = false;
 
@@ -162,7 +171,9 @@ namespace Test.Zinnia.Rule
         {
             RuleContainer container = new RuleContainer();
             ListContainsRule rule = containingObject.AddComponent<ListContainsRule>();
-            rule.objects.Add(element);
+            UnityObjectObservableList objects = containingObject.AddComponent<UnityObjectObservableList>();
+            rule.Objects = objects;
+            objects.Add(element);
             container.Interface = rule;
             return container;
         }

--- a/Tests/Editor/Tracking/Collision/Active/ActiveCollisionConsumerTest.cs
+++ b/Tests/Editor/Tracking/Collision/Active/ActiveCollisionConsumerTest.cs
@@ -1,5 +1,6 @@
-﻿using Zinnia.Tracking.Collision.Active;
-using Zinnia.Rule;
+﻿using Zinnia.Rule;
+using Zinnia.Data.Collection;
+using Zinnia.Tracking.Collision.Active;
 
 namespace Test.Zinnia.Tracking.Collision.Active
 {
@@ -71,8 +72,11 @@ namespace Test.Zinnia.Tracking.Collision.Active
             publisherObject.AddComponent<RuleStub>();
             NegationRule negationRule = containingObject.AddComponent<NegationRule>();
             AnyComponentTypeRule anyComponentTypeRule = containingObject.AddComponent<AnyComponentTypeRule>();
-            anyComponentTypeRule.componentTypes.Add(typeof(RuleStub));
-            negationRule.rule = new RuleContainer
+            SerializableTypeObservableList rules = containingObject.AddComponent<SerializableTypeObservableList>();
+            anyComponentTypeRule.ComponentTypes = rules;
+            rules.Add(typeof(RuleStub));
+
+            negationRule.Rule = new RuleContainer
             {
                 Interface = anyComponentTypeRule
             };

--- a/Tests/Editor/Tracking/Collision/Active/ActiveCollisionsContainerTest.cs
+++ b/Tests/Editor/Tracking/Collision/Active/ActiveCollisionsContainerTest.cs
@@ -1,4 +1,5 @@
 ﻿using Zinnia.Rule;
+using Zinnia.Data.Collection;
 using Zinnia.Tracking.Collision;
 using Zinnia.Tracking.Collision.Active;
 
@@ -99,8 +100,11 @@ namespace Test.Zinnia.Tracking.Collision.Active
             oneContainer.AddComponent<RuleStub>();
             NegationRule negationRule = oneContainer.AddComponent<NegationRule>();
             AnyComponentTypeRule anyComponentTypeRule = oneContainer.AddComponent<AnyComponentTypeRule>();
-            anyComponentTypeRule.componentTypes.Add(typeof(RuleStub));
-            negationRule.rule = new RuleContainer
+            SerializableTypeObservableList rules = containingObject.AddComponent<SerializableTypeObservableList>();
+            anyComponentTypeRule.ComponentTypes = rules;
+            rules.Add(typeof(RuleStub));
+
+            negationRule.Rule = new RuleContainer
             {
                 Interface = anyComponentTypeRule
             };

--- a/Tests/Editor/Tracking/SurfaceLocatorTest.cs
+++ b/Tests/Editor/Tracking/SurfaceLocatorTest.cs
@@ -1,5 +1,6 @@
 ﻿using Zinnia.Rule;
 using Zinnia.Tracking;
+using Zinnia.Data.Collection;
 
 namespace Test.Zinnia.Tracking
 {
@@ -81,8 +82,11 @@ namespace Test.Zinnia.Tracking
             validSurface.AddComponent<RuleStub>();
             NegationRule negationRule = validSurface.AddComponent<NegationRule>();
             AnyComponentTypeRule anyComponentTypeRule = validSurface.AddComponent<AnyComponentTypeRule>();
-            anyComponentTypeRule.componentTypes.Add(typeof(RuleStub));
-            negationRule.rule = new RuleContainer
+            SerializableTypeObservableList rules = containingObject.AddComponent<SerializableTypeObservableList>();
+            anyComponentTypeRule.ComponentTypes = rules;
+            rules.Add(typeof(RuleStub));
+
+            negationRule.Rule = new RuleContainer
             {
                 Interface = anyComponentTypeRule
             };


### PR DESCRIPTION
All usages of fields have now been switched to properties that are
serialized with Malimbe to create an appropriate backing field to
display in the Unity Inspector.

All uses of List collections have also been replaced with concrete
versions of the ObservableList, which makes it possible to track
changes occurring to the lists at runtime and provides a single
component that allows mutating the list via UnityEvents.