### PR TITLE
feat(Cast): update fields to properties and lists to observable

### DIFF
--- a/Runtime/Cast/FixedLineCast.cs
+++ b/Runtime/Cast/FixedLineCast.cs
@@ -1,10 +1,10 @@
 namespace Zinnia.Cast
 {
-    using Malimbe.PropertySerializationAttribute;
-    /*using Malimbe.PropertySetterMethod;*/
-    /*using Malimbe.PropertyValidationMethod;*/
-    using Malimbe.XmlDocumentationAttribute;
     using UnityEngine;
+    using Malimbe.XmlDocumentationAttribute;
+    using Malimbe.PropertySerializationAttribute;
+    using Malimbe.MemberChangeMethod;
+    using Zinnia.Extension;
 
     /// <summary>
     /// Casts a straight line in the direction of the origin for a fixed length.
@@ -14,7 +14,7 @@ namespace Zinnia.Cast
         /// <summary>
         /// The current length of the cast.
         /// </summary>
-        [Serialized, /*Validated*/]
+        [Serialized]
         [field: DocumentedByXml]
         public float CurrentLength { get; set; } = 1f;
 
@@ -24,41 +24,47 @@ namespace Zinnia.Cast
         /// <param name="data">The data to extract the new current length from.</param>
         public virtual void SetCurrentLength(EventData data)
         {
-            TargetHit = data?.targetHit;
-            if (data?.points.Count >= 2)
+            TargetHit = data?.TargetHit;
+            if (data?.Points.Count >= 2)
             {
-                CurrentLength = Vector3.Distance(data.points[0], data.points[1]);
+                CurrentLength = Vector3.Distance(data.Points[0], data.Points[1]);
             }
         }
 
         /// <inheritdoc />
         protected override void GeneratePoints()
         {
-            Vector3 originPosition = origin.transform.position;
+            Vector3 originPosition = Origin.transform.position;
             points[0] = originPosition;
-            points[1] = originPosition + origin.transform.forward * CurrentLength;
+            points[1] = originPosition + Origin.transform.forward * CurrentLength;
         }
 
         /// <summary>
-        /// Handles changes to <see cref="StraightLineCast.MaximumLength"/>.
+        /// Retrieves <see cref="CurrentLength"/> clamped between `0f` and <see cref="StraightLineCast.MaximumLength"/>.
         /// </summary>
-        /// <param name="previousValue">The previous value.</param>
-        /// <param name="newValue">The new value.</param>
-        /*[CalledBySetter(nameof(MaximumLength))]*/
-        protected virtual void OnMaximumLengthChange(float previousValue, ref float newValue)
+        /// <returns>The clamped value.</returns>
+        protected virtual float GetClampedCurrentLength()
         {
-            CurrentLength = Mathf.Clamp(CurrentLength, 0f, newValue);
+            return Mathf.Clamp(CurrentLength, 0f, MaximumLength);
+        }
+
+        /// <inheritdoc />
+        protected override void OnAfterMaximumLengthChange()
+        {
+            CurrentLength = GetClampedCurrentLength();
         }
 
         /// <summary>
-        /// Handles changes to <see cref="CurrentLength"/>.
+        /// Called after <see cref="CurrentLength"/> has been changed.
         /// </summary>
-        /// <param name="previousValue">The previous value.</param>
-        /// <param name="newValue">The new value.</param>
-        /*[CalledBySetter(nameof(CurrentLength))]*/
-        protected virtual void OnCurrentLengthChange(float previousValue, ref float newValue)
+        [CalledAfterChangeOf(nameof(CurrentLength))]
+        protected virtual void OnAfterCurrentLengthChange()
         {
-            newValue = Mathf.Clamp(newValue, 0f, MaximumLength);
+            float clampedCurrentLength = GetClampedCurrentLength();
+            if (!CurrentLength.ApproxEquals(clampedCurrentLength))
+            {
+                CurrentLength = clampedCurrentLength;
+            }
         }
     }
 }

