### PR TITLE
feat(Event): update fields to properties and lists to observable

### DIFF
--- a/Runtime/Action/ActionRegistrar.cs
+++ b/Runtime/Action/ActionRegistrar.cs
@@ -140,9 +140,9 @@
             }
 
             // It is expected that we have less SourceLimits than we have Sources, so this order of nesting the loops is the preferred one.
-            foreach (GameObject limit in SourceLimits.ReadOnlyElements)
+            foreach (GameObject limit in SourceLimits.SubscribableElements)
             {
-                foreach (ActionSource source in Sources.ReadOnlyElements)
+                foreach (ActionSource source in Sources.SubscribableElements)
                 {
                     TryAddTargetSource(source, limit);
                 }
@@ -193,7 +193,7 @@
         [RequiresBehaviourState]
         protected virtual void OnSourceAdded(ActionSource source)
         {
-            foreach (GameObject limit in SourceLimits.ReadOnlyElements)
+            foreach (GameObject limit in SourceLimits.SubscribableElements)
             {
                 TryAddTargetSource(source, limit);
             }
@@ -206,7 +206,7 @@
         [RequiresBehaviourState]
         protected virtual void OnSourceRemoved(ActionSource source)
         {
-            foreach (GameObject limit in SourceLimits.ReadOnlyElements)
+            foreach (GameObject limit in SourceLimits.SubscribableElements)
             {
                 TryRemoveTargetSource(source, limit);
             }
@@ -219,7 +219,7 @@
         [RequiresBehaviourState]
         protected virtual void OnSourceLimitAdded(GameObject limit)
         {
-            foreach (ActionSource source in Sources.ReadOnlyElements)
+            foreach (ActionSource source in Sources.SubscribableElements)
             {
                 TryAddTargetSource(source, limit);
             }
@@ -232,7 +232,7 @@
         [RequiresBehaviourState]
         protected virtual void OnSourceLimitRemoved(GameObject limit)
         {
-            foreach (ActionSource source in Sources.ReadOnlyElements)
+            foreach (ActionSource source in Sources.SubscribableElements)
             {
                 TryRemoveTargetSource(source, limit);
             }
@@ -271,7 +271,7 @@
             }
 
             RemoveSourcesListeners();
-            foreach (ActionSource source in Sources.ReadOnlyElements)
+            foreach (ActionSource source in Sources.SubscribableElements)
             {
                 OnSourceRemoved(source);
             }
@@ -299,7 +299,7 @@
             }
 
             RemoveSourcesLimitsListeners();
-            foreach (GameObject limit in SourceLimits.ReadOnlyElements)
+            foreach (GameObject limit in SourceLimits.SubscribableElements)
             {
                 OnSourceLimitRemoved(limit);
             }

--- a/Runtime/Action/AllAction.cs
+++ b/Runtime/Action/AllAction.cs
@@ -47,7 +47,7 @@
             Actions.ElementAdded.AddListener(OnActionAdded);
             Actions.ElementRemoved.AddListener(OnActionRemoved);
 
-            foreach (Action action in Actions.ReadOnlyElements)
+            foreach (Action action in Actions.SubscribableElements)
             {
                 action.ActivationStateChanged.AddListener(OnActionActivationStateChanged);
             }
@@ -61,7 +61,7 @@
             Actions.ElementAdded.RemoveListener(OnActionAdded);
             Actions.ElementRemoved.RemoveListener(OnActionRemoved);
 
-            foreach (Action action in Actions.ReadOnlyElements)
+            foreach (Action action in Actions.SubscribableElements)
             {
                 action.ActivationStateChanged.RemoveListener(OnActionActivationStateChanged);
             }
@@ -82,8 +82,8 @@
                 return;
             }
 
-            bool areAllActionsActivated = Actions.ReadOnlyElements.Count > 0 != DefaultValue;
-            foreach (Action action in Actions.ReadOnlyElements)
+            bool areAllActionsActivated = Actions.SubscribableElements.Count > 0 != DefaultValue;
+            foreach (Action action in Actions.SubscribableElements)
             {
                 if (!action.IsActivated)
                 {

--- a/Runtime/Action/AnyAction.cs
+++ b/Runtime/Action/AnyAction.cs
@@ -47,7 +47,7 @@
             Actions.ElementAdded.AddListener(OnActionAdded);
             Actions.ElementRemoved.AddListener(OnActionRemoved);
 
-            foreach (Action action in Actions.ReadOnlyElements)
+            foreach (Action action in Actions.SubscribableElements)
             {
                 action.ActivationStateChanged.AddListener(OnActionActivationStateChanged);
             }
@@ -61,7 +61,7 @@
             Actions.ElementAdded.RemoveListener(OnActionAdded);
             Actions.ElementRemoved.RemoveListener(OnActionRemoved);
 
-            foreach (Action action in Actions.ReadOnlyElements)
+            foreach (Action action in Actions.SubscribableElements)
             {
                 action.ActivationStateChanged.RemoveListener(OnActionActivationStateChanged);
             }
@@ -83,7 +83,7 @@
             }
 
             bool areAllActionsActivated = DefaultValue;
-            foreach (Action action in Actions.ReadOnlyElements)
+            foreach (Action action in Actions.SubscribableElements)
             {
                 if (action.IsActivated)
                 {

--- a/Runtime/Action/Collection/ActionRegistrarSourceObservableList.cs
+++ b/Runtime/Action/Collection/ActionRegistrarSourceObservableList.cs
@@ -64,9 +64,9 @@
         /// <param name="setAll">Whether to ignore the source and just set all sources to the given state.</param>
         protected virtual void SetSourceEnabledState(GameObject source, bool state, bool setAll)
         {
-            for (int index = 0; index < ReadOnlyElements.Count; index++)
+            for (int index = 0; index < SubscribableElements.Count; index++)
             {
-                ActionRegistrar.ActionSource actionSource = ReadOnlyElements[index];
+                ActionRegistrar.ActionSource actionSource = SubscribableElements[index];
                 if (actionSource.Container != source && !setAll)
                 {
                     continue;

--- a/Runtime/Data/Collection/BehaviourObservableList.cs
+++ b/Runtime/Data/Collection/BehaviourObservableList.cs
@@ -1,0 +1,21 @@
+﻿namespace Zinnia.Data.Collection
+{
+    using UnityEngine;
+    using UnityEngine.Events;
+    using System;
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// Allows observing changes to a <see cref="List{T}"/> of <see cref="Behaviour"/>s.
+    /// </summary>
+    public class BehaviourObservableList : DefaultObservableList<Behaviour, BehaviourObservableList.UnityEvent>
+    {
+        /// <summary>
+        /// Defines the event with the <see cref="Behaviour"/>.
+        /// </summary>
+        [Serializable]
+        public class UnityEvent : UnityEvent<Behaviour>
+        {
+        }
+    }
+}

--- a/Runtime/Data/Collection/BehaviourObservableList.cs.meta
+++ b/Runtime/Data/Collection/BehaviourObservableList.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 45641bb26f54b8d4797b08b74c29645c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Data/Collection/ObservableList.cs
+++ b/Runtime/Data/Collection/ObservableList.cs
@@ -55,11 +55,13 @@
         public int CurrentIndex { get; set; }
 
         /// <summary>
-        /// The collection to observe changes of.
+        /// The elements to observe changes of, accessible from components that *are* keeping in sync with the state of the collection by subscribing to the list mutation events. Alternatively use <see cref="NonSubscribableElements"/> instead.
         /// </summary>
-        public IReadOnlyList<TElement> ReadOnlyElements => wasStartCalled
-            ? (IReadOnlyList<TElement>)Elements
-            : Array.Empty<TElement>();
+        public IReadOnlyList<TElement> SubscribableElements => wasStartCalled ? (IReadOnlyList<TElement>)Elements : Array.Empty<TElement>();
+        /// <summary>
+        /// The elements to observe changes of, accessible from components that are *not* interested in keeping in sync with the state of the collection. Alternatively use <see cref="SubscribableElements"/> instead.
+        /// </summary>
+        public IReadOnlyList<TElement> NonSubscribableElements => Elements;
 
         /// <summary>
         /// The collection to observe changes of.
@@ -121,7 +123,7 @@
         [RequiresBehaviourState]
         public virtual void AddAt(TElement element, int index)
         {
-            if (ReadOnlyElements.Count == 0)
+            if (SubscribableElements.Count == 0)
             {
                 Add(element);
                 return;
@@ -153,7 +155,7 @@
         [RequiresBehaviourState]
         public virtual void SetAt(TElement element, int index)
         {
-            if (ReadOnlyElements.Count == 0)
+            if (SubscribableElements.Count == 0)
             {
                 return;
             }
@@ -214,13 +216,13 @@
         [RequiresBehaviourState]
         public virtual void RemoveAt(int index)
         {
-            if (ReadOnlyElements.Count == 0)
+            if (SubscribableElements.Count == 0)
             {
                 return;
             }
 
             index = Elements.GetWrappedAndClampedIndex(index);
-            TElement removedElement = ReadOnlyElements[index];
+            TElement removedElement = SubscribableElements[index];
             Elements.RemoveAt(index);
             EmitRemoveEvents(removedElement);
         }
@@ -241,7 +243,7 @@
         [RequiresBehaviourState]
         public virtual void Clear(bool removeFromFront)
         {
-            if (ReadOnlyElements.Count == 0)
+            if (SubscribableElements.Count == 0)
             {
                 return;
             }
@@ -251,7 +253,7 @@
                 Elements.Reverse();
             }
 
-            foreach (TElement element in ReadOnlyElements)
+            foreach (TElement element in SubscribableElements)
             {
                 ElementRemoved?.Invoke(element);
             }
@@ -264,14 +266,14 @@
         {
             wasStartCalled = true;
 
-            if (ReadOnlyElements == null)
+            if (SubscribableElements == null)
             {
                 return;
             }
 
-            for (int index = 0; index < ReadOnlyElements.Count; index++)
+            for (int index = 0; index < SubscribableElements.Count; index++)
             {
-                TElement element = ReadOnlyElements[index];
+                TElement element = SubscribableElements[index];
                 if (EqualityComparer<TElement>.Default.Equals(element, default))
                 {
                     continue;
@@ -294,7 +296,7 @@
         {
             ElementAdded?.Invoke(element);
 
-            if (ReadOnlyElements.Count == 1)
+            if (SubscribableElements.Count == 1)
             {
                 BecamePopulated?.Invoke(element);
             }
@@ -308,7 +310,7 @@
         {
             ElementRemoved?.Invoke(element);
 
-            if (ReadOnlyElements.Count == 0)
+            if (SubscribableElements.Count == 0)
             {
                 BecameEmpty?.Invoke(element);
             }

--- a/Runtime/Event/ComponentGameObjectEmitter.cs
+++ b/Runtime/Event/ComponentGameObjectEmitter.cs
@@ -1,10 +1,9 @@
 ﻿namespace Zinnia.Event
 {
-    using Malimbe.MemberClearanceMethod;
-    using Malimbe.PropertySerializationAttribute;
-    /*using Malimbe.PropertyValidationMethod;*/
-    using Malimbe.XmlDocumentationAttribute;
     using UnityEngine;
+    using Malimbe.MemberClearanceMethod;
+    using Malimbe.XmlDocumentationAttribute;
+    using Malimbe.PropertySerializationAttribute;
 
     /// <summary>
     /// Extracts the <see cref="GameObject"/> from the <see cref="Source"/> and emits an event containing the result.
@@ -14,7 +13,7 @@
         /// <summary>
         /// The source to extract from.
         /// </summary>
-        [Serialized, /*Validated,*/ Cleared]
+        [Serialized, Cleared]
         [field: DocumentedByXml]
         public Component Source { get; set; }
 

--- a/Runtime/Event/EventProxyEmitter.cs
+++ b/Runtime/Event/EventProxyEmitter.cs
@@ -13,7 +13,7 @@
         /// <returns><see langword="true"/> if the emitter is in a valid state.</returns>
         protected virtual bool IsValid()
         {
-            return (isActiveAndEnabled);
+            return isActiveAndEnabled;
         }
     }
 }

--- a/Runtime/Event/GameObjectEmitter.cs
+++ b/Runtime/Event/GameObjectEmitter.cs
@@ -27,11 +27,7 @@
         /// <summary>
         /// The extracted <see cref="GameObject"/>.
         /// </summary>
-        public GameObject Result
-        {
-            get;
-            protected set;
-        }
+        public GameObject Result { get; protected set; }
 
         /// <summary>
         /// Extracts the <see cref="GameObject"/>/

--- a/Runtime/Event/RestrictableSingleEventProxyEmitter.cs
+++ b/Runtime/Event/RestrictableSingleEventProxyEmitter.cs
@@ -1,7 +1,9 @@
 ﻿namespace Zinnia.Event
 {
-    using Malimbe.XmlDocumentationAttribute;
     using UnityEngine.Events;
+    using Malimbe.MemberClearanceMethod;
+    using Malimbe.XmlDocumentationAttribute;
+    using Malimbe.PropertySerializationAttribute;
     using Zinnia.Extension;
     using Zinnia.Rule;
 
@@ -10,8 +12,9 @@
         /// <summary>
         /// Determines whether the received payload is valid to be re-emitted.
         /// </summary>
-        [DocumentedByXml]
-        public RuleContainer receiveValidity;
+        [Serialized, Cleared]
+        [field: DocumentedByXml]
+        public RuleContainer ReceiveValidity { get; set; }
 
         /// <summary>
         /// Gets the target for the validity check.
@@ -22,7 +25,7 @@
         /// <inheritdoc />
         protected override bool IsValid()
         {
-            return (base.IsValid() && receiveValidity.Accepts(GetTargetToCheck()));
+            return base.IsValid() && ReceiveValidity.Accepts(GetTargetToCheck());
         }
     }
 }

--- a/Runtime/Event/SingleEventProxyEmitter.cs
+++ b/Runtime/Event/SingleEventProxyEmitter.cs
@@ -1,7 +1,7 @@
 ﻿namespace Zinnia.Event
 {
-    using Malimbe.XmlDocumentationAttribute;
     using UnityEngine.Events;
+    using Malimbe.XmlDocumentationAttribute;
 
     /// <summary>
     /// Emits a UnityEvent with a single payload whenever the Receive method is called.
@@ -13,11 +13,7 @@
         /// <summary>
         /// The most recent received payload.
         /// </summary>
-        public TValue Payload
-        {
-            get;
-            protected set;
-        }
+        public TValue Payload { get; protected set; }
 
         /// <summary>
         /// Is emitted when Receive is called.

--- a/Runtime/Haptics/HapticProcessor.cs
+++ b/Runtime/Haptics/HapticProcessor.cs
@@ -35,7 +35,7 @@
         protected override void DoBegin()
         {
             HapticProcess firstActiveProcess = null;
-            foreach (HapticProcess process in HapticProcesses.ReadOnlyElements)
+            foreach (HapticProcess process in HapticProcesses.SubscribableElements)
             {
                 if (process.IsActive())
                 {

--- a/Runtime/Process/Component/GameObjectSourceTargetProcessor.cs
+++ b/Runtime/Process/Component/GameObjectSourceTargetProcessor.cs
@@ -42,7 +42,7 @@
         [RequiresBehaviourState]
         public override void Process()
         {
-            ApplySourcesToTargets(Sources.ReadOnlyElements, Targets.ReadOnlyElements);
+            ApplySourcesToTargets(Sources.SubscribableElements, Targets.SubscribableElements);
         }
 
         /// <inheritdoc />

--- a/Runtime/Process/Moment/MomentProcessor.cs
+++ b/Runtime/Process/Moment/MomentProcessor.cs
@@ -141,7 +141,7 @@
                 return;
             }
 
-            foreach (MomentProcess currentProcess in Processes.ReadOnlyElements)
+            foreach (MomentProcess currentProcess in Processes.SubscribableElements)
             {
                 currentProcess.Process();
             }

--- a/Runtime/Rule/AllRule.cs
+++ b/Runtime/Rule/AllRule.cs
@@ -23,12 +23,12 @@
         [RequiresBehaviourState]
         public bool Accepts(object target)
         {
-            if (Rules == null || Rules.ReadOnlyElements.Count == 0)
+            if (Rules == null || Rules.SubscribableElements.Count == 0)
             {
                 return false;
             }
 
-            foreach (RuleContainer rule in Rules.ReadOnlyElements)
+            foreach (RuleContainer rule in Rules.SubscribableElements)
             {
                 if (!rule.Accepts(target))
                 {

--- a/Runtime/Rule/AnyComponentTypeRule.cs
+++ b/Runtime/Rule/AnyComponentTypeRule.cs
@@ -26,7 +26,7 @@
                 return false;
             }
 
-            foreach (SerializableType serializedType in ComponentTypes.ReadOnlyElements)
+            foreach (SerializableType serializedType in ComponentTypes.SubscribableElements)
             {
                 if (serializedType.ActualType != null && targetGameObject.GetComponent(serializedType) != null)
                 {

--- a/Runtime/Rule/AnyRule.cs
+++ b/Runtime/Rule/AnyRule.cs
@@ -28,7 +28,7 @@
                 return false;
             }
 
-            foreach (RuleContainer rule in Rules.ReadOnlyElements)
+            foreach (RuleContainer rule in Rules.SubscribableElements)
             {
                 if (rule.Accepts(target))
                 {

--- a/Runtime/Rule/AnyTagRule.cs
+++ b/Runtime/Rule/AnyTagRule.cs
@@ -25,7 +25,7 @@
                 return false;
             }
 
-            foreach (string testedTag in Tags.ReadOnlyElements)
+            foreach (string testedTag in Tags.SubscribableElements)
             {
                 if (targetGameObject.CompareTag(testedTag))
                 {

--- a/Runtime/Rule/RulesMatcher.cs
+++ b/Runtime/Rule/RulesMatcher.cs
@@ -53,7 +53,7 @@
                 return;
             }
 
-            foreach (Element element in Elements.ReadOnlyElements)
+            foreach (Element element in Elements.SubscribableElements)
             {
                 if (element.Rule.Accepts(source))
                 {

--- a/Runtime/Tracking/Follow/ObjectFollower.cs
+++ b/Runtime/Tracking/Follow/ObjectFollower.cs
@@ -109,7 +109,7 @@
         protected override void ApplySourceToTarget(GameObject source, GameObject target)
         {
             GameObject followOffset = GetFollowOffset();
-            if (followOffset != null && !followOffset.transform.IsChildOf(Targets.ReadOnlyElements[Targets.CurrentIndex].transform))
+            if (followOffset != null && !followOffset.transform.IsChildOf(Targets.SubscribableElements[Targets.CurrentIndex].transform))
             {
                 throw new ArgumentException($"The `targetOffsets` at index [{Targets.CurrentIndex}] must be a child of the GameObject at `targets` index [{Targets.CurrentIndex}].");
             }
@@ -122,13 +122,13 @@
         /// <returns></returns>
         protected virtual GameObject GetFollowOffset()
         {
-            if (Targets == null || TargetOffsets == null || Targets.ReadOnlyElements.Count == 0 || TargetOffsets.ReadOnlyElements.Count == 0)
+            if (Targets == null || TargetOffsets == null || Targets.SubscribableElements.Count == 0 || TargetOffsets.SubscribableElements.Count == 0)
             {
                 return null;
             }
 
-            int currentIndexTargets = TargetOffsets.ReadOnlyElements.GetWrappedAndClampedIndex(Targets.CurrentIndex);
-            return TargetOffsets.ReadOnlyElements[currentIndexTargets];
+            int currentIndexTargets = TargetOffsets.SubscribableElements.GetWrappedAndClampedIndex(Targets.CurrentIndex);
+            return TargetOffsets.SubscribableElements[currentIndexTargets];
         }
     }
 }

--- a/Runtime/Tracking/Modification/ComponentEnabledStateModifier.cs
+++ b/Runtime/Tracking/Modification/ComponentEnabledStateModifier.cs
@@ -39,7 +39,7 @@
                 return;
             }
 
-            foreach (SerializableType serializableType in Types.ReadOnlyElements)
+            foreach (SerializableType serializableType in Types.SubscribableElements)
             {
                 foreach (Component targetObject in Target.GetComponentsInChildren(serializableType, true))
                 {

--- a/Runtime/Tracking/Modification/GameObjectStateSwitcher.cs
+++ b/Runtime/Tracking/Modification/GameObjectStateSwitcher.cs
@@ -37,7 +37,7 @@
         public virtual void SwitchNext()
         {
             CurrentIndex++;
-            if (CurrentIndex >= Targets.ReadOnlyElements.Count)
+            if (CurrentIndex >= Targets.SubscribableElements.Count)
             {
                 CurrentIndex = 0;
             }
@@ -54,7 +54,7 @@
             CurrentIndex--;
             if (CurrentIndex < 0)
             {
-                CurrentIndex = Targets.ReadOnlyElements.Count - 1;
+                CurrentIndex = Targets.SubscribableElements.Count - 1;
             }
 
             Switch();
@@ -67,7 +67,7 @@
         [RequiresBehaviourState]
         public virtual void SwitchTo(int index)
         {
-            CurrentIndex = Mathf.Clamp(index, 0, Targets.ReadOnlyElements.Count - 1);
+            CurrentIndex = Mathf.Clamp(index, 0, Targets.SubscribableElements.Count - 1);
             Switch();
         }
 
@@ -85,9 +85,9 @@
         /// </summary>
         protected virtual void Switch()
         {
-            for (int index = 0; index < Targets.ReadOnlyElements.Count; index++)
+            for (int index = 0; index < Targets.SubscribableElements.Count; index++)
             {
-                Targets.ReadOnlyElements[index].SetActive(index == CurrentIndex ? TargetState : !TargetState);
+                Targets.SubscribableElements[index].SetActive(index == CurrentIndex ? TargetState : !TargetState);
             }
         }
     }

--- a/Runtime/Tracking/Velocity/VelocityTrackerProcessor.cs
+++ b/Runtime/Tracking/Velocity/VelocityTrackerProcessor.cs
@@ -65,7 +65,7 @@
             }
 
             VelocityTracker firstActiveTracker = null;
-            foreach (VelocityTracker tracker in VelocityTrackers.ReadOnlyElements)
+            foreach (VelocityTracker tracker in VelocityTrackers.SubscribableElements)
             {
                 if (tracker.IsActive())
                 {

--- a/Tests/Editor/Action/ActionRegistrarTest.cs
+++ b/Tests/Editor/Action/ActionRegistrarTest.cs
@@ -74,8 +74,8 @@ namespace Test.Zinnia.Action
             yield return null;
 
             Assert.AreEqual(2, targetAction.ReadOnlySources.Count);
-            Assert.AreEqual(1, subject.SourceLimits.ReadOnlyElements.Count);
-            Assert.IsNull(subject.SourceLimits.ReadOnlyElements[0]);
+            Assert.AreEqual(1, subject.SourceLimits.SubscribableElements.Count);
+            Assert.IsNull(subject.SourceLimits.SubscribableElements[0]);
 
             Object.DestroyImmediate(targetActionObject);
             Object.DestroyImmediate(oneSourceActionObject);
@@ -121,7 +121,7 @@ namespace Test.Zinnia.Action
 
             Assert.AreEqual(1, targetAction.ReadOnlySources.Count);
             Assert.AreEqual(twoSourceAction, targetAction.ReadOnlySources[0]);
-            Assert.AreEqual(twoSourceActionObject, subject.SourceLimits.ReadOnlyElements[0]);
+            Assert.AreEqual(twoSourceActionObject, subject.SourceLimits.SubscribableElements[0]);
 
             Object.DestroyImmediate(targetActionObject);
             Object.DestroyImmediate(oneSourceActionObject);
@@ -165,8 +165,8 @@ namespace Test.Zinnia.Action
             yield return null;
 
             Assert.AreEqual(1, targetAction.ReadOnlySources.Count);
-            Assert.AreEqual(1, subject.SourceLimits.ReadOnlyElements.Count);
-            Assert.IsNull(subject.SourceLimits.ReadOnlyElements[0]);
+            Assert.AreEqual(1, subject.SourceLimits.SubscribableElements.Count);
+            Assert.IsNull(subject.SourceLimits.SubscribableElements[0]);
 
             Object.DestroyImmediate(targetActionObject);
             Object.DestroyImmediate(oneSourceActionObject);

--- a/Tests/Editor/Action/Collection/ActionRegistrarSourceObservableListTest.cs
+++ b/Tests/Editor/Action/Collection/ActionRegistrarSourceObservableListTest.cs
@@ -52,13 +52,13 @@ namespace Test.Zinnia.Action.Collection
             subject.Add(oneActionSource);
             subject.Add(twoActionSource);
 
-            Assert.IsFalse(subject.ReadOnlyElements[0].Enabled);
-            Assert.IsFalse(subject.ReadOnlyElements[1].Enabled);
+            Assert.IsFalse(subject.SubscribableElements[0].Enabled);
+            Assert.IsFalse(subject.SubscribableElements[1].Enabled);
 
             subject.EnableSource(oneSourceActionObject);
 
-            Assert.IsTrue(subject.ReadOnlyElements[0].Enabled);
-            Assert.IsFalse(subject.ReadOnlyElements[1].Enabled);
+            Assert.IsTrue(subject.SubscribableElements[0].Enabled);
+            Assert.IsFalse(subject.SubscribableElements[1].Enabled);
 
             Object.DestroyImmediate(oneSourceActionObject);
             Object.DestroyImmediate(twoSourceActionObject);
@@ -89,13 +89,13 @@ namespace Test.Zinnia.Action.Collection
             subject.Add(oneActionSource);
             subject.Add(twoActionSource);
 
-            Assert.IsTrue(subject.ReadOnlyElements[0].Enabled);
-            Assert.IsTrue(subject.ReadOnlyElements[1].Enabled);
+            Assert.IsTrue(subject.SubscribableElements[0].Enabled);
+            Assert.IsTrue(subject.SubscribableElements[1].Enabled);
 
             subject.DisableSource(oneSourceActionObject);
 
-            Assert.IsFalse(subject.ReadOnlyElements[0].Enabled);
-            Assert.IsTrue(subject.ReadOnlyElements[1].Enabled);
+            Assert.IsFalse(subject.SubscribableElements[0].Enabled);
+            Assert.IsTrue(subject.SubscribableElements[1].Enabled);
 
             Object.DestroyImmediate(oneSourceActionObject);
             Object.DestroyImmediate(twoSourceActionObject);
@@ -126,13 +126,13 @@ namespace Test.Zinnia.Action.Collection
             subject.Add(oneActionSource);
             subject.Add(twoActionSource);
 
-            Assert.IsFalse(subject.ReadOnlyElements[0].Enabled);
-            Assert.IsFalse(subject.ReadOnlyElements[1].Enabled);
+            Assert.IsFalse(subject.SubscribableElements[0].Enabled);
+            Assert.IsFalse(subject.SubscribableElements[1].Enabled);
 
             subject.EnableAllSources();
 
-            Assert.IsTrue(subject.ReadOnlyElements[0].Enabled);
-            Assert.IsTrue(subject.ReadOnlyElements[1].Enabled);
+            Assert.IsTrue(subject.SubscribableElements[0].Enabled);
+            Assert.IsTrue(subject.SubscribableElements[1].Enabled);
 
             Object.DestroyImmediate(oneSourceActionObject);
             Object.DestroyImmediate(twoSourceActionObject);
@@ -163,13 +163,13 @@ namespace Test.Zinnia.Action.Collection
             subject.Add(oneActionSource);
             subject.Add(twoActionSource);
 
-            Assert.IsTrue(subject.ReadOnlyElements[0].Enabled);
-            Assert.IsTrue(subject.ReadOnlyElements[1].Enabled);
+            Assert.IsTrue(subject.SubscribableElements[0].Enabled);
+            Assert.IsTrue(subject.SubscribableElements[1].Enabled);
 
             subject.DisableAllSources();
 
-            Assert.IsFalse(subject.ReadOnlyElements[0].Enabled);
-            Assert.IsFalse(subject.ReadOnlyElements[1].Enabled);
+            Assert.IsFalse(subject.SubscribableElements[0].Enabled);
+            Assert.IsFalse(subject.SubscribableElements[1].Enabled);
 
             Object.DestroyImmediate(oneSourceActionObject);
             Object.DestroyImmediate(twoSourceActionObject);

--- a/Tests/Editor/Data/Collection/GameObjectObservableListTest.cs
+++ b/Tests/Editor/Data/Collection/GameObjectObservableListTest.cs
@@ -87,11 +87,11 @@ namespace Test.Zinnia.Data.Collection
             GameObject elementOne = new GameObject();
             GameObject elementTwo = new GameObject();
 
-            Assert.IsEmpty(subject.ReadOnlyElements);
+            Assert.IsEmpty(subject.SubscribableElements);
 
             subject.Add(elementOne);
 
-            Assert.AreEqual(1, subject.ReadOnlyElements.Count);
+            Assert.AreEqual(1, subject.SubscribableElements.Count);
             Assert.IsTrue(becamePopulatedMock.Received);
             Assert.IsTrue(elementAddedMock.Received);
             Assert.IsFalse(elementRemovedMock.Received);
@@ -104,8 +104,8 @@ namespace Test.Zinnia.Data.Collection
 
             subject.Add(elementTwo);
 
-            Assert.AreEqual(2, subject.ReadOnlyElements.Count);
-            Assert.AreEqual(elementTwo, subject.ReadOnlyElements[1]);
+            Assert.AreEqual(2, subject.SubscribableElements.Count);
+            Assert.AreEqual(elementTwo, subject.SubscribableElements[1]);
 
             Assert.IsFalse(becamePopulatedMock.Received);
             Assert.IsTrue(elementAddedMock.Received);
@@ -131,11 +131,11 @@ namespace Test.Zinnia.Data.Collection
             GameObject elementOne = new GameObject();
             GameObject elementTwo = new GameObject();
 
-            Assert.IsEmpty(subject.ReadOnlyElements);
+            Assert.IsEmpty(subject.SubscribableElements);
 
             subject.AddAt(elementOne, 0);
 
-            Assert.AreEqual(1, subject.ReadOnlyElements.Count);
+            Assert.AreEqual(1, subject.SubscribableElements.Count);
             Assert.IsTrue(becamePopulatedMock.Received);
             Assert.IsTrue(elementAddedMock.Received);
             Assert.IsFalse(elementRemovedMock.Received);
@@ -148,8 +148,8 @@ namespace Test.Zinnia.Data.Collection
 
             subject.AddAt(elementTwo, 0);
 
-            Assert.AreEqual(2, subject.ReadOnlyElements.Count);
-            Assert.AreEqual(elementTwo, subject.ReadOnlyElements[0]);
+            Assert.AreEqual(2, subject.SubscribableElements.Count);
+            Assert.AreEqual(elementTwo, subject.SubscribableElements[0]);
 
             Assert.IsFalse(becamePopulatedMock.Received);
             Assert.IsTrue(elementAddedMock.Received);
@@ -177,11 +177,11 @@ namespace Test.Zinnia.Data.Collection
             GameObject elementOne = new GameObject();
             GameObject elementTwo = new GameObject();
 
-            Assert.IsEmpty(subject.ReadOnlyElements);
+            Assert.IsEmpty(subject.SubscribableElements);
 
             subject.AddAtCurrentIndex(elementOne);
 
-            Assert.AreEqual(1, subject.ReadOnlyElements.Count);
+            Assert.AreEqual(1, subject.SubscribableElements.Count);
             Assert.IsTrue(becamePopulatedMock.Received);
             Assert.IsTrue(elementAddedMock.Received);
             Assert.IsFalse(elementRemovedMock.Received);
@@ -193,8 +193,8 @@ namespace Test.Zinnia.Data.Collection
             becameEmptyMock.Reset();
 
             subject.AddAtCurrentIndex(elementTwo);
-            Assert.AreEqual(2, subject.ReadOnlyElements.Count);
-            Assert.AreEqual(elementTwo, subject.ReadOnlyElements[0]);
+            Assert.AreEqual(2, subject.SubscribableElements.Count);
+            Assert.AreEqual(elementTwo, subject.SubscribableElements[0]);
 
             Assert.IsFalse(becamePopulatedMock.Received);
             Assert.IsTrue(elementAddedMock.Received);
@@ -225,15 +225,15 @@ namespace Test.Zinnia.Data.Collection
             elementAddedMock.Reset();
             elementRemovedMock.Reset();
 
-            Assert.AreEqual(elementOne, subject.ReadOnlyElements[0]);
-            Assert.AreEqual(elementTwo, subject.ReadOnlyElements[1]);
-            Assert.AreEqual(elementThree, subject.ReadOnlyElements[2]);
+            Assert.AreEqual(elementOne, subject.SubscribableElements[0]);
+            Assert.AreEqual(elementTwo, subject.SubscribableElements[1]);
+            Assert.AreEqual(elementThree, subject.SubscribableElements[2]);
 
             subject.SetAt(elementFour, 1);
 
-            Assert.AreEqual(elementOne, subject.ReadOnlyElements[0]);
-            Assert.AreEqual(elementFour, subject.ReadOnlyElements[1]);
-            Assert.AreEqual(elementThree, subject.ReadOnlyElements[2]);
+            Assert.AreEqual(elementOne, subject.SubscribableElements[0]);
+            Assert.AreEqual(elementFour, subject.SubscribableElements[1]);
+            Assert.AreEqual(elementThree, subject.SubscribableElements[2]);
 
             Assert.IsTrue(elementAddedMock.Received);
             Assert.IsTrue(elementRemovedMock.Received);
@@ -266,15 +266,15 @@ namespace Test.Zinnia.Data.Collection
             elementAddedMock.Reset();
             elementRemovedMock.Reset();
 
-            Assert.AreEqual(elementOne, subject.ReadOnlyElements[0]);
-            Assert.AreEqual(elementTwo, subject.ReadOnlyElements[1]);
-            Assert.AreEqual(elementThree, subject.ReadOnlyElements[2]);
+            Assert.AreEqual(elementOne, subject.SubscribableElements[0]);
+            Assert.AreEqual(elementTwo, subject.SubscribableElements[1]);
+            Assert.AreEqual(elementThree, subject.SubscribableElements[2]);
 
             subject.SetAtCurrentIndex(elementFour);
 
-            Assert.AreEqual(elementOne, subject.ReadOnlyElements[0]);
-            Assert.AreEqual(elementFour, subject.ReadOnlyElements[1]);
-            Assert.AreEqual(elementThree, subject.ReadOnlyElements[2]);
+            Assert.AreEqual(elementOne, subject.SubscribableElements[0]);
+            Assert.AreEqual(elementFour, subject.SubscribableElements[1]);
+            Assert.AreEqual(elementThree, subject.SubscribableElements[2]);
 
             Assert.IsTrue(elementAddedMock.Received);
             Assert.IsTrue(elementRemovedMock.Received);
@@ -316,7 +316,7 @@ namespace Test.Zinnia.Data.Collection
             elementRemovedMock.Reset();
             becameEmptyMock.Reset();
 
-            Assert.AreEqual(3, subject.ReadOnlyElements.Count);
+            Assert.AreEqual(3, subject.SubscribableElements.Count);
 
             subject.Remove(elementOne);
 
@@ -325,9 +325,9 @@ namespace Test.Zinnia.Data.Collection
             Assert.IsTrue(elementRemovedMock.Received);
             Assert.IsFalse(becameEmptyMock.Received);
 
-            Assert.AreEqual(2, subject.ReadOnlyElements.Count);
-            Assert.AreEqual(elementTwo, subject.ReadOnlyElements[0]);
-            Assert.AreEqual(elementOne, subject.ReadOnlyElements[1]);
+            Assert.AreEqual(2, subject.SubscribableElements.Count);
+            Assert.AreEqual(elementTwo, subject.SubscribableElements[0]);
+            Assert.AreEqual(elementOne, subject.SubscribableElements[1]);
 
             becamePopulatedMock.Reset();
             elementAddedMock.Reset();
@@ -341,8 +341,8 @@ namespace Test.Zinnia.Data.Collection
             Assert.IsTrue(elementRemovedMock.Received);
             Assert.IsFalse(becameEmptyMock.Received);
 
-            Assert.AreEqual(1, subject.ReadOnlyElements.Count);
-            Assert.AreEqual(elementTwo, subject.ReadOnlyElements[0]);
+            Assert.AreEqual(1, subject.SubscribableElements.Count);
+            Assert.AreEqual(elementTwo, subject.SubscribableElements[0]);
 
             becamePopulatedMock.Reset();
             elementAddedMock.Reset();
@@ -356,7 +356,7 @@ namespace Test.Zinnia.Data.Collection
             Assert.IsTrue(elementRemovedMock.Received);
             Assert.IsTrue(becameEmptyMock.Received);
 
-            Assert.AreEqual(0, subject.ReadOnlyElements.Count);
+            Assert.AreEqual(0, subject.SubscribableElements.Count);
 
             becamePopulatedMock.Reset();
             elementAddedMock.Reset();
@@ -398,7 +398,7 @@ namespace Test.Zinnia.Data.Collection
             elementRemovedMock.Reset();
             becameEmptyMock.Reset();
 
-            Assert.AreEqual(3, subject.ReadOnlyElements.Count);
+            Assert.AreEqual(3, subject.SubscribableElements.Count);
 
             subject.RemoveLastOccurrence(elementOne);
 
@@ -407,9 +407,9 @@ namespace Test.Zinnia.Data.Collection
             Assert.IsTrue(elementRemovedMock.Received);
             Assert.IsFalse(becameEmptyMock.Received);
 
-            Assert.AreEqual(2, subject.ReadOnlyElements.Count);
-            Assert.AreEqual(elementOne, subject.ReadOnlyElements[0]);
-            Assert.AreEqual(elementTwo, subject.ReadOnlyElements[1]);
+            Assert.AreEqual(2, subject.SubscribableElements.Count);
+            Assert.AreEqual(elementOne, subject.SubscribableElements[0]);
+            Assert.AreEqual(elementTwo, subject.SubscribableElements[1]);
 
             becamePopulatedMock.Reset();
             elementAddedMock.Reset();
@@ -423,8 +423,8 @@ namespace Test.Zinnia.Data.Collection
             Assert.IsTrue(elementRemovedMock.Received);
             Assert.IsFalse(becameEmptyMock.Received);
 
-            Assert.AreEqual(1, subject.ReadOnlyElements.Count);
-            Assert.AreEqual(elementTwo, subject.ReadOnlyElements[0]);
+            Assert.AreEqual(1, subject.SubscribableElements.Count);
+            Assert.AreEqual(elementTwo, subject.SubscribableElements[0]);
 
             becamePopulatedMock.Reset();
             elementAddedMock.Reset();
@@ -438,7 +438,7 @@ namespace Test.Zinnia.Data.Collection
             Assert.IsTrue(elementRemovedMock.Received);
             Assert.IsTrue(becameEmptyMock.Received);
 
-            Assert.AreEqual(0, subject.ReadOnlyElements.Count);
+            Assert.AreEqual(0, subject.SubscribableElements.Count);
 
             becamePopulatedMock.Reset();
             elementAddedMock.Reset();
@@ -465,7 +465,7 @@ namespace Test.Zinnia.Data.Collection
             GameObject elementTwo = new GameObject();
             GameObject elementThree = new GameObject();
 
-            Assert.AreEqual(0, subject.ReadOnlyElements.Count);
+            Assert.AreEqual(0, subject.SubscribableElements.Count);
 
             Assert.IsFalse(becamePopulatedMock.Received);
             Assert.IsFalse(elementAddedMock.Received);
@@ -481,7 +481,7 @@ namespace Test.Zinnia.Data.Collection
             elementRemovedMock.Reset();
             becameEmptyMock.Reset();
 
-            Assert.AreEqual(3, subject.ReadOnlyElements.Count);
+            Assert.AreEqual(3, subject.SubscribableElements.Count);
 
             subject.RemoveAt(1);
 
@@ -490,9 +490,9 @@ namespace Test.Zinnia.Data.Collection
             Assert.IsTrue(elementRemovedMock.Received);
             Assert.IsFalse(becameEmptyMock.Received);
 
-            Assert.AreEqual(2, subject.ReadOnlyElements.Count);
-            Assert.AreEqual(elementOne, subject.ReadOnlyElements[0]);
-            Assert.AreEqual(elementThree, subject.ReadOnlyElements[1]);
+            Assert.AreEqual(2, subject.SubscribableElements.Count);
+            Assert.AreEqual(elementOne, subject.SubscribableElements[0]);
+            Assert.AreEqual(elementThree, subject.SubscribableElements[1]);
 
             becamePopulatedMock.Reset();
             elementAddedMock.Reset();
@@ -522,7 +522,7 @@ namespace Test.Zinnia.Data.Collection
             GameObject elementTwo = new GameObject();
             GameObject elementThree = new GameObject();
 
-            Assert.AreEqual(0, subject.ReadOnlyElements.Count);
+            Assert.AreEqual(0, subject.SubscribableElements.Count);
 
             Assert.IsFalse(becamePopulatedMock.Received);
             Assert.IsFalse(elementAddedMock.Received);
@@ -538,7 +538,7 @@ namespace Test.Zinnia.Data.Collection
             elementRemovedMock.Reset();
             becameEmptyMock.Reset();
 
-            Assert.AreEqual(3, subject.ReadOnlyElements.Count);
+            Assert.AreEqual(3, subject.SubscribableElements.Count);
 
             subject.RemoveAtCurrentIndex();
 
@@ -547,9 +547,9 @@ namespace Test.Zinnia.Data.Collection
             Assert.IsTrue(elementRemovedMock.Received);
             Assert.IsFalse(becameEmptyMock.Received);
 
-            Assert.AreEqual(2, subject.ReadOnlyElements.Count);
-            Assert.AreEqual(elementOne, subject.ReadOnlyElements[0]);
-            Assert.AreEqual(elementThree, subject.ReadOnlyElements[1]);
+            Assert.AreEqual(2, subject.SubscribableElements.Count);
+            Assert.AreEqual(elementOne, subject.SubscribableElements[0]);
+            Assert.AreEqual(elementThree, subject.SubscribableElements[1]);
 
             becamePopulatedMock.Reset();
             elementAddedMock.Reset();
@@ -592,7 +592,7 @@ namespace Test.Zinnia.Data.Collection
             elementRemovedMock.Reset();
             becameEmptyMock.Reset();
 
-            Assert.AreEqual(3, subject.ReadOnlyElements.Count);
+            Assert.AreEqual(3, subject.SubscribableElements.Count);
 
             subject.Clear(false);
 
@@ -601,7 +601,7 @@ namespace Test.Zinnia.Data.Collection
             Assert.IsTrue(elementRemovedMock.Received);
             Assert.IsTrue(becameEmptyMock.Received);
 
-            Assert.AreEqual(0, subject.ReadOnlyElements.Count);
+            Assert.AreEqual(0, subject.SubscribableElements.Count);
 
             Object.DestroyImmediate(elementOne);
             Object.DestroyImmediate(elementTwo);
@@ -638,7 +638,7 @@ namespace Test.Zinnia.Data.Collection
             elementRemovedMock.Reset();
             becameEmptyMock.Reset();
 
-            Assert.AreEqual(3, subject.ReadOnlyElements.Count);
+            Assert.AreEqual(3, subject.SubscribableElements.Count);
 
             subject.Clear(true);
 
@@ -647,7 +647,7 @@ namespace Test.Zinnia.Data.Collection
             Assert.IsTrue(elementRemovedMock.Received);
             Assert.IsTrue(becameEmptyMock.Received);
 
-            Assert.AreEqual(0, subject.ReadOnlyElements.Count);
+            Assert.AreEqual(0, subject.SubscribableElements.Count);
 
             Object.DestroyImmediate(elementOne);
             Object.DestroyImmediate(elementTwo);

--- a/Tests/Editor/Event/BehaviourEnabledObserverTest.cs
+++ b/Tests/Editor/Event/BehaviourEnabledObserverTest.cs
@@ -1,0 +1,125 @@
+﻿using Zinnia.Event;
+using Zinnia.Data.Collection;
+
+namespace Test.Zinnia.Event
+{
+    using UnityEngine;
+    using UnityEngine.TestTools;
+    using System.Collections;
+    using NUnit.Framework;
+    using Test.Zinnia.Utility.Mock;
+
+    public class BehaviourEnabledObserverTest
+    {
+        private GameObject containingObject;
+        private BehaviourEnabledObserver subject;
+
+        [SetUp]
+        public void SetUp()
+        {
+            containingObject = new GameObject();
+            containingObject.SetActive(false);
+            subject = containingObject.AddComponent<BehaviourEnabledObserver>();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            Object.DestroyImmediate(containingObject);
+        }
+
+        [UnityTest]
+        public IEnumerator CheckStateOnEnable()
+        {
+            UnityEventListenerMock activeAndEnabledMock = new UnityEventListenerMock();
+            subject.ActiveAndEnabled.AddListener(activeAndEnabledMock.Listen);
+
+            CheckState behaviourToCheck = containingObject.AddComponent<CheckState>();
+            behaviourToCheck.enabled = false;
+
+            BehaviourObservableList behaviours = containingObject.AddComponent<BehaviourObservableList>();
+            subject.Behaviours = behaviours;
+
+            containingObject.SetActive(true);
+
+            behaviours.Add(behaviourToCheck);
+
+            Assert.IsFalse(activeAndEnabledMock.Received);
+
+            yield return new WaitForEndOfFrame();
+
+            Assert.IsFalse(activeAndEnabledMock.Received);
+
+            behaviourToCheck.enabled = true;
+
+            yield return new WaitForEndOfFrame();
+
+            Assert.IsTrue(activeAndEnabledMock.Received);
+        }
+
+        [UnityTest]
+        public IEnumerator CheckStateOnEnableInsideLimitedTime()
+        {
+            UnityEventListenerMock activeAndEnabledMock = new UnityEventListenerMock();
+            subject.ActiveAndEnabled.AddListener(activeAndEnabledMock.Listen);
+
+            CheckState behaviourToCheck = containingObject.AddComponent<CheckState>();
+            behaviourToCheck.enabled = false;
+
+            BehaviourObservableList behaviours = containingObject.AddComponent<BehaviourObservableList>();
+            subject.Behaviours = behaviours;
+            subject.MaximumRunTime = 0.1f;
+
+            containingObject.SetActive(true);
+
+            behaviours.Add(behaviourToCheck);
+
+            Assert.IsFalse(activeAndEnabledMock.Received);
+
+            yield return new WaitForEndOfFrame();
+
+            Assert.IsFalse(activeAndEnabledMock.Received);
+
+            behaviourToCheck.enabled = true;
+
+            yield return new WaitForSeconds(0.05f);
+
+            Assert.IsTrue(activeAndEnabledMock.Received);
+        }
+
+        [UnityTest]
+        public IEnumerator CheckStateOnEnableOutsideLimitedTime()
+        {
+            UnityEventListenerMock activeAndEnabledMock = new UnityEventListenerMock();
+            subject.ActiveAndEnabled.AddListener(activeAndEnabledMock.Listen);
+
+            CheckState behaviourToCheck = containingObject.AddComponent<CheckState>();
+            behaviourToCheck.enabled = false;
+
+            BehaviourObservableList behaviours = containingObject.AddComponent<BehaviourObservableList>();
+            subject.Behaviours = behaviours;
+            subject.MaximumRunTime = 0.1f;
+
+            containingObject.SetActive(true);
+
+            behaviours.Add(behaviourToCheck);
+
+            Assert.IsFalse(activeAndEnabledMock.Received);
+
+            yield return new WaitForSeconds(0.11f);
+
+            Assert.IsFalse(activeAndEnabledMock.Received);
+
+            behaviourToCheck.enabled = true;
+
+            yield return new WaitForEndOfFrame();
+
+            Assert.IsFalse(activeAndEnabledMock.Received);
+        }
+    }
+
+    public class CheckState : MonoBehaviour
+    {
+        private void OnEnable() { }
+    }
+}

--- a/Tests/Editor/Event/BehaviourEnabledObserverTest.cs.meta
+++ b/Tests/Editor/Event/BehaviourEnabledObserverTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 15f70299ea378ed40a07e0f3a258dd89
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Editor/Event/GameObjectEventProxyEmitterTest.cs
+++ b/Tests/Editor/Event/GameObjectEventProxyEmitterTest.cs
@@ -55,7 +55,7 @@ namespace Test.Zinnia.Event
             rule.Objects = objects;
 
             objects.Add(digestValid);
-            subject.receiveValidity = new RuleContainer
+            subject.ReceiveValidity = new RuleContainer
             {
                 Interface = rule
             };

--- a/Tests/Editor/Process/Component/GameObjectSourceTargetProcessorTest.cs
+++ b/Tests/Editor/Process/Component/GameObjectSourceTargetProcessorTest.cs
@@ -36,12 +36,12 @@ namespace Test.Zinnia.Process.Component
             subject.Sources = containingObject.AddComponent<GameObjectObservableList>();
             yield return null;
 
-            Assert.IsEmpty(subject.Sources.ReadOnlyElements);
+            Assert.IsEmpty(subject.Sources.SubscribableElements);
 
             subject.Sources.Add(source);
 
-            Assert.AreEqual(1, subject.Sources.ReadOnlyElements.Count);
-            Assert.AreEqual(source, subject.Sources.ReadOnlyElements[0]);
+            Assert.AreEqual(1, subject.Sources.SubscribableElements.Count);
+            Assert.AreEqual(source, subject.Sources.SubscribableElements[0]);
 
             Object.DestroyImmediate(source);
         }
@@ -55,12 +55,12 @@ namespace Test.Zinnia.Process.Component
 
             subject.Sources.Add(source);
 
-            Assert.AreEqual(1, subject.Sources.ReadOnlyElements.Count);
-            Assert.AreEqual(source, subject.Sources.ReadOnlyElements[0]);
+            Assert.AreEqual(1, subject.Sources.SubscribableElements.Count);
+            Assert.AreEqual(source, subject.Sources.SubscribableElements[0]);
 
             subject.Sources.Remove(source);
 
-            Assert.IsEmpty(subject.Sources.ReadOnlyElements);
+            Assert.IsEmpty(subject.Sources.SubscribableElements);
 
             Object.DestroyImmediate(source);
         }
@@ -78,15 +78,15 @@ namespace Test.Zinnia.Process.Component
             subject.Sources.Add(source1);
             subject.Sources.Add(source2);
 
-            Assert.AreEqual(2, subject.Sources.ReadOnlyElements.Count);
+            Assert.AreEqual(2, subject.Sources.SubscribableElements.Count);
 
             subject.Sources.CurrentIndex = 0;
 
             subject.Sources.SetAtCurrentIndex(newSource1);
 
-            Assert.AreEqual(2, subject.Sources.ReadOnlyElements.Count);
-            Assert.AreEqual(newSource1, subject.Sources.ReadOnlyElements[0]);
-            Assert.AreEqual(source2, subject.Sources.ReadOnlyElements[1]);
+            Assert.AreEqual(2, subject.Sources.SubscribableElements.Count);
+            Assert.AreEqual(newSource1, subject.Sources.SubscribableElements[0]);
+            Assert.AreEqual(source2, subject.Sources.SubscribableElements[1]);
 
             Object.DestroyImmediate(source1);
             Object.DestroyImmediate(source2);
@@ -103,12 +103,12 @@ namespace Test.Zinnia.Process.Component
 
             subject.Sources.Add(source);
 
-            Assert.AreEqual(1, subject.Sources.ReadOnlyElements.Count);
-            Assert.AreEqual(source, subject.Sources.ReadOnlyElements[0]);
+            Assert.AreEqual(1, subject.Sources.SubscribableElements.Count);
+            Assert.AreEqual(source, subject.Sources.SubscribableElements[0]);
 
             subject.Sources.Clear(false);
 
-            Assert.IsEmpty(subject.Sources.ReadOnlyElements);
+            Assert.IsEmpty(subject.Sources.SubscribableElements);
 
             Object.DestroyImmediate(source);
         }
@@ -121,12 +121,12 @@ namespace Test.Zinnia.Process.Component
             subject.Targets = containingObject.AddComponent<GameObjectObservableList>();
             yield return null;
 
-            Assert.IsEmpty(subject.Targets.ReadOnlyElements);
+            Assert.IsEmpty(subject.Targets.SubscribableElements);
 
             subject.Targets.Add(target);
 
-            Assert.AreEqual(1, subject.Targets.ReadOnlyElements.Count);
-            Assert.AreEqual(target, subject.Targets.ReadOnlyElements[0]);
+            Assert.AreEqual(1, subject.Targets.SubscribableElements.Count);
+            Assert.AreEqual(target, subject.Targets.SubscribableElements[0]);
 
             Object.DestroyImmediate(target);
         }
@@ -140,12 +140,12 @@ namespace Test.Zinnia.Process.Component
 
             subject.Targets.Add(target);
 
-            Assert.AreEqual(1, subject.Targets.ReadOnlyElements.Count);
-            Assert.AreEqual(target, subject.Targets.ReadOnlyElements[0]);
+            Assert.AreEqual(1, subject.Targets.SubscribableElements.Count);
+            Assert.AreEqual(target, subject.Targets.SubscribableElements[0]);
 
             subject.Targets.Remove(target);
 
-            Assert.IsEmpty(subject.Targets.ReadOnlyElements);
+            Assert.IsEmpty(subject.Targets.SubscribableElements);
 
             Object.DestroyImmediate(target);
         }
@@ -162,15 +162,15 @@ namespace Test.Zinnia.Process.Component
             subject.Targets.Add(target1);
             subject.Targets.Add(target2);
 
-            Assert.AreEqual(2, subject.Targets.ReadOnlyElements.Count);
+            Assert.AreEqual(2, subject.Targets.SubscribableElements.Count);
 
             subject.Targets.CurrentIndex = 0;
 
             subject.Targets.SetAtCurrentIndex(newTarget1);
 
-            Assert.AreEqual(2, subject.Targets.ReadOnlyElements.Count);
-            Assert.AreEqual(newTarget1, subject.Targets.ReadOnlyElements[0]);
-            Assert.AreEqual(target2, subject.Targets.ReadOnlyElements[1]);
+            Assert.AreEqual(2, subject.Targets.SubscribableElements.Count);
+            Assert.AreEqual(newTarget1, subject.Targets.SubscribableElements[0]);
+            Assert.AreEqual(target2, subject.Targets.SubscribableElements[1]);
 
             Object.DestroyImmediate(target1);
             Object.DestroyImmediate(target2);
@@ -186,12 +186,12 @@ namespace Test.Zinnia.Process.Component
 
             subject.Targets.Add(target);
 
-            Assert.AreEqual(1, subject.Targets.ReadOnlyElements.Count);
-            Assert.AreEqual(target, subject.Targets.ReadOnlyElements[0]);
+            Assert.AreEqual(1, subject.Targets.SubscribableElements.Count);
+            Assert.AreEqual(target, subject.Targets.SubscribableElements[0]);
 
             subject.Targets.Clear(false);
 
-            Assert.IsEmpty(subject.Targets.ReadOnlyElements);
+            Assert.IsEmpty(subject.Targets.SubscribableElements);
 
             Object.DestroyImmediate(target);
         }

--- a/Tests/Editor/Tracking/Follow/ObjectFollowerTest.cs
+++ b/Tests/Editor/Tracking/Follow/ObjectFollowerTest.cs
@@ -38,10 +38,10 @@ namespace Test.Zinnia.Tracking.Follow
             subject.TargetOffsets = containingObject.AddComponent<GameObjectObservableList>();
             yield return null;
 
-            Assert.IsEmpty(subject.TargetOffsets.ReadOnlyElements);
+            Assert.IsEmpty(subject.TargetOffsets.SubscribableElements);
             subject.TargetOffsets.Add(offset);
-            Assert.AreEqual(1, subject.TargetOffsets.ReadOnlyElements.Count);
-            Assert.AreEqual(offset, subject.TargetOffsets.ReadOnlyElements[0]);
+            Assert.AreEqual(1, subject.TargetOffsets.SubscribableElements.Count);
+            Assert.AreEqual(offset, subject.TargetOffsets.SubscribableElements[0]);
             Object.DestroyImmediate(offset);
         }
 
@@ -53,11 +53,11 @@ namespace Test.Zinnia.Tracking.Follow
             yield return null;
 
             subject.TargetOffsets.Add(offset);
-            Assert.AreEqual(1, subject.TargetOffsets.ReadOnlyElements.Count);
-            Assert.AreEqual(offset, subject.TargetOffsets.ReadOnlyElements[0]);
+            Assert.AreEqual(1, subject.TargetOffsets.SubscribableElements.Count);
+            Assert.AreEqual(offset, subject.TargetOffsets.SubscribableElements[0]);
 
             subject.TargetOffsets.Remove(offset);
-            Assert.IsEmpty(subject.TargetOffsets.ReadOnlyElements);
+            Assert.IsEmpty(subject.TargetOffsets.SubscribableElements);
             Object.DestroyImmediate(offset);
         }
 
@@ -73,15 +73,15 @@ namespace Test.Zinnia.Tracking.Follow
 
             subject.TargetOffsets.Add(offset1);
             subject.TargetOffsets.Add(offset2);
-            Assert.AreEqual(2, subject.TargetOffsets.ReadOnlyElements.Count);
+            Assert.AreEqual(2, subject.TargetOffsets.SubscribableElements.Count);
 
             subject.TargetOffsets.CurrentIndex = 0;
 
             subject.TargetOffsets.SetAtCurrentIndex(newOffset1);
 
-            Assert.AreEqual(2, subject.TargetOffsets.ReadOnlyElements.Count);
-            Assert.AreEqual(newOffset1, subject.TargetOffsets.ReadOnlyElements[0]);
-            Assert.AreEqual(offset2, subject.TargetOffsets.ReadOnlyElements[1]);
+            Assert.AreEqual(2, subject.TargetOffsets.SubscribableElements.Count);
+            Assert.AreEqual(newOffset1, subject.TargetOffsets.SubscribableElements[0]);
+            Assert.AreEqual(offset2, subject.TargetOffsets.SubscribableElements[1]);
 
             Object.DestroyImmediate(offset1);
             Object.DestroyImmediate(offset2);
@@ -97,11 +97,11 @@ namespace Test.Zinnia.Tracking.Follow
             yield return null;
 
             subject.TargetOffsets.Add(offset);
-            Assert.AreEqual(1, subject.TargetOffsets.ReadOnlyElements.Count);
-            Assert.AreEqual(offset, subject.TargetOffsets.ReadOnlyElements[0]);
+            Assert.AreEqual(1, subject.TargetOffsets.SubscribableElements.Count);
+            Assert.AreEqual(offset, subject.TargetOffsets.SubscribableElements[0]);
 
             subject.TargetOffsets.Clear(false);
-            Assert.IsEmpty(subject.TargetOffsets.ReadOnlyElements);
+            Assert.IsEmpty(subject.TargetOffsets.SubscribableElements);
             Object.DestroyImmediate(offset);
         }
 


### PR DESCRIPTION
All usages of fields have now been switched to properties that are
serialized with Malimbe to create an appropriate backing field to
display in the Unity Inspector.

All uses of List collections have also been replaced with concrete
versions of the ObservableList, which makes it possible to track
changes occurring to the lists at runtime and provides a single
component that allows mutating the list via UnityEvents.

The BehaviourEnabledObserver has also been re-written to utilise a
Coroutine instead of using InvokeRepeating.

The ObservableList has also had a new ReadOnlyCollection added that
allows for receiving the List collection at any time before Start
is called, however this list is not suitable for using with the
subscribed events or creating any reactive process based on the
List contents.