### PR TITLE
fix(tests): ensure created objects are destroyed within the test

### DIFF
--- a/Tests/Editor/Data/Collection/GameObjectObservableListTest.cs
+++ b/Tests/Editor/Data/Collection/GameObjectObservableListTest.cs
@@ -21,7 +21,6 @@ namespace Test.Zinnia.Data.Collection
         [TearDown]
         public void TearDown()
         {
-            Object.DestroyImmediate(subject);
             Object.DestroyImmediate(containingObject);
         }
 
@@ -678,6 +677,9 @@ namespace Test.Zinnia.Data.Collection
             Assert.IsTrue(elementAddedMock.Received);
             Assert.IsFalse(elementRemovedMock.Received);
             Assert.IsFalse(becameEmptyMock.Received);
+
+            Object.DestroyImmediate(elementOne);
+            Object.DestroyImmediate(elementTwo);
         }
 
         private sealed class GameObjectObservableListMock : GameObjectObservableList

--- a/Tests/Editor/Data/Collection/GameObjectObservableSetTest.cs
+++ b/Tests/Editor/Data/Collection/GameObjectObservableSetTest.cs
@@ -640,6 +640,9 @@ namespace Test.Zinnia.Data.Collection
             Assert.IsTrue(elementAddedMock.Received);
             Assert.IsFalse(elementRemovedMock.Received);
             Assert.IsFalse(becameEmptyMock.Received);
+
+            Object.DestroyImmediate(elementOne);
+            Object.DestroyImmediate(elementTwo);
         }
 
         private sealed class GameObjectObservableSetMock : GameObjectObservableSet

--- a/Tests/Editor/Data/Operation/GameObjectClonerTest.cs
+++ b/Tests/Editor/Data/Operation/GameObjectClonerTest.cs
@@ -21,7 +21,6 @@ namespace Test.Zinnia.Data.Operation
         [TearDown]
         public void TearDown()
         {
-            Object.DestroyImmediate(subject);
             Object.DestroyImmediate(containingObject);
         }
 
@@ -45,6 +44,8 @@ namespace Test.Zinnia.Data.Operation
             Assert.IsNull(actual);
             Assert.IsFalse(clonedMock.Received);
             Assert.IsNull(clonedMock.Value);
+
+            Object.DestroyImmediate(actual);
         }
 
         [Test]
@@ -99,6 +100,7 @@ namespace Test.Zinnia.Data.Operation
 
             Object.DestroyImmediate(actual);
             Object.DestroyImmediate(source);
+            Object.DestroyImmediate(expected);
         }
 
         [Test]

--- a/Tests/Editor/Tracking/Follow/Modifier/FollowModifierTest.cs
+++ b/Tests/Editor/Tracking/Follow/Modifier/FollowModifierTest.cs
@@ -22,7 +22,6 @@ namespace Test.Zinnia.Tracking.Follow.Modifier
         [TearDown]
         public void TearDown()
         {
-            Object.DestroyImmediate(subject);
             Object.DestroyImmediate(containingObject);
         }
 
@@ -66,7 +65,7 @@ namespace Test.Zinnia.Tracking.Follow.Modifier
             Assert.IsTrue(rotationMock.modified);
             Assert.IsTrue(scaleMock.modified);
 
-            Object.DestroyImmediate(subject);
+            Object.DestroyImmediate(source);
             Object.DestroyImmediate(target);
             Object.DestroyImmediate(offset);
         }
@@ -110,7 +109,7 @@ namespace Test.Zinnia.Tracking.Follow.Modifier
             Assert.IsTrue(rotationMock.modified);
             Assert.IsTrue(scaleMock.modified);
 
-            Object.DestroyImmediate(subject);
+            Object.DestroyImmediate(source);
             Object.DestroyImmediate(target);
         }
 
@@ -153,7 +152,6 @@ namespace Test.Zinnia.Tracking.Follow.Modifier
             Assert.IsFalse(rotationMock.modified);
             Assert.IsFalse(scaleMock.modified);
 
-            Object.DestroyImmediate(subject);
             Object.DestroyImmediate(target);
             Object.DestroyImmediate(offset);
         }
@@ -197,7 +195,7 @@ namespace Test.Zinnia.Tracking.Follow.Modifier
             Assert.IsFalse(rotationMock.modified);
             Assert.IsFalse(scaleMock.modified);
 
-            Object.DestroyImmediate(subject);
+            Object.DestroyImmediate(source);
             Object.DestroyImmediate(offset);
         }
 