--- a/Runtime/Cast/ParabolicLineCast.cs
+++ b/Runtime/Cast/ParabolicLineCast.cs
@@ -1,7 +1,8 @@
 ﻿namespace Zinnia.Cast
 {
-    using Malimbe.XmlDocumentationAttribute;
     using UnityEngine;
+    using Malimbe.XmlDocumentationAttribute;
+    using Malimbe.PropertySerializationAttribute;
     using Zinnia.Utility;
 
     /// <summary>
@@ -12,35 +13,40 @@
         /// <summary>
         /// The maximum length of the projected cast. The x value is the length of the forward cast, the y value is the length of the downward cast.
         /// </summary>
-        [DocumentedByXml]
-        public Vector2 maximumLength = new Vector2(10f, float.PositiveInfinity);
+        [Serialized]
+        [field: DocumentedByXml]
+        public Vector2 MaximumLength { get; set; } = new Vector2(10f, float.PositiveInfinity);
         /// <summary>
         /// The maximum angle in degrees of the origin before the cast line height is restricted. A lower angle setting will prevent the cast being projected high into the sky and curving back down.
         /// </summary>
-        [Range(1, 100), DocumentedByXml]
-        public float heightLimitAngle = 100f;
+        [Serialized]
+        [field: DocumentedByXml, Range(1f, 100f)]
+        public float HeightLimitAngle { get; set; } = 100f;
         /// <summary>
         /// The number of points to generate on the parabolic line.
         /// </summary>
         /// <remarks>The higher the number, the more CPU intensive the point generation becomes.</remarks>
-        [DocumentedByXml]
-        public int segmentCount = 10;
+        [Serialized]
+        [field: DocumentedByXml]
+        public int SegmentCount { get; set; } = 10;
         /// <summary>
-        /// The number of points along the parabolic line to check for an early cast collision. Useful if the parabolic line is appearing to clip through locations. 0 won't make any checks and it will be capped at <see cref="segmentCount" />.
+        /// The number of points along the parabolic line to check for an early cast collision. Useful if the parabolic line is appearing to clip through locations. 0 won't make any checks and it will be capped at <see cref="SegmentCount" />.
         /// </summary>
         /// <remarks>The higher the number, the more CPU intensive the checks become.</remarks>
-        [DocumentedByXml]
-        public int collisionCheckFrequency;
+        [Serialized]
+        [field: DocumentedByXml]
+        public int CollisionCheckFrequency { get; set; }
         /// <summary>
         /// The amount of height offset to apply to the projected cast to generate a smoother line even when the cast is pointing straight.
         /// </summary>
-        [DocumentedByXml]
-        public float curveOffset = 1f;
+        [Serialized]
+        [field: DocumentedByXml]
+        public float CurveOffset { get; set; } = 1f;
 
         /// <summary>
         /// Used to move the points back and up a bit to prevent the cast clipping at the collision points.
         /// </summary>
-        protected const float ADJUSTMENT_OFFSET = 0.0001f;
+        protected const float AdjustmentOffset = 0.0001f;
 
         /// <inheritdoc />
         protected override void DoCastPoints()
@@ -56,18 +62,17 @@
         /// <returns>The collision point or the point being the furthest away on the cast line if nothing is hit.</returns>
         protected virtual Vector3 ProjectForward()
         {
-            float rotation = Vector3.Dot(Vector3.up, origin.transform.forward.normalized);
-            float length = maximumLength.x;
+            float rotation = Vector3.Dot(Vector3.up, Origin.transform.forward.normalized);
+            float length = MaximumLength.x;
 
-            if ((rotation * 100f) > heightLimitAngle)
+            if ((rotation * 100f) > HeightLimitAngle)
             {
-                float controllerRotationOffset = 1f - (rotation - heightLimitAngle / 100f);
-                length = maximumLength.x * controllerRotationOffset * controllerRotationOffset;
+                float controllerRotationOffset = 1f - (rotation - HeightLimitAngle / 100f);
+                length = MaximumLength.x * controllerRotationOffset * controllerRotationOffset;
             }
 
-            Ray ray = new Ray(origin.transform.position, origin.transform.forward);
-            RaycastHit hitData;
-            bool hasCollided = PhysicsCast.Raycast(physicsCast, ray, out hitData, length, Physics.IgnoreRaycastLayer);
+            Ray ray = new Ray(Origin.transform.position, Origin.transform.forward);
+            bool hasCollided = PhysicsCast.Raycast(PhysicsCast, ray, out RaycastHit hitData, length, Physics.IgnoreRaycastLayer);
 
             // Adjust the cast length if something is blocking it.
             if (hasCollided && hitData.distance < length)
@@ -76,7 +81,7 @@
             }
 
             // Use an offset to move the point back and up a bit to prevent the cast clipping at the collision point.
-            return ray.GetPoint(length - ADJUSTMENT_OFFSET) + (Vector3.up * ADJUSTMENT_OFFSET);
+            return ray.GetPoint(length - AdjustmentOffset) + (Vector3.up * AdjustmentOffset);
         }
 
         /// <summary>
