### PR TITLE
feat(Haptics):  update fields to properties and lists to observable

### DIFF
--- a/Runtime/Haptics/AudioClipHapticPulser.cs
+++ b/Runtime/Haptics/AudioClipHapticPulser.cs
@@ -3,34 +3,38 @@
     using UnityEngine;
     using System.Collections;
     using Malimbe.XmlDocumentationAttribute;
+    using Malimbe.PropertySerializationAttribute;
 
     /// <summary>
-    /// Creates a haptic pattern based on the waveform of an <see cref="UnityEngine.AudioClip"/> and utilizes a <see cref="HapticPulser"/> to create the effect.
+    /// Creates a haptic pattern based on the waveform of an <see cref="UnityEngine.AudioClip"/> and utilizes a <see cref="Haptics.HapticPulser"/> to create the effect.
     /// </summary>
     public class AudioClipHapticPulser : HapticProcess
     {
         /// <summary>
         /// The pulse process to utilize.
         /// </summary>
-        [DocumentedByXml]
-        public HapticPulser hapticPulser;
+        [Serialized]
+        [field: DocumentedByXml]
+        public HapticPulser HapticPulser { get; set; }
         /// <summary>
         /// The waveform to represent the haptic pattern.
         /// </summary>
-        [DocumentedByXml]
-        public AudioClip audioClip;
+        [Serialized]
+        [field: DocumentedByXml]
+        public AudioClip AudioClip { get; set; }
         /// <summary>
         /// Multiplies the current audio peak to affect the wave intensity.
         /// </summary>
-        [DocumentedByXml]
-        public float intensityMultiplier = 1f;
+        [Serialized]
+        [field: DocumentedByXml]
+        public float IntensityMultiplier { get; set; } = 1f;
 
         /// <summary>
         /// A reference to the started routine.
         /// </summary>
         protected Coroutine hapticRoutine;
         /// <summary>
-        /// The original intensity of the provided <see cref="HapticPulser"/> to reset back to after the process is complete.
+        /// The original intensity of <see cref="HapticPulser"/> to reset back to after the process is complete.
         /// </summary>
         protected float cachedIntensity;
         /// <summary>
@@ -41,13 +45,13 @@
         /// <inheritdoc />
         public override bool IsActive()
         {
-            return (base.IsActive() && hapticPulser != null && audioClip != null && hapticPulser.IsActive());
+            return base.IsActive() && HapticPulser != null && AudioClip != null && HapticPulser.IsActive();
         }
 
         /// <inheritdoc />
         protected override void DoBegin()
         {
-            cachedIntensity = hapticPulser.Intensity;
+            cachedIntensity = HapticPulser.Intensity;
             hapticRoutine = StartCoroutine(HapticProcessRoutine());
         }
 
@@ -61,7 +65,7 @@
 
             StopCoroutine(hapticRoutine);
             hapticRoutine = null;
-            hapticPulser.Cancel();
+            HapticPulser.Cancel();
             ResetIntensity();
         }
 
@@ -70,11 +74,11 @@
         /// </summary>
         protected virtual void ResetIntensity()
         {
-            hapticPulser.Intensity = cachedIntensity;
+            HapticPulser.Intensity = cachedIntensity;
         }
 
         /// <summary>
-        /// Enumerates through the given <see cref="AudioClip"/> and pulses for each amplitude of the wave.
+        /// Enumerates through <see cref="AudioClip"/> and pulses for each amplitude of the wave.
         /// </summary>
         /// <returns>An Enumerator to manage the running of the Coroutine.</returns>
         protected virtual IEnumerator HapticProcessRoutine()
@@ -82,21 +86,21 @@
             float[] audioData = new float[BufferSize];
             int sampleOffset = -BufferSize;
             float startTime = Time.time;
-            float length = audioClip.length;
+            float length = AudioClip.length;
             float endTime = startTime + length;
-            float sampleRate = audioClip.samples;
+            float sampleRate = AudioClip.samples;
             while (Time.time <= endTime)
             {
                 float lerpVal = (Time.time - startTime) / length;
                 int sampleIndex = (int)(sampleRate * lerpVal);
                 if (sampleIndex >= sampleOffset + BufferSize)
                 {
-                    audioClip.GetData(audioData, sampleIndex);
+                    AudioClip.GetData(audioData, sampleIndex);
                     sampleOffset = sampleIndex;
                 }
                 float currentSample = Mathf.Abs(audioData[sampleIndex - sampleOffset]);
-                hapticPulser.Intensity = currentSample * intensityMultiplier;
-                hapticPulser.Begin();
+                HapticPulser.Intensity = currentSample * IntensityMultiplier;
+                HapticPulser.Begin();
                 yield return null;
             }
             ResetIntensity();