@@ -242,7 +240,7 @@ namespace Test.Zinnia.Tracking.Follow.Modifier
             Assert.IsFalse(rotationMock.modified);
             Assert.IsFalse(scaleMock.modified);
 
-            Object.DestroyImmediate(subject);
+            Object.DestroyImmediate(source);
             Object.DestroyImmediate(target);
             Object.DestroyImmediate(offset);
         }
@@ -288,7 +286,7 @@ namespace Test.Zinnia.Tracking.Follow.Modifier
             Assert.IsFalse(rotationMock.modified);
             Assert.IsFalse(scaleMock.modified);
 
-            Object.DestroyImmediate(subject);
+            Object.DestroyImmediate(source);
             Object.DestroyImmediate(target);
             Object.DestroyImmediate(offset);
         }

--- a/Tests/Editor/Tracking/Follow/Modifier/Property/Scale/TransformScaleTest.cs
+++ b/Tests/Editor/Tracking/Follow/Modifier/Property/Scale/TransformScaleTest.cs
@@ -20,7 +20,6 @@ namespace Test.Zinnia.Tracking.Follow.Modifier.Property.Scale
         [TearDown]
         public void TearDown()
         {
-            Object.DestroyImmediate(subject);
             Object.DestroyImmediate(containingObject);
         }
 
@@ -82,6 +81,7 @@ namespace Test.Zinnia.Tracking.Follow.Modifier.Property.Scale
 
             Object.DestroyImmediate(source);
             Object.DestroyImmediate(target);
+            Object.DestroyImmediate(offset);
         }
 
         [Test]

--- a/Tests/Editor/Tracking/Modification/GameObjectStateMirrorTest.cs
+++ b/Tests/Editor/Tracking/Modification/GameObjectStateMirrorTest.cs
@@ -21,7 +21,6 @@ namespace Test.Zinnia.Tracking.Modification
         [TearDown]
         public void TearDown()
         {
-            Object.DestroyImmediate(subject);
             Object.DestroyImmediate(containingObject);
         }
 
@@ -58,6 +57,11 @@ namespace Test.Zinnia.Tracking.Modification
             Assert.IsTrue(target1.gameObject.activeInHierarchy);
             Assert.IsTrue(target2.gameObject.activeInHierarchy);
             Assert.IsTrue(target3.gameObject.activeInHierarchy);
+
+            Object.DestroyImmediate(source);
+            Object.DestroyImmediate(target1);
+            Object.DestroyImmediate(target2);
+            Object.DestroyImmediate(target3);
         }
 
         [Test]
@@ -93,6 +97,11 @@ namespace Test.Zinnia.Tracking.Modification
             Assert.IsFalse(target1.gameObject.activeInHierarchy);
             Assert.IsFalse(target2.gameObject.activeInHierarchy);
             Assert.IsFalse(target3.gameObject.activeInHierarchy);
+
+            Object.DestroyImmediate(source);
+            Object.DestroyImmediate(target1);
+            Object.DestroyImmediate(target2);
+            Object.DestroyImmediate(target3);
         }
 
         [Test]
@@ -137,6 +146,11 @@ namespace Test.Zinnia.Tracking.Modification
             Assert.IsFalse(target1.gameObject.activeInHierarchy);
             Assert.IsFalse(target2.gameObject.activeInHierarchy);
             Assert.IsFalse(target3.gameObject.activeInHierarchy);
+
+            Object.DestroyImmediate(source);
+            Object.DestroyImmediate(target1);
+            Object.DestroyImmediate(target2);
+            Object.DestroyImmediate(target3);
         }
     }
 }

--- a/Tests/Editor/Tracking/Modification/PinchScalerTest.cs
+++ b/Tests/Editor/Tracking/Modification/PinchScalerTest.cs
@@ -20,7 +20,6 @@ namespace Test.Zinnia.Tracking.Modification
         [TearDown]
         public void TearDown()
         {
-            Object.DestroyImmediate(subject);
             Object.DestroyImmediate(containingObject);
         }
 
@@ -181,6 +180,8 @@ namespace Test.Zinnia.Tracking.Modification
             target.transform.localScale = Vector3.one * 2f;
             subject.RestoreSavedScale();
             Assert.AreEqual(Vector3.one, target.transform.localScale);
+
+            Object.DestroyImmediate(target);
         }
     }
 }


### PR DESCRIPTION
When GameObjects are created in tests, they should be immediately
destroyed at the end of the test to prevent creating a dirty scene
for the next test.

This fix ensures no created GameObjects have been left around at
the end of a test.