@@ -88,9 +93,8 @@
         {
             Vector3 point = Vector3.zero;
             Ray ray = new Ray(downwardOrigin, Vector3.down);
-            RaycastHit hitData;
 
-            bool downRayHit = PhysicsCast.Raycast(physicsCast, ray, out hitData, maximumLength.y, Physics.IgnoreRaycastLayer);
+            bool downRayHit = PhysicsCast.Raycast(PhysicsCast, ray, out RaycastHit hitData, MaximumLength.y, Physics.IgnoreRaycastLayer);
 
             if (!downRayHit || (TargetHit?.collider != null && TargetHit.Value.collider != hitData.collider))
             {
@@ -116,10 +120,10 @@
         {
             GeneratePoints(forward, down);
 
-            collisionCheckFrequency = Mathf.Clamp(collisionCheckFrequency, 0, segmentCount);
-            int step = segmentCount / (collisionCheckFrequency > 0 ? collisionCheckFrequency : 1);
+            CollisionCheckFrequency = Mathf.Clamp(CollisionCheckFrequency, 0, SegmentCount);
+            int step = SegmentCount / (CollisionCheckFrequency > 0 ? CollisionCheckFrequency : 1);
 
-            for (int index = 0; index < segmentCount - step; index += step)
+            for (int index = 0; index < SegmentCount - step; index += step)
             {
                 Vector3 currentPoint = points[index];
                 Vector3 nextPoint = index + step < points.Count ? points[index + step] : points[points.Count - 1];
@@ -127,19 +131,18 @@
                 float nextPointDistance = Vector3.Distance(currentPoint, nextPoint);
 
                 Ray pointsRay = new Ray(currentPoint, nextPointDirection);
-                RaycastHit pointsHitData;
 
-                if (!PhysicsCast.Raycast(physicsCast, pointsRay, out pointsHitData, nextPointDistance, Physics.IgnoreRaycastLayer))
+                if (!PhysicsCast.Raycast(PhysicsCast, pointsRay, out RaycastHit pointsHitData, nextPointDistance, Physics.IgnoreRaycastLayer))
                 {
                     continue;
                 }
 
                 Vector3 collisionPoint = pointsRay.GetPoint(pointsHitData.distance);
                 Ray downwardRay = new Ray(collisionPoint + Vector3.up * 0.01f, Vector3.down);
-                RaycastHit downwardHitData;
 
-                if (!PhysicsCast.Raycast(physicsCast, downwardRay, out downwardHitData, float.PositiveInfinity, Physics.IgnoreRaycastLayer))
+                if (!PhysicsCast.Raycast(PhysicsCast, downwardRay, out RaycastHit downwardHitData, float.PositiveInfinity, Physics.IgnoreRaycastLayer))
                 {
+                    TargetHit = null;
                     continue;
                 }
 
@@ -165,14 +168,14 @@
         {
             Vector3[] curvePoints =
             {
-                origin.transform.position,
-                forward + new Vector3(0f, curveOffset, 0f),
+                Origin.transform.position,
+                forward + new Vector3(0f, CurveOffset, 0f),
                 down,
                 down
             };
 
             points.Clear();
-            points.AddRange(BezierCurveGenerator.GeneratePoints(segmentCount, curvePoints));
+            points.AddRange(BezierCurveGenerator.GeneratePoints(SegmentCount, curvePoints));
         }
     }
 }

--- a/Runtime/Cast/PhysicsCast.cs
+++ b/Runtime/Cast/PhysicsCast.cs
@@ -1,7 +1,8 @@
 ﻿namespace Zinnia.Cast
 {
-    using Malimbe.XmlDocumentationAttribute;
     using UnityEngine;
+    using Malimbe.XmlDocumentationAttribute;
+    using Malimbe.PropertySerializationAttribute;
 
     /// <summary>
     /// Allows customizing of Unity Physics casting within other scripts by applying settings at edit time.
@@ -11,13 +12,15 @@
         /// <summary>
         /// The layers to ignore when casting.
         /// </summary>
-        [DocumentedByXml]
-        public LayerMask layersToIgnore = Physics.IgnoreRaycastLayer;
+        [Serialized]
+        [field: DocumentedByXml]
+        public LayerMask LayersToIgnore { get; set; } = Physics.IgnoreRaycastLayer;
         /// <summary>
         /// Determines whether the cast will interact with trigger colliders.
         /// </summary>
-        [DocumentedByXml]
-        public QueryTriggerInteraction triggerInteraction = QueryTriggerInteraction.UseGlobal;
+        [Serialized]
+        [field: DocumentedByXml]
+        public QueryTriggerInteraction TriggerInteraction { get; set; } = QueryTriggerInteraction.UseGlobal;
 
         /// <summary>
         /// Generates a Raycast either from the given <see cref="PhysicsCast"/> object or a default <see cref="Physics.Raycast(Ray,out RaycastHit,float,int,QueryTriggerInteraction)"/>.
@@ -28,7 +31,7 @@
         /// <param name="length">The maximum length of the <see cref="Ray"/>.</param>
         /// <param name="ignoreLayers">A <see cref="LayerMask"/> of layers to ignore from the <see cref="Ray"/>.</param>
         /// <param name="affectTriggers">Determines the trigger interaction level of the <see cref="Ray"/>.</param>
-        /// <returns><see langword="true"/> if the <see cref="Ray"/> successfully collides with a valid <see cref="GameObject"/>.</returns>
+        /// <returns>Whether the <see cref="Ray"/> successfully collides with a valid <see cref="GameObject"/>.</returns>
         public static bool Raycast(PhysicsCast customCast, Ray ray, out RaycastHit hitData, float length, LayerMask ignoreLayers, QueryTriggerInteraction affectTriggers = QueryTriggerInteraction.UseGlobal)
         {
             if (customCast != null)
@@ -71,7 +74,7 @@
         /// <param name="hitData">The <see cref="RaycastHit"/> data.</param>
         /// <param name="ignoreLayers">A <see cref="LayerMask"/> of layers to ignore from the Linecast.</param>
         /// <param name="affectTriggers">Determines the trigger interaction level of the cast.</param>
-        /// <returns><see langword="true"/> if the Linecast successfully collides with a valid <see cref="GameObject"/>.</returns>
+        /// <returns>Whether the Linecast successfully collides with a valid <see cref="GameObject"/>.</returns>
         public static bool Linecast(PhysicsCast customCast, Vector3 startPosition, Vector3 endPosition, out RaycastHit hitData, LayerMask ignoreLayers, QueryTriggerInteraction affectTriggers = QueryTriggerInteraction.UseGlobal)
         {
             if (customCast != null)
@@ -95,7 +98,7 @@
         /// <param name="maxDistance">The max length of the sweep.</param>
         /// <param name="ignoreLayers">A <see cref="LayerMask"/> of layers to ignore from the SphereCast.</param>
         /// <param name="affectTriggers">Determines the trigger interaction level of the cast.</param>
-        /// <returns><see langword="true"/> if the SphereCast successfully collides with a valid <see cref="GameObject"/>.</returns>
+        /// <returns>Whether the SphereCast successfully collides with a valid <see cref="GameObject"/>.</returns>
         public static bool SphereCast(PhysicsCast customCast, Vector3 origin, float radius, Vector3 direction, out RaycastHit hitData, float maxDistance, LayerMask ignoreLayers, QueryTriggerInteraction affectTriggers = QueryTriggerInteraction.UseGlobal)
         {
             if (customCast != null)
@@ -143,7 +146,7 @@
         /// <param name="maxDistance">The max length of the sweep.</param>
         /// <param name="ignoreLayers">A <see cref="LayerMask"/> of layers to ignore from the CapsuleCast.</param>
         /// <param name="affectTriggers">Determines the trigger interaction level of the cast.</param>
-        /// <returns><see langword="true"/> if the CapsuleCast successfully collides with a valid <see cref="GameObject"/>.</returns>
+        /// <returns>Whether the CapsuleCast successfully collides with a valid <see cref="GameObject"/>.</returns>
         public static bool CapsuleCast(PhysicsCast customCast, Vector3 point1, Vector3 point2, float radius, Vector3 direction, out RaycastHit hitData, float maxDistance, LayerMask ignoreLayers, QueryTriggerInteraction affectTriggers = QueryTriggerInteraction.UseGlobal)
         {
             if (customCast != null)
@@ -192,7 +195,7 @@
         /// <param name="maxDistance">The max length of the cast.</param>
         /// <param name="ignoreLayers">A <see cref="LayerMask"/> of layers to ignore from the BoxCast.</param>
         /// <param name="affectTriggers">Determines the trigger interaction level of the cast.</param>
-        /// <returns><see langword="true"/> if the BoxCast successfully collides with a valid <see cref="GameObject"/>.</returns>
+        /// <returns>Whether the BoxCast successfully collides with a valid <see cref="GameObject"/>.</returns>
         public static bool BoxCast(PhysicsCast customCast, Vector3 center, Vector3 halfExtents, Vector3 direction, out RaycastHit hitData, Quaternion orientation, float maxDistance, LayerMask ignoreLayers, QueryTriggerInteraction affectTriggers = QueryTriggerInteraction.UseGlobal)
         {
             if (customCast != null)
@@ -235,10 +238,10 @@
         /// <param name="ray">The <see cref="Ray"/> to cast with.</param>
         /// <param name="hitData">The <see cref="RaycastHit"/> data.</param>
         /// <param name="length">The maximum length of the <see cref="Ray"/>.</param>
-        /// <returns><see langword="true"/> if the raycast successfully collides with a valid <see cref="GameObject"/>.</returns>
+        /// <returns>Whether the raycast successfully collides with a valid <see cref="GameObject"/>.</returns>
         public virtual bool CustomRaycast(Ray ray, out RaycastHit hitData, float length)
         {
-            return Physics.Raycast(ray, out hitData, length, ~layersToIgnore, triggerInteraction);
+            return Physics.Raycast(ray, out hitData, length, ~LayersToIgnore, TriggerInteraction);
         }
 
         /// <summary>
@@ -249,7 +252,7 @@
         /// <returns>A collection of collisions determined by the cast.</returns>
         public virtual RaycastHit[] CustomRaycastAll(Ray ray, float length)
         {
-            return Physics.RaycastAll(ray, length, ~layersToIgnore, triggerInteraction);
+            return Physics.RaycastAll(ray, length, ~LayersToIgnore, TriggerInteraction);
         }
 
         /// <summary>
@@ -258,10 +261,10 @@
         /// <param name="startPosition">The world position to start the linecast from.</param>
         /// <param name="endPosition">The world position to end the linecast at.</param>
         /// <param name="hitData">The <see cref="RaycastHit"/> data.</param>
-        /// <returns><see langword="true"/> if the linecast successfully collides with a valid <see cref="GameObject"/>.</returns>
+        /// <returns>Whether the linecast successfully collides with a valid <see cref="GameObject"/>.</returns>
         public virtual bool CustomLinecast(Vector3 startPosition, Vector3 endPosition, out RaycastHit hitData)
         {
-            return Physics.Linecast(startPosition, endPosition, out hitData, ~layersToIgnore, triggerInteraction);
+            return Physics.Linecast(startPosition, endPosition, out hitData, ~LayersToIgnore, TriggerInteraction);
         }
 
         /// <summary>
@@ -272,10 +275,10 @@
         /// <param name="direction">The direction into which to sweep the spherecast.</param>
         /// <param name="hitData">The <see cref="RaycastHit"/> data.</param>
         /// <param name="maxDistance">The max length of the sweep.</param>
-        /// <returns><see langword="true"/> if the spherecast successfully collides with a valid <see cref="GameObject"/>.</returns>
+        /// <returns>Whether the spherecast successfully collides with a valid <see cref="GameObject"/>.</returns>
         public virtual bool CustomSphereCast(Vector3 origin, float radius, Vector3 direction, out RaycastHit hitData, float maxDistance)
         {
-            return Physics.SphereCast(origin, radius, direction, out hitData, maxDistance, ~layersToIgnore, triggerInteraction);
+            return Physics.SphereCast(origin, radius, direction, out hitData, maxDistance, ~LayersToIgnore, TriggerInteraction);
         }
 
         /// <summary>
@@ -288,7 +291,7 @@
         /// <returns>A collection of collisions determined by the cast.</returns>
         public virtual RaycastHit[] CustomSphereCastAll(Vector3 origin, float radius, Vector3 direction, float maxDistance)
         {
-            return Physics.SphereCastAll(origin, radius, direction, maxDistance, ~layersToIgnore, triggerInteraction);
+            return Physics.SphereCastAll(origin, radius, direction, maxDistance, ~LayersToIgnore, TriggerInteraction);
         }
 
         /// <summary>
@@ -300,10 +303,10 @@
         /// <param name="direction">The direction into which to sweep the capsulecast.</param>
         /// <param name="hitData">The <see cref="RaycastHit"/> data.</param>
         /// <param name="maxDistance">The max length of the sweep.</param>
-        /// <returns><see langword="true"/> if the capsulecast successfully collides with a valid <see cref="GameObject"/>.</returns>
+        /// <returns>Whether the capsulecast successfully collides with a valid <see cref="GameObject"/>.</returns>
         public virtual bool CustomCapsuleCast(Vector3 point1, Vector3 point2, float radius, Vector3 direction, out RaycastHit hitData, float maxDistance)
         {
-            return Physics.CapsuleCast(point1, point2, radius, direction, out hitData, maxDistance, ~layersToIgnore, triggerInteraction);
+            return Physics.CapsuleCast(point1, point2, radius, direction, out hitData, maxDistance, ~LayersToIgnore, TriggerInteraction);
         }
 
         /// <summary>
@@ -317,7 +320,7 @@
         /// <returns>A collection of collisions determined by the cast.</returns>
         public virtual RaycastHit[] CustomCapsuleCastAll(Vector3 point1, Vector3 point2, float radius, Vector3 direction, float maxDistance)
         {
-            return Physics.CapsuleCastAll(point1, point2, radius, direction, maxDistance, ~layersToIgnore, triggerInteraction);
+            return Physics.CapsuleCastAll(point1, point2, radius, direction, maxDistance, ~LayersToIgnore, TriggerInteraction);
         }
 
         /// <summary>
@@ -329,10 +332,10 @@
         /// <param name="hitData">The <see cref="RaycastHit"/> data.</param>
         /// <param name="orientation">The rotation of the boxcast.</param>
         /// <param name="maxDistance">The max length of the boxcast.</param>
-        /// <returns><see langword="true"/> if the boxcast successfully collides with a valid <see cref="GameObject"/>.</returns>
+        /// <returns>Whether the boxcast successfully collides with a valid <see cref="GameObject"/>.</returns>
         public virtual bool CustomBoxCast(Vector3 center, Vector3 halfExtents, Vector3 direction, out RaycastHit hitData, Quaternion orientation, float maxDistance)
         {
-            return Physics.BoxCast(center, halfExtents, direction, out hitData, orientation, maxDistance, ~layersToIgnore, triggerInteraction);
+            return Physics.BoxCast(center, halfExtents, direction, out hitData, orientation, maxDistance, ~LayersToIgnore, TriggerInteraction);
         }
 
         /// <summary>
@@ -346,7 +349,7 @@
         /// <returns>A collection of collisions determined by the cast.</returns>
         public virtual RaycastHit[] CustomBoxCastAll(Vector3 center, Vector3 halfExtents, Vector3 direction, Quaternion orientation, float maxDistance)
         {
-            return Physics.BoxCastAll(center, halfExtents, direction, orientation, maxDistance, ~layersToIgnore, triggerInteraction);
+            return Physics.BoxCastAll(center, halfExtents, direction, orientation, maxDistance, ~LayersToIgnore, TriggerInteraction);
         }
     }
 }

--- a/Runtime/Cast/PointsCast.cs
+++ b/Runtime/Cast/PointsCast.cs
@@ -4,8 +4,10 @@
     using UnityEngine.Events;
     using System;
     using System.Collections.Generic;
-    using Malimbe.BehaviourStateRequirementMethod;
+    using Malimbe.MemberClearanceMethod;
     using Malimbe.XmlDocumentationAttribute;
+    using Malimbe.PropertySerializationAttribute;
+    using Malimbe.BehaviourStateRequirementMethod;
     using Zinnia.Extension;
     using Zinnia.Process;
     using Zinnia.Rule;
@@ -24,23 +26,24 @@
             /// <summary>
             /// The result of the most recent cast. <see langword="null"/> when the cast didn't hit anything.
             /// </summary>
-            [DocumentedByXml]
-            public RaycastHit? targetHit;
+            [Serialized]
+            [field: DocumentedByXml]
+            public RaycastHit? TargetHit { get; set; }
+
             /// <summary>
             /// The points along the the most recent cast.
             /// </summary>
-            [DocumentedByXml]
-            public IReadOnlyList<Vector3> points;
+            public IReadOnlyList<Vector3> Points { get; set; }
 
             public EventData Set(EventData source)
             {
-                return Set(source.targetHit, source.points);
+                return Set(source.TargetHit, source.Points);
             }
 
             public EventData Set(RaycastHit? targetHit, IReadOnlyList<Vector3> points)
             {
-                this.targetHit = targetHit;
-                this.points = points;
+                TargetHit = targetHit;
+                Points = points;
                 return this;
             }
 
@@ -61,18 +64,21 @@
         /// <summary>
         /// The origin point for the cast.
         /// </summary>
-        [DocumentedByXml]
-        public GameObject origin;
+        [Serialized, Cleared]
+        [field: DocumentedByXml]
+        public GameObject Origin { get; set; }
         /// <summary>
         /// Allows to optionally affect the cast.
         /// </summary>
-        [DocumentedByXml]
-        public PhysicsCast physicsCast;
+        [Serialized, Cleared]
+        [field: DocumentedByXml]
+        public PhysicsCast PhysicsCast { get; set; }
         /// <summary>
         /// Allows to optionally determine targets based on the set rules.
         /// </summary>
-        [DocumentedByXml]
-        public RuleContainer targetValidity;
+        [Serialized, Cleared]
+        [field: DocumentedByXml]
+        public RuleContainer TargetValidity { get; set; }
 
         /// <summary>
         /// Emitted whenever the cast result changes.
@@ -81,7 +87,7 @@
         public UnityEvent ResultsChanged = new UnityEvent();
 
         /// <summary>
-        /// The result of the most recent cast. <see langword="null"/> when the cast didn't hit anything or an invalid target according to <see cref="targetValidity"/>.
+        /// The result of the most recent cast. <see langword="null"/> when the cast didn't hit anything or an invalid target according to <see cref="TargetValidity"/>.
         /// </summary>
         public RaycastHit? TargetHit
         {
@@ -91,19 +97,27 @@
             }
             protected set
             {
-                targetHit = (value != null && targetValidity.Accepts(value.Value.transform.gameObject) ? value : null);
+                targetHit = value != null && TargetValidity.Accepts(value.Value.transform.gameObject) ? value : null;
             }
         }
+        /// <summary>
+        /// The data held for a valid raycast hit.
+        /// </summary>
+        private RaycastHit? targetHit;
 
         /// <summary>
         /// The points along the the most recent cast.
         /// </summary>
         public IReadOnlyList<Vector3> Points => points;
 
+        /// <summary>
+        /// The points along the the most recent cast.
+        /// </summary>
         protected readonly List<Vector3> points = new List<Vector3>();
+        /// <summary>
+        /// The data to emit with an event.
+        /// </summary>
         protected readonly EventData eventData = new EventData();
-
-        private RaycastHit? targetHit;
 
         /// <summary>
         /// Casts and creates points along the cast.
@@ -111,7 +125,7 @@
         [RequiresBehaviourState]
         public virtual void CastPoints()
         {
-            if (origin == null)
+            if (Origin == null)
             {
                 return;
             }

--- a/Runtime/Cast/StraightLineCast.cs
+++ b/Runtime/Cast/StraightLineCast.cs
@@ -2,8 +2,8 @@
 {
     using UnityEngine;
     using Malimbe.PropertySerializationAttribute;
-    /*using Malimbe.PropertyValidationMethod;*/
     using Malimbe.XmlDocumentationAttribute;
+    using Malimbe.MemberChangeMethod;
 
     /// <summary>
     /// Casts a straight line and creates points at the origin and target.
@@ -13,7 +13,7 @@
         /// <summary>
         /// The maximum length to cast.
         /// </summary>
-        [Serialized, /*Validated*/]
+        [Serialized]
         [field: DocumentedByXml]
         public float MaximumLength { get; set; } = 100f;
 
@@ -40,15 +40,21 @@
         /// </summary>
         protected virtual void GeneratePoints()
         {
-            Vector3 originPosition = origin.transform.position;
-            Vector3 originForward = origin.transform.forward;
+            Vector3 originPosition = Origin.transform.position;
+            Vector3 originForward = Origin.transform.forward;
 
             Ray ray = new Ray(originPosition, originForward);
-            bool hasCollided = PhysicsCast.Raycast(physicsCast, ray, out RaycastHit hitData, MaximumLength, Physics.IgnoreRaycastLayer);
+            bool hasCollided = PhysicsCast.Raycast(PhysicsCast, ray, out RaycastHit hitData, MaximumLength, Physics.IgnoreRaycastLayer);
             TargetHit = hasCollided ? hitData : (RaycastHit?)null;
 
             points[0] = originPosition;
             points[1] = hasCollided ? hitData.point : originPosition + originForward * MaximumLength;
         }
+
+        /// <summary>
+        /// Called after <see cref="MaximumLength"/> has been changed.
+        /// </summary>
+        [CalledAfterChangeOf(nameof(MaximumLength))]
+        protected virtual void OnAfterMaximumLengthChange() { }
     }
 }

--- a/Runtime/Pointer/ObjectPointer.cs
+++ b/Runtime/Pointer/ObjectPointer.cs
@@ -311,10 +311,10 @@
             if (IsVisible)
             {
                 previousPointsCastData.Set(activePointsCastData);
-                if (data.targetHit != null)
+                if (data.TargetHit != null)
                 {
-                    Transform targetTransform = data.targetHit.Value.transform;
-                    if (targetTransform != null && targetTransform != activePointsCastData?.targetHit?.transform)
+                    Transform targetTransform = data.TargetHit.Value.transform;
+                    if (targetTransform != null && targetTransform != activePointsCastData?.TargetHit?.transform)
                     {
                         TryEmitExit(previousPointsCastData);
                         Entered?.Invoke(GetEventData(data));
@@ -367,7 +367,7 @@
         /// </summary>
         protected virtual void UpdateRenderData()
         {
-            pointsData.Points = (activePointsCastData.points ?? Array.Empty<Vector3>());
+            pointsData.Points = (activePointsCastData.Points ?? Array.Empty<Vector3>());
             pointsData.StartPoint = GetElementRepresentation(origin);
             pointsData.RepeatedSegmentPoint = GetElementRepresentation(repeatedSegment);
             pointsData.EndPoint = GetElementRepresentation(destination);
@@ -413,7 +413,7 @@
         /// <param name="data">The current points cast data.</param>
         protected virtual void TryEmitExit(PointsCast.EventData data)
         {
-            if (activePointsCastData.targetHit?.transform != null)
+            if (activePointsCastData.TargetHit?.transform != null)
             {
                 Exited?.Invoke(GetEventData(data));
                 IsHovering = false;
@@ -450,7 +450,7 @@
         /// <returns>A <see cref="GameObject"/> to represent <paramref name="element"/>.</returns>
         protected virtual GameObject GetElementRepresentation(Element element)
         {
-            bool isValid = (activePointsCastData.targetHit != null);
+            bool isValid = (activePointsCastData.TargetHit != null);
 
             switch (element.visibility)
             {
@@ -490,12 +490,12 @@
             Transform pointerTransform = transform;
 
             eventData.Transform = pointerTransform;
-            eventData.PositionOverride = validDestinationTransform == null ? data.targetHit?.point : validDestinationTransform.position;
+            eventData.PositionOverride = validDestinationTransform == null ? data.TargetHit?.point : validDestinationTransform.position;
             eventData.RotationOverride = validDestinationTransform == null ? Quaternion.identity : validDestinationTransform.localRotation;
             eventData.ScaleOverride = validDestinationTransform == null ? Vector3.one : validDestinationTransform.lossyScale;
             eventData.Origin = pointerTransform.position;
             eventData.Direction = pointerTransform.forward;
-            eventData.CollisionData = data?.targetHit ?? default;
+            eventData.CollisionData = data?.TargetHit ?? default;
             return eventData.Set(ActivationState, IsHovering, HoverDuration, data);
         }
     }

--- a/Runtime/Tracking/Modification/PointNormalRotator.cs
+++ b/Runtime/Tracking/Modification/PointNormalRotator.cs
@@ -26,12 +26,12 @@
         [RequiresBehaviourState]
         public virtual void HandleData(PointsCast.EventData data)
         {
-            if (Target == null || data.targetHit == null)
+            if (Target == null || data.TargetHit == null)
             {
                 return;
             }
 
-            Target.transform.rotation = Quaternion.FromToRotation(Vector3.up, data.targetHit.Value.normal);
+            Target.transform.rotation = Quaternion.FromToRotation(Vector3.up, data.TargetHit.Value.normal);
         }
     }
 }

--- a/Tests/Editor/Cast/FixedLineCastTest.cs
+++ b/Tests/Editor/Cast/FixedLineCastTest.cs
@@ -21,7 +21,6 @@ namespace Test.Zinnia.Cast
         [TearDown]
         public void TearDown()
         {
-            Object.DestroyImmediate(subject);
             Object.DestroyImmediate(containingObject);
         }
 
@@ -30,7 +29,7 @@ namespace Test.Zinnia.Cast
         {
             UnityEventListenerMock castResultsChangedMock = new UnityEventListenerMock();
             subject.ResultsChanged.AddListener(castResultsChangedMock.Listen);
-            subject.origin = subject.gameObject;
+            subject.Origin = subject.gameObject;
             subject.CurrentLength = 10f;
 
             subject.ManualOnEnable();

--- a/Tests/Editor/Cast/ParabolicLineCastTest.cs
+++ b/Tests/Editor/Cast/ParabolicLineCastTest.cs
@@ -5,6 +5,8 @@ using Zinnia.Data.Collection;
 namespace Test.Zinnia.Cast
 {
     using UnityEngine;
+    using UnityEngine.TestTools;
+    using System.Collections;
     using NUnit.Framework;
     using Test.Zinnia.Utility.Mock;
     using Test.Zinnia.Utility.Stub;
@@ -27,7 +29,6 @@ namespace Test.Zinnia.Cast
         [TearDown]
         public void TearDown()
         {
-            Object.DestroyImmediate(subject);
             Object.DestroyImmediate(containingObject);
             Object.DestroyImmediate(validSurface);
             Physics.autoSimulation = true;
@@ -38,12 +39,12 @@ namespace Test.Zinnia.Cast
         {
             UnityEventListenerMock castResultsChangedMock = new UnityEventListenerMock();
             subject.ResultsChanged.AddListener(castResultsChangedMock.Listen);
-            subject.origin = subject.gameObject;
+            subject.Origin = subject.gameObject;
 
             validSurface.transform.position = Vector3.forward * 5f + Vector3.down * 4f;
 
-            subject.maximumLength = new Vector2(5f, 5f);
-            subject.segmentCount = 5;
+            subject.MaximumLength = new Vector2(5f, 5f);
+            subject.SegmentCount = 5;
 
             Physics.Simulate(Time.fixedDeltaTime);
             subject.Process();
@@ -71,12 +72,12 @@ namespace Test.Zinnia.Cast
         {
             UnityEventListenerMock castResultsChangedMock = new UnityEventListenerMock();
             subject.ResultsChanged.AddListener(castResultsChangedMock.Listen);
-            subject.origin = subject.gameObject;
+            subject.Origin = subject.gameObject;
 
             validSurface.transform.position = Vector3.forward * 5f + Vector3.down * 4f;
 
-            subject.maximumLength = new Vector2(2f, 5f);
-            subject.segmentCount = 5;
+            subject.MaximumLength = new Vector2(2f, 5f);
+            subject.SegmentCount = 5;
 
             Physics.Simulate(Time.fixedDeltaTime);
             subject.Process();
@@ -104,12 +105,12 @@ namespace Test.Zinnia.Cast
         {
             UnityEventListenerMock castResultsChangedMock = new UnityEventListenerMock();
             subject.ResultsChanged.AddListener(castResultsChangedMock.Listen);
-            subject.origin = subject.gameObject;
+            subject.Origin = subject.gameObject;
 
             validSurface.transform.position = Vector3.forward * 5f + Vector3.down * 4f;
 
-            subject.maximumLength = new Vector2(5f, 2f);
-            subject.segmentCount = 5;
+            subject.MaximumLength = new Vector2(5f, 2f);
+            subject.SegmentCount = 5;
 
             Physics.Simulate(Time.fixedDeltaTime);
             subject.Process();
@@ -132,12 +133,12 @@ namespace Test.Zinnia.Cast
             Assert.IsTrue(castResultsChangedMock.Received);
         }
 
-        [Test]
-        public void CastPointsInvalidTarget()
+        [UnityTest]
+        public IEnumerator CastPointsInvalidTarget()
         {
             UnityEventListenerMock castResultsChangedMock = new UnityEventListenerMock();
             subject.ResultsChanged.AddListener(castResultsChangedMock.Listen);
-            subject.origin = subject.gameObject;
+            subject.Origin = subject.gameObject;
 
             validSurface.transform.position = Vector3.forward * 5f + Vector3.down * 4f;
             validSurface.AddComponent<RuleStub>();
@@ -146,18 +147,19 @@ namespace Test.Zinnia.Cast
             SerializableTypeComponentObservableList rules = containingObject.AddComponent<SerializableTypeComponentObservableList>();
             anyComponentTypeRule.ComponentTypes = rules;
             rules.Add(typeof(RuleStub));
+            yield return null;
 
             negationRule.Rule = new RuleContainer
             {
                 Interface = anyComponentTypeRule
             };
-            subject.targetValidity = new RuleContainer
+            subject.TargetValidity = new RuleContainer
             {
                 Interface = negationRule
             };
 
-            subject.maximumLength = new Vector2(5f, 5f);
-            subject.segmentCount = 5;
+            subject.MaximumLength = new Vector2(5f, 5f);
+            subject.SegmentCount = 5;
 
             Physics.Simulate(Time.fixedDeltaTime);
             subject.Process();
@@ -185,12 +187,12 @@ namespace Test.Zinnia.Cast
         {
             UnityEventListenerMock castResultsChangedMock = new UnityEventListenerMock();
             subject.ResultsChanged.AddListener(castResultsChangedMock.Listen);
-            subject.origin = subject.gameObject;
+            subject.Origin = subject.gameObject;
 
             validSurface.transform.position = Vector3.forward * 5f + Vector3.down * 4f;
 
-            subject.maximumLength = new Vector2(5f, 5f);
-            subject.segmentCount = 5;
+            subject.MaximumLength = new Vector2(5f, 5f);
+            subject.SegmentCount = 5;
             subject.gameObject.SetActive(false);
 
             Physics.Simulate(Time.fixedDeltaTime);
@@ -206,12 +208,12 @@ namespace Test.Zinnia.Cast
         {
             UnityEventListenerMock castResultsChangedMock = new UnityEventListenerMock();
             subject.ResultsChanged.AddListener(castResultsChangedMock.Listen);
-            subject.origin = subject.gameObject;
+            subject.Origin = subject.gameObject;
 
             validSurface.transform.position = Vector3.forward * 5f + Vector3.down * 4f;
 
-            subject.maximumLength = new Vector2(5f, 5f);
-            subject.segmentCount = 5;
+            subject.MaximumLength = new Vector2(5f, 5f);
+            subject.SegmentCount = 5;
             subject.enabled = false;
 
             Physics.Simulate(Time.fixedDeltaTime);

--- a/Tests/Editor/Cast/StraightLineCastTest.cs
+++ b/Tests/Editor/Cast/StraightLineCastTest.cs
@@ -5,6 +5,8 @@ using Zinnia.Data.Collection;
 namespace Test.Zinnia.Cast
 {
     using UnityEngine;
+    using UnityEngine.TestTools;
+    using System.Collections;
     using NUnit.Framework;
     using Test.Zinnia.Utility.Mock;
     using Test.Zinnia.Utility.Stub;
@@ -27,7 +29,6 @@ namespace Test.Zinnia.Cast
         [TearDown]
         public void TearDown()
         {
-            Object.DestroyImmediate(subject);
             Object.DestroyImmediate(containingObject);
             Object.DestroyImmediate(validSurface);
             Physics.autoSimulation = true;
@@ -38,7 +39,7 @@ namespace Test.Zinnia.Cast
         {
             UnityEventListenerMock castResultsChangedMock = new UnityEventListenerMock();
             subject.ResultsChanged.AddListener(castResultsChangedMock.Listen);
-            subject.origin = subject.gameObject;
+            subject.Origin = subject.gameObject;
 
             validSurface.transform.position = Vector3.forward * 5f;
 
@@ -60,7 +61,7 @@ namespace Test.Zinnia.Cast
         {
             UnityEventListenerMock castResultsChangedMock = new UnityEventListenerMock();
             subject.ResultsChanged.AddListener(castResultsChangedMock.Listen);
-            subject.origin = subject.gameObject;
+            subject.Origin = subject.gameObject;
 
             validSurface.transform.position = Vector3.forward * 5f;
             subject.MaximumLength = validSurface.transform.position.z / 2f;
@@ -78,12 +79,12 @@ namespace Test.Zinnia.Cast
             Assert.IsTrue(castResultsChangedMock.Received);
         }
 
-        [Test]
-        public void CastPointsInvalidTarget()
+        [UnityTest]
+        public IEnumerator CastPointsInvalidTarget()
         {
             UnityEventListenerMock castResultsChangedMock = new UnityEventListenerMock();
             subject.ResultsChanged.AddListener(castResultsChangedMock.Listen);
-            subject.origin = subject.gameObject;
+            subject.Origin = subject.gameObject;
 
             validSurface.transform.position = Vector3.forward * 5f;
             validSurface.AddComponent<RuleStub>();
@@ -92,12 +93,13 @@ namespace Test.Zinnia.Cast
             SerializableTypeComponentObservableList rules = containingObject.AddComponent<SerializableTypeComponentObservableList>();
             anyComponentTypeRule.ComponentTypes = rules;
             rules.Add(typeof(RuleStub));
+            yield return null;
 
             negationRule.Rule = new RuleContainer
             {
                 Interface = anyComponentTypeRule
             };
-            subject.targetValidity = new RuleContainer
+            subject.TargetValidity = new RuleContainer
             {
                 Interface = negationRule
             };
@@ -120,7 +122,7 @@ namespace Test.Zinnia.Cast
         {
             UnityEventListenerMock castResultsChangedMock = new UnityEventListenerMock();
             subject.ResultsChanged.AddListener(castResultsChangedMock.Listen);
-            subject.origin = subject.gameObject;
+            subject.Origin = subject.gameObject;
 
             validSurface.transform.position = Vector3.forward * 5f;
 
@@ -140,7 +142,7 @@ namespace Test.Zinnia.Cast
         {
             UnityEventListenerMock castResultsChangedMock = new UnityEventListenerMock();
             subject.ResultsChanged.AddListener(castResultsChangedMock.Listen);
-            subject.origin = subject.gameObject;
+            subject.Origin = subject.gameObject;
 
             validSurface.transform.position = Vector3.forward * 5f;
 

--- a/Tests/Editor/Pointer/ObjectPointerTest.cs
+++ b/Tests/Editor/Pointer/ObjectPointerTest.cs
@@ -797,15 +797,15 @@ namespace Test.Zinnia.Pointer
                 }
                 return new PointsCast.EventData()
                 {
-                    points = points,
-                    targetHit = hit
+                    Points = points,
+                    TargetHit = hit
                 };
             }
             else
             {
                 return new PointsCast.EventData()
                 {
-                    points = points
+                    Points = points
                 };
             }
         }

--- a/Tests/Editor/Tracking/Modification/PointNormalRotatorTest.cs
+++ b/Tests/Editor/Tracking/Modification/PointNormalRotatorTest.cs
@@ -41,7 +41,7 @@ namespace Test.Zinnia.Tracking.Modification
 
             PointsCast.EventData data = new PointsCast.EventData
             {
-                targetHit = cast
+                TargetHit = cast
             };
 
             subject.HandleData(data);
@@ -67,7 +67,7 @@ namespace Test.Zinnia.Tracking.Modification
 
             PointsCast.EventData data = new PointsCast.EventData
             {
-                targetHit = cast
+                TargetHit = cast
             };
 
             subject.enabled = false;


### PR DESCRIPTION
All usages of fields have now been switched to properties that are
serialized with Malimbe to create an appropriate backing field to
display in the Unity Inspector.

All uses of List collections have also been replaced with concrete
versions of the ObservableList, which makes it possible to track
changes occurring to the lists at runtime and provides a single
component that allows mutating the list via UnityEvents.