### PR TITLE
feat(Association): update fields to properties and lists to observable

### DIFF
--- a/Runtime/Association/Collection.meta
+++ b/Runtime/Association/Collection.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1e7a334c502e1e14bad6ad0b5adaf4d3
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Association/Collection/GameObjectsAssociationObservableList.cs
+++ b/Runtime/Association/Collection/GameObjectsAssociationObservableList.cs
@@ -1,0 +1,21 @@
+﻿namespace Zinnia.Association.Collection
+{
+    using UnityEngine.Events;
+    using System;
+    using System.Collections.Generic;
+    using Zinnia.Data.Collection;
+
+    /// <summary>
+    /// Allows observing changes to a <see cref="List{T}"/> of <see cref="GameObjectsAssociation"/>s.
+    /// </summary>
+    public class GameObjectsAssociationObservableList : DefaultObservableList<GameObjectsAssociation, GameObjectsAssociationObservableList.UnityEvent>
+    {
+        /// <summary>
+        /// Defines the event with the <see cref="GameObjectsAssociation"/>.
+        /// </summary>
+        [Serializable]
+        public class UnityEvent : UnityEvent<GameObjectsAssociation>
+        {
+        }
+    }
+}

--- a/Runtime/Association/Collection/GameObjectsAssociationObservableList.cs.meta
+++ b/Runtime/Association/Collection/GameObjectsAssociationObservableList.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 779e9557f9c8dd44cad15352425bc739
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Association/GameObjectsAssociation.cs
+++ b/Runtime/Association/GameObjectsAssociation.cs
@@ -1,8 +1,9 @@
 ﻿namespace Zinnia.Association
 {
     using UnityEngine;
-    using System.Collections.Generic;
     using Malimbe.XmlDocumentationAttribute;
+    using Malimbe.PropertySerializationAttribute;
+    using Zinnia.Data.Collection;
 
     /// <summary>
     /// Holds <see cref="GameObject"/>s to (de)activate.
@@ -12,11 +13,12 @@
         /// <summary>
         /// The <see cref="GameObject"/>s to (de)activate.
         /// </summary>
-        [DocumentedByXml]
-        public List<GameObject> gameObjects = new List<GameObject>();
+        [Serialized]
+        [field: DocumentedByXml]
+        public GameObjectObservableList GameObjects { get; set; }
 
         /// <summary>
-        /// Whether the <see cref="gameObjects"/> should be activated.
+        /// Whether the <see cref="GameObjects"/> should be activated.
         /// </summary>
         /// <returns></returns>
         public abstract bool ShouldBeActive();

--- a/Runtime/Association/GameObjectsAssociationActivator.cs
+++ b/Runtime/Association/GameObjectsAssociationActivator.cs
@@ -1,12 +1,11 @@
 ﻿namespace Zinnia.Association
 {
     using UnityEngine;
-    using System.Collections.Generic;
-    using Malimbe.PropertySerializationAttribute;
-    /*using Malimbe.PropertySetterMethod;*/
-    /*using Malimbe.PropertyValidationMethod;*/
+    using Malimbe.MemberChangeMethod;
     using Malimbe.XmlDocumentationAttribute;
+    using Malimbe.PropertySerializationAttribute;
     using Zinnia.Process;
+    using Zinnia.Association.Collection;
 
     /// <summary>
     /// (De)activates <see cref="GameObjectsAssociation"/>s.
@@ -16,9 +15,9 @@
         /// <summary>
         /// The associations in order they will be activated if they match the currently expected state.
         /// </summary>
-        [Serialized, /*Validated*/]
+        [Serialized]
         [field: DocumentedByXml]
-        public List<GameObjectsAssociation> Associations { get; set; } = new List<GameObjectsAssociation>();
+        public GameObjectsAssociationObservableList Associations { get; set; }
 
         /// <summary>
         /// The currently activated association, or <see langword="null"/> if no association is activated.
@@ -31,7 +30,7 @@
         public virtual void Activate()
         {
             GameObjectsAssociation desiredAssociation = null;
-            foreach (GameObjectsAssociation association in Associations)
+            foreach (GameObjectsAssociation association in Associations.NonSubscribableElements)
             {
                 if (association.ShouldBeActive())
                 {
@@ -47,20 +46,20 @@
 
             CurrentAssociation = desiredAssociation;
 
-            foreach (GameObjectsAssociation association in Associations)
+            foreach (GameObjectsAssociation association in Associations.NonSubscribableElements)
             {
                 if (association == desiredAssociation)
                 {
                     continue;
                 }
 
-                foreach (GameObject associatedObject in association.gameObjects)
+                foreach (GameObject associatedObject in association.GameObjects.NonSubscribableElements)
                 {
                     associatedObject.SetActive(false);
                 }
             }
 
-            foreach (GameObject associatedObject in desiredAssociation.gameObjects)
+            foreach (GameObject associatedObject in desiredAssociation.GameObjects.NonSubscribableElements)
             {
                 associatedObject.SetActive(true);
             }
@@ -74,6 +73,9 @@
             Deactivate(Associations);
         }
 
+        /// <summary>
+        /// Calls <see cref="Activate"/> on the specified moment.
+        /// </summary>
         public void Process()
         {
             Activate();
@@ -81,9 +83,9 @@
 
         protected virtual void Awake()
         {
-            foreach (GameObjectsAssociation association in Associations)
+            foreach (GameObjectsAssociation association in Associations.NonSubscribableElements)
             {
-                foreach (GameObject associatedObject in association.gameObjects)
+                foreach (GameObject associatedObject in association.GameObjects.NonSubscribableElements)
                 {
                     if (associatedObject.activeInHierarchy)
                     {
@@ -108,11 +110,11 @@
         /// Deactivates the association that is currently activated and all other known associations.
         /// </summary>
         /// <param name="associations">The associations to deactivate.</param>
-        protected virtual void Deactivate(List<GameObjectsAssociation> associations)
+        protected virtual void Deactivate(GameObjectsAssociationObservableList associations)
         {
-            foreach (GameObjectsAssociation association in associations)
+            foreach (GameObjectsAssociation association in associations.NonSubscribableElements)
             {
-                foreach (GameObject associatedObject in association.gameObjects)
+                foreach (GameObject associatedObject in association.GameObjects.NonSubscribableElements)
                 {
                     associatedObject.SetActive(false);
                 }
@@ -120,7 +122,7 @@
 
             if (CurrentAssociation != null)
             {
-                foreach (GameObject associatedObject in CurrentAssociation.gameObjects)
+                foreach (GameObject associatedObject in CurrentAssociation.GameObjects.NonSubscribableElements)
                 {
                     associatedObject.SetActive(false);
                 }
@@ -130,14 +132,20 @@
         }
 
         /// <summary>
-        /// Handles changes to <see cref="Associations"/>.
+        /// Called before <see cref="Associations"/> has been changed.
         /// </summary>
-        /// <param name="previousValue">The previous value.</param>
-        /// <param name="newValue">The new value.</param>
-        /*[CalledBySetter(nameof(Associations))]*/
-        protected virtual void OnAssociationsChange(List<GameObjectsAssociation> previousValue, ref List<GameObjectsAssociation> newValue)
+        [CalledBeforeChangeOf(nameof(Associations))]
+        protected virtual void OnBeforeAssociationsChange()
         {
-            Deactivate(previousValue);
+            Deactivate(Associations);
+        }
+
+        /// <summary>
+        /// Called after <see cref="Associations"/> has been changed.
+        /// </summary>
+        [CalledAfterChangeOf(nameof(Associations))]
+        protected virtual void OnAfterAssociationsChange()
+        {
             Activate();
         }
     }

--- a/Runtime/Association/LoadedXrDeviceAssociation.cs
+++ b/Runtime/Association/LoadedXrDeviceAssociation.cs
@@ -4,6 +4,7 @@
     using UnityEngine.XR;
     using System.Text.RegularExpressions;
     using Malimbe.XmlDocumentationAttribute;
+    using Malimbe.PropertySerializationAttribute;
 
     /// <summary>
     /// Holds <see cref="GameObject"/>s to (de)activate based on the loaded XR device's name.
@@ -13,13 +14,14 @@
         /// <summary>
         /// A regular expression to match the name of the XR device that needs to be loaded.
         /// </summary>
-        [DocumentedByXml]
-        public string xrDeviceNamePattern;
+        [Serialized]
+        [field: DocumentedByXml]
+        public string XrDeviceNamePattern { get; set; }
 
         /// <inheritdoc/>
         public override bool ShouldBeActive()
         {
-            return Regex.IsMatch(XRSettings.loadedDeviceName, xrDeviceNamePattern);
+            return Regex.IsMatch(XRSettings.loadedDeviceName, XrDeviceNamePattern);
         }
     }
 }

--- a/Tests/Editor/Association/GameObjectsAssociationActivatorTest.cs
+++ b/Tests/Editor/Association/GameObjectsAssociationActivatorTest.cs
@@ -1,4 +1,6 @@
 ﻿using Zinnia.Association;
+using Zinnia.Association.Collection;
+using Zinnia.Data.Collection;
 
 namespace Test.Zinnia.Association
 {
@@ -11,27 +13,31 @@ namespace Test.Zinnia.Association
     {
         private GameObject containingObject;
         private GameObjectsAssociationActivatorMock subject;
+        private GameObjectsAssociationObservableList associations;
 
         [SetUp]
         public void SetUp()
         {
             containingObject = new GameObject();
+            containingObject.SetActive(false);
             subject = containingObject.AddComponent<GameObjectsAssociationActivatorMock>();
+            associations = containingObject.AddComponent<GameObjectsAssociationObservableList>();
+            subject.Associations = associations;
+            containingObject.SetActive(true);
         }
 
         [TearDown]
         public void TearDown()
         {
-            foreach (GameObjectsAssociation association in subject.Associations)
+            foreach (GameObjectsAssociation association in subject.Associations.NonSubscribableElements)
             {
-                foreach (GameObject associatedObject in association.gameObjects)
+                foreach (GameObject associatedObject in association.GameObjects.NonSubscribableElements)
                 {
-                    Object.DestroyImmediate(associatedObject);
+                    Object.Destroy(associatedObject);
                 }
             }
 
-            Object.DestroyImmediate(subject);
-            Object.DestroyImmediate(containingObject);
+            Object.Destroy(containingObject);
         }
 
         [Test]
@@ -49,7 +55,8 @@ namespace Test.Zinnia.Association
             gameObject.SetActive(false);
 
             GameObjectsAssociationMock associationMock = containingObject.AddComponent<GameObjectsAssociationMock>();
-            associationMock.gameObjects.Add(gameObject);
+            associationMock.GameObjects = containingObject.AddComponent<GameObjectObservableList>();
+            associationMock.GameObjects.Add(gameObject);
             associationMock.shouldBeActive = true;
 
             subject.Associations.Add(associationMock);
@@ -67,6 +74,7 @@ namespace Test.Zinnia.Association
             Assert.IsNull(subject.CurrentAssociation);
 
             GameObjectsAssociationMock associationMock = containingObject.AddComponent<GameObjectsAssociationMock>();
+            associationMock.GameObjects = containingObject.AddComponent<GameObjectObservableList>();
             associationMock.shouldBeActive = true;
 
             subject.Associations.Add(associationMock);
@@ -82,8 +90,9 @@ namespace Test.Zinnia.Association
         public void AwakeLogsWarningForMultipleActiveGameObjects()
         {
             GameObjectsAssociationMock associationMock = containingObject.AddComponent<GameObjectsAssociationMock>();
-            associationMock.gameObjects.Add(new GameObject());
-            associationMock.gameObjects.Add(new GameObject());
+            associationMock.GameObjects = containingObject.AddComponent<GameObjectObservableList>();
+            associationMock.GameObjects.Add(new GameObject());
+            associationMock.GameObjects.Add(new GameObject());
 
             subject.Associations.Add(associationMock);
 


### PR DESCRIPTION
All usages of fields have now been switched to properties that are
serialized with Malimbe to create an appropriate backing field to
display in the Unity Inspector.

All uses of List collections have also been replaced with concrete
versions of the ObservableList, which makes it possible to track
changes occurring to the lists at runtime and provides a single
component that allows mutating the list via UnityEvents.