--- a/Runtime/Haptics/Collection.meta
+++ b/Runtime/Haptics/Collection.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b1a22a1fa89765849b3842fa85b1df79
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Haptics/Collection/HapticProcessObservableList.cs
+++ b/Runtime/Haptics/Collection/HapticProcessObservableList.cs
@@ -1,0 +1,21 @@
+﻿namespace Zinnia.Haptics.Collection
+{
+    using UnityEngine.Events;
+    using System;
+    using System.Collections.Generic;
+    using Zinnia.Data.Collection;
+
+    /// <summary>
+    /// Allows observing changes to a <see cref="List{T}"/> of <see cref="HapticProcess"/>s.
+    /// </summary>
+    public class HapticProcessObservableList : DefaultObservableList<HapticProcess, HapticProcessObservableList.UnityEvent>
+    {
+        /// <summary>
+        /// Defines the event with the <see cref="HapticProcess"/>.
+        /// </summary>
+        [Serializable]
+        public class UnityEvent : UnityEvent<HapticProcess>
+        {
+        }
+    }
+}

--- a/Runtime/Haptics/Collection/HapticProcessObservableList.cs.meta
+++ b/Runtime/Haptics/Collection/HapticProcessObservableList.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0dea9bd4fa4b5cc4b9b36a77382cb3b5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Haptics/HapticProcessor.cs
+++ b/Runtime/Haptics/HapticProcessor.cs
@@ -1,7 +1,8 @@
 ﻿namespace Zinnia.Haptics
 {
-    using System.Collections.Generic;
     using Malimbe.XmlDocumentationAttribute;
+    using Malimbe.PropertySerializationAttribute;
+    using Zinnia.Haptics.Collection;
 
     /// <summary>
     /// A proxy for managing the first active <see cref="HapticProcess"/> that is provided in the collection.
@@ -11,8 +12,9 @@
         /// <summary>
         /// Process the first active <see cref="HapticProcess"/> found in the collection.
         /// </summary>
-        [DocumentedByXml]
-        public List<HapticProcess> hapticProcesses = new List<HapticProcess>();
+        [Serialized]
+        [field: DocumentedByXml]
+        public HapticProcessObservableList HapticProcesses { get; set; }
 
         private HapticProcess _activeHapticProcess;
         /// <summary>
@@ -33,7 +35,7 @@
         protected override void DoBegin()
         {
             HapticProcess firstActiveProcess = null;
-            foreach (HapticProcess process in hapticProcesses)
+            foreach (HapticProcess process in HapticProcesses.ReadOnlyElements)
             {
                 if (process.IsActive())
                 {

--- a/Runtime/Haptics/HapticPulser.cs
+++ b/Runtime/Haptics/HapticPulser.cs
@@ -1,10 +1,9 @@
 ﻿namespace Zinnia.Haptics
 {
-    using Malimbe.PropertySerializationAttribute;
-    /*using Malimbe.PropertySetterMethod;*/
-    /*using Malimbe.PropertyValidationMethod;*/
-    using Malimbe.XmlDocumentationAttribute;
     using UnityEngine;
+    using Malimbe.XmlDocumentationAttribute;
+    using Malimbe.PropertySerializationAttribute;
+    using Malimbe.MemberChangeMethod;
 
     /// <summary>
     /// Creates a single pulse on a haptic device for a given intensity.
@@ -14,19 +13,20 @@
         /// <summary>
         /// The intensity of the haptic rumble.
         /// </summary>
-        [Serialized, /*Validated*/]
-        [field: Range(0f, 1f), DocumentedByXml]
+        [Serialized]
+        [field: DocumentedByXml, Range(0f, 1f)]
         public float Intensity { get; set; } = 1f;
 
         /// <summary>
-        /// Handles changes to <see cref="Intensity"/>.
+        /// Called after <see cref="Intensity"/> has been changed.
         /// </summary>
-        /// <param name="previousValue">The previous value.</param>
-        /// <param name="newValue">The new value.</param>
-        /*[CalledBySetter(nameof(Intensity))]*/
-        protected virtual void OnIntensityChange(float previousValue, ref float newValue)
+        [CalledAfterChangeOf(nameof(Intensity))]
+        protected virtual void OnAfterIntensityChange()
         {
-            newValue = Mathf.Clamp01(newValue);
+            if (Intensity < 0f || Intensity > 1f)
+            {
+                Intensity = Mathf.Clamp01(Intensity);
+            }
         }
     }
 }

--- a/Runtime/Haptics/TimedHapticProcess.cs
+++ b/Runtime/Haptics/TimedHapticProcess.cs
@@ -2,32 +2,33 @@
 {
     using UnityEngine;
     using System.Collections;
-    using Malimbe.PropertySerializationAttribute;
-    /*using Malimbe.PropertyValidationMethod;*/
+    using Malimbe.MemberClearanceMethod;
     using Malimbe.XmlDocumentationAttribute;
+    using Malimbe.PropertySerializationAttribute;
 
     /// <summary>
-    /// Processes a given <see cref="HapticProcess"/> repeatedly for a given duration and with a pause interval between each process.
+    /// Processes a given <see cref="Haptics.HapticProcess"/> repeatedly for a given duration and with a pause interval between each process.
     /// </summary>
     public class TimedHapticProcess : HapticProcess
     {
         /// <summary>
         /// The process to utilize.
         /// </summary>
-        [DocumentedByXml]
-        public HapticProcess hapticProcess;
+        [Serialized]
+        [field: DocumentedByXml]
+        public HapticProcess HapticProcess { get; set; }
 
         /// <summary>
         /// The amount of time to keep repeating the process for.
         /// </summary>
-        [Serialized, /*Validated*/]
+        [Serialized]
         [field: DocumentedByXml]
         public float Duration { get; set; } = 1f;
 
         /// <summary>
         /// The amount of time to pause after each process iteration.
         /// </summary>
-        [Serialized, /*Validated*/]
+        [Serialized]
         [field: DocumentedByXml]
         public float Interval { get; set; } = 0.1f;
 
@@ -39,7 +40,7 @@
         /// <inheritdoc />
         public override bool IsActive()
         {
-            return (base.IsActive() && hapticProcess != null && hapticProcess.IsActive());
+            return base.IsActive() && HapticProcess != null && HapticProcess.IsActive();
         }
 
         /// <summary>
@@ -62,11 +63,11 @@
 
             StopCoroutine(hapticRoutine);
             hapticRoutine = null;
-            hapticProcess.Cancel();
+            HapticProcess.Cancel();
         }
 
         /// <summary>
-        /// Enumerates for the specified duration calling the given <see cref="hapticProcess"/> with a specified interval delay between each call.
+        /// Enumerates for the specified duration calling <see cref="HapticProcess"/> with a specified interval delay between each call.
         /// </summary>
         /// <returns>An Enumerator to manage the running of the Coroutine.</returns>
         protected virtual IEnumerator HapticProcessRoutine()
@@ -81,7 +82,7 @@
 
             while (currentDuration > 0)
             {
-                hapticProcess.Begin();
+                HapticProcess.Begin();
                 yield return delay;
                 currentDuration -= Interval;
             }

--- a/Runtime/Haptics/XRNodeHapticPulser.cs
+++ b/Runtime/Haptics/XRNodeHapticPulser.cs
@@ -1,7 +1,8 @@
 ﻿namespace Zinnia.Haptics
 {
-    using Malimbe.XmlDocumentationAttribute;
     using UnityEngine.XR;
+    using Malimbe.XmlDocumentationAttribute;
+    using Malimbe.PropertySerializationAttribute;
 
     /// <summary>
     /// Creates a timed haptic pulse on an <see cref="XRNode"/>.
@@ -11,23 +12,25 @@
         /// <summary>
         /// The node to pulse.
         /// </summary>
-        [DocumentedByXml]
-        public XRNode node = XRNode.LeftHand;
+        [Serialized]
+        [field: DocumentedByXml]
+        public XRNode Node { get; set; } = XRNode.LeftHand;
         /// <summary>
-        /// The duration to pulse <see cref="node"/> for.
+        /// The duration to pulse <see cref="Node"/> for.
         /// </summary>
-        [DocumentedByXml]
-        public float duration = 0.005f;
+        [Serialized]
+        [field: DocumentedByXml]
+        public float Duration { get; set; } = 0.005f;
 
         /// <summary>
-        /// The haptic capabilities of <see cref="node"/>.
+        /// The haptic capabilities of <see cref="Node"/>.
         /// </summary>
         protected HapticCapabilities nodeHapticCapabilities;
 
         /// <inheritdoc />
         protected override void DoBegin()
         {
-            Pulse(Intensity, duration);
+            Pulse(Intensity, Duration);
         }
 
         /// <inheritdoc />
@@ -37,13 +40,13 @@
         }
 
         /// <summary>
-        /// Sends a pulse to <see cref="node"/>.
+        /// Sends a pulse to <see cref="Node"/>.
         /// </summary>
         /// <param name="intensity">The intensity to pulse with.</param>
         /// <param name="duration">The duration to pulse for.</param>
         protected virtual void Pulse(float intensity, float duration)
         {
-            InputDevice device = InputDevices.GetDeviceAtXRNode(node);
+            InputDevice device = InputDevices.GetDeviceAtXRNode(Node);
             if (!device.TryGetHapticCapabilities(out nodeHapticCapabilities))
             {
                 return;


### PR DESCRIPTION
All usages of fields have now been switched to properties that are
serialized with Malimbe to create an appropriate backing field to
display in the Unity Inspector.

All uses of List collections have also been replaced with concrete
versions of the ObservableList, which makes it possible to track
changes occurring to the lists at runtime and provides a single
component that allows mutating the list via UnityEvents.