### PR TITLE
feat(Pointer): update fields to properties and lists to observable

### DIFF
--- a/Runtime/Pointer/ObjectPointer.cs
+++ b/Runtime/Pointer/ObjectPointer.cs
@@ -3,17 +3,20 @@
     using UnityEngine;
     using UnityEngine.Events;
     using System;
-    using Malimbe.BehaviourStateRequirementMethod;
+    using Malimbe.MemberClearanceMethod;
     using Malimbe.XmlDocumentationAttribute;
+    using Malimbe.PropertySerializationAttribute;
+    using Malimbe.BehaviourStateRequirementMethod;
     using Zinnia.Cast;
     using Zinnia.Data.Type;
     using Zinnia.Extension;
     using Zinnia.Visual;
+    using Zinnia.Process;
 
     /// <summary>
     /// Allows pointing at objects and notifies when a target is hit, continues to be hit or stops being hit by listening to a <see cref="PointsCast"/>.
     /// </summary>
-    public class ObjectPointer : MonoBehaviour
+    public class ObjectPointer : MonoBehaviour, IProcessable
     {
         /// <summary>
         /// Holds data about a <see cref="ObjectPointer"/> event.
@@ -24,35 +27,39 @@
             /// <summary>
             /// Whether the <see cref="ObjectPointer"/> is currently activated.
             /// </summary>
-            [DocumentedByXml]
-            public bool isActive;
+            [Serialized]
+            [field: DocumentedByXml]
+            public bool IsCurrentlyActive { get; set; }
             /// <summary>
             /// Whether the <see cref="ObjectPointer"/> is currently hovering over a target.
             /// </summary>
-            [DocumentedByXml]
-            public bool isHovering;
+            [Serialized]
+            [field: DocumentedByXml]
+            public bool IsCurrentlyHovering { get; set; }
             /// <summary>
             /// The duration that the <see cref="ObjectPointer"/> has been hovering over it's current target.
             /// </summary>
-            [DocumentedByXml]
-            public float hoverDuration;
+            [Serialized]
+            [field: DocumentedByXml]
+            public float CurrentHoverDuration { get; set; }
             /// <summary>
             /// The points cast data given to the <see cref="ObjectPointer"/>.
             /// </summary>
-            [DocumentedByXml]
-            public PointsCast.EventData pointsCastData;
+            [Serialized]
+            [field: DocumentedByXml]
+            public PointsCast.EventData CurrentPointsCastData { get; set; }
 
             public EventData Set(EventData source)
             {
-                return Set(source.isActive, source.isHovering, source.hoverDuration, source.pointsCastData);
+                return Set(source.IsCurrentlyActive, source.IsCurrentlyHovering, source.CurrentHoverDuration, source.CurrentPointsCastData);
             }
 
             public EventData Set(bool isActive, bool isHovering, float hoverDuration, PointsCast.EventData pointsCastData)
             {
-                this.isActive = isActive;
-                this.isHovering = isHovering;
-                this.hoverDuration = hoverDuration;
-                this.pointsCastData = pointsCastData;
+                IsCurrentlyActive = isActive;
+                IsCurrentlyHovering = isHovering;
+                CurrentHoverDuration = hoverDuration;
+                CurrentPointsCastData = pointsCastData;
                 return this;
             }
 
@@ -80,73 +87,28 @@
         }
 
         /// <summary>
-        /// Describes an element of the rendered <see cref="ObjectPointer"/>.
-        /// </summary>
-        [Serializable]
-        public class Element
-        {
-            /// <summary>
-            /// The visibility of an <see cref="Element"/>.
-            /// </summary>
-            public enum Visibility
-            {
-                /// <summary>
-                /// The <see cref="Element"/> will only be visible when the <see cref="ObjectPointer"/> is activated.
-                /// </summary>
-                OnWhenPointerActivated,
-                /// <summary>
-                /// The <see cref="Element"/> will always be visible regardless of the <see cref="ObjectPointer"/> state.
-                /// </summary>
-                AlwaysOn,
-                /// <summary>
-                /// The <see cref="Element"/> will never be visible regardless of the <see cref="ObjectPointer"/> state.
-                /// </summary>
-                AlwaysOff
-            }
-
-            /// <summary>
-            /// Represents the <see cref="Element"/> when it's colliding with a valid object.
-            /// </summary>
-            [DocumentedByXml]
-            public GameObject validObject;
-            /// <summary>
-            /// Represents the <see cref="Element"/> when it's colliding with an invalid object or not colliding at all.
-            /// </summary>
-            [DocumentedByXml]
-            public GameObject invalidObject;
-            /// <summary>
-            /// Determines when the <see cref="Element"/> is visible.
-            /// </summary>
-            [DocumentedByXml]
-            public Visibility visibility = Visibility.OnWhenPointerActivated;
-        }
-
-        /// <summary>
-        /// Determines if the <see cref="ObjectPointer"/> should be automatically activated when the script is enabled.
-        /// </summary>
-        [DocumentedByXml]
-        public bool activateOnEnable;
-
-        /// <summary>
         /// Represents the origin, i.e. the first rendered point.
         /// </summary>
-        [DocumentedByXml]
-        public Element origin = new Element();
+        [Serialized, Cleared]
+        [field: Header("Pointer Element Settings"), DocumentedByXml]
+        public PointerElement Origin { get; set; }
         /// <summary>
-        /// Represents the segments between <see cref="origin"/> and <see cref="destination"/>. This will get cloned to create all the segments.
+        /// Represents the segments between <see cref="Origin"/> and <see cref="Destination"/>. This will get cloned to create all the segments.
         /// </summary>
-        [DocumentedByXml]
-        public Element repeatedSegment = new Element();
+        [Serialized, Cleared]
+        [field: DocumentedByXml]
+        public PointerElement RepeatedSegment { get; set; }
         /// <summary>
         /// Represents the destination, i.e. the last rendered point.
         /// </summary>
-        [DocumentedByXml]
-        public Element destination = new Element();
+        [Serialized, Cleared]
+        [field: DocumentedByXml]
+        public PointerElement Destination { get; set; }
 
         /// <summary>
         /// Emitted when the <see cref="ObjectPointer"/> becomes active.
         /// </summary>
-        [DocumentedByXml]
+        [Header("Pointer Events"), DocumentedByXml]
         public UnityEvent Activated = new UnityEvent();
         /// <summary>
         /// Emitted when the <see cref="ObjectPointer"/> becomes inactive.
@@ -190,46 +152,25 @@
         public PointsRendererUnityEvent RenderDataChanged = new PointsRendererUnityEvent();
 
         /// <summary>
-        /// The activation state of the <see cref="ObjectPointer"/>.
+        /// Whether the <see cref="ObjectPointer"/> is currently activated.
         /// </summary>
-        public bool ActivationState
-        {
-            get;
-            protected set;
-        }
-
-        /// <summary>
-        /// Reports hover duration of the <see cref="ObjectPointer"/> over the current target.
-        /// </summary>
-        public float HoverDuration
-        {
-            get;
-            protected set;
-        }
-
-        /// <summary>
-        /// The target that the <see cref="ObjectPointer"/> is currently hovering over. If there is no target then it is <see langword="null"/>.
-        /// </summary>
-        public EventData HoverTarget => (IsHovering ? GetEventData(activePointsCastData) : null);
-
-        /// <summary>
-        /// The target that the <see cref="ObjectPointer"/> has most recently selected.
-        /// </summary>
-        public EventData SelectedTarget
-        {
-            get;
-            protected set;
-        }
-
+        public bool IsActivated { get; protected set; }
         /// <summary>
         /// Whether the <see cref="ObjectPointer"/> is currently hovering over a target.
         /// </summary>
-        /// <returns><see langword="true"/> if the <see cref="ObjectPointer"/> is currently hovering over a target, <see langword="false"/> otherwise.</returns>
-        public bool IsHovering
-        {
-            get;
-            protected set;
-        }
+        public bool IsHovering { get; protected set; }
+        /// <summary>
+        /// The duration that the <see cref="ObjectPointer"/> is hovering over the current target.
+        /// </summary>
+        public float HoverDuration { get; protected set; }
+        /// <summary>
+        /// The target that the <see cref="ObjectPointer"/> is currently hovering over. If there is no target then it is <see langword="null"/>.
+        /// </summary>
+        public EventData HoverTarget => IsHovering ? GetEventData(activePointsCastData) : null;
+        /// <summary>
+        /// The target that the <see cref="ObjectPointer"/> has most recently selected.
+        /// </summary>
+        public EventData SelectedTarget { get; protected set; }
 
         /// <summary>
         /// Whether any <see cref="Element"/> of the <see cref="ObjectPointer"/> is currently visible.
@@ -243,28 +184,43 @@
                     return false;
                 }
 
-                if (origin.visibility == Element.Visibility.AlwaysOff &&
-                    repeatedSegment.visibility == Element.Visibility.AlwaysOff &&
-                    destination.visibility == Element.Visibility.AlwaysOff)
+                if (Origin.ElementVisibility == PointerElement.Visibility.AlwaysOff &&
+                    RepeatedSegment.ElementVisibility == PointerElement.Visibility.AlwaysOff &&
+                    Destination.ElementVisibility == PointerElement.Visibility.AlwaysOff)
                 {
                     return false;
                 }
 
-                if (origin.visibility == Element.Visibility.AlwaysOn ||
-                    repeatedSegment.visibility == Element.Visibility.AlwaysOn ||
-                    destination.visibility == Element.Visibility.AlwaysOn)
+                if (Origin.ElementVisibility == PointerElement.Visibility.AlwaysOn ||
+                    RepeatedSegment.ElementVisibility == PointerElement.Visibility.AlwaysOn ||
+                    Destination.ElementVisibility == PointerElement.Visibility.AlwaysOn)
                 {
                     return true;
                 }
 
-                return ActivationState;
+                return IsActivated;
             }
         }
 
+        /// <summary>
+        /// The current active points in the cast.
+        /// </summary>
         protected readonly PointsCast.EventData activePointsCastData = new PointsCast.EventData();
+        /// <summary>
+        /// The previous active points in the cast.
+        /// </summary>
         protected readonly PointsCast.EventData previousPointsCastData = new PointsCast.EventData();
-        protected bool? previousVisibility;
+        /// <summary>
+        /// Whether the pointer was visible in the previous frame.
+        /// </summary>
+        protected bool? wasPreviouslyVisible;
+        /// <summary>
+        /// The event data to emit on pointer events.
+        /// </summary>
         protected readonly EventData eventData = new EventData();
+        /// <summary>
+        /// The points data to render the pointer with.
+        /// </summary>
         protected readonly PointsRenderer.PointsData pointsData = new PointsRenderer.PointsData();
 
         /// <summary>
@@ -273,12 +229,12 @@
         [RequiresBehaviourState]
         public virtual void Activate()
         {
-            if (ActivationState)
+            if (IsActivated)
             {
                 return;
             }
 
-            ActivationState = true;
+            IsActivated = true;
             UpdateRenderData();
             Activated?.Invoke(HoverTarget);
         }
@@ -297,7 +253,7 @@
         [RequiresBehaviourState]
         public virtual void Select()
         {
-            SelectedTarget = (ActivationState ? HoverTarget : null);
+            SelectedTarget = IsActivated ? HoverTarget : null;
             Selected?.Invoke(SelectedTarget);
         }
 
@@ -338,16 +294,19 @@
             }
 
             UpdateRenderData();
+        }
 
+        /// <summary>
+        /// Processes the appearance of the pointer.
+        /// </summary>
+        [RequiresBehaviourState]
+        public void Process()
+        {
+            TryEmitVisibilityEvent();
         }
 
         protected virtual void OnEnable()
         {
-            if (activateOnEnable)
-            {
-                Activate();
-            }
-            ActivationState = activateOnEnable;
             TryEmitVisibilityEvent();
             UpdateRenderData();
         }
@@ -357,27 +316,22 @@
             TryDeactivate(true);
         }
 
-        protected virtual void Update()
-        {
-            TryEmitVisibilityEvent();
-        }
-
         /// <summary>
         /// Updates the <see cref="Element"/>'s <see cref="GameObject"/>'s visibility and emits the <see cref="RenderDataChanged"/> event with the <see cref="GameObject"/>s used for the <see cref="Element"/>s.
         /// </summary>
         protected virtual void UpdateRenderData()
         {
-            pointsData.Points = (activePointsCastData.Points ?? Array.Empty<Vector3>());
-            pointsData.StartPoint = GetElementRepresentation(origin);
-            pointsData.RepeatedSegmentPoint = GetElementRepresentation(repeatedSegment);
-            pointsData.EndPoint = GetElementRepresentation(destination);
+            pointsData.Points = activePointsCastData.Points ?? Array.Empty<Vector3>();
+            pointsData.StartPoint = GetElementRepresentation(Origin);
+            pointsData.RepeatedSegmentPoint = GetElementRepresentation(RepeatedSegment);
+            pointsData.EndPoint = GetElementRepresentation(Destination);
 
-            TryDeactivateElementObject(origin.validObject);
-            TryDeactivateElementObject(origin.invalidObject);
-            TryDeactivateElementObject(repeatedSegment.validObject);
-            TryDeactivateElementObject(repeatedSegment.invalidObject);
-            TryDeactivateElementObject(destination.validObject);
-            TryDeactivateElementObject(destination.invalidObject);
+            TryDeactivateElementObject(Origin.ValidObject);
+            TryDeactivateElementObject(Origin.InvalidObject);
+            TryDeactivateElementObject(RepeatedSegment.ValidObject);
+            TryDeactivateElementObject(RepeatedSegment.InvalidObject);
+            TryDeactivateElementObject(Destination.ValidObject);
+            TryDeactivateElementObject(Destination.InvalidObject);
 
             pointsData.StartPoint.TrySetActive(true);
             pointsData.RepeatedSegmentPoint.TrySetActive(true);
@@ -393,7 +347,7 @@
         /// <param name="ignoreBehaviourState">Determines if the events should be emitted based on the <see cref="Behaviour.enabled"/> state.</param>
         protected virtual void TryDeactivate(bool ignoreBehaviourState)
         {
-            if ((!isActiveAndEnabled && !ignoreBehaviourState) || !ActivationState)
+            if ((!isActiveAndEnabled && !ignoreBehaviourState) || !IsActivated)
             {
                 return;
             }
@@ -401,7 +355,7 @@
             UpdateRenderData();
             TryEmitExit(previousPointsCastData);
             Deactivated?.Invoke(HoverTarget);
-            ActivationState = false;
+            IsActivated = false;
             activePointsCastData.Clear();
             previousPointsCastData.Clear();
             UpdateRenderData();
@@ -426,12 +380,12 @@
         /// </summary>
         protected virtual void TryEmitVisibilityEvent()
         {
-            if (IsVisible == previousVisibility)
+            if (IsVisible == wasPreviouslyVisible)
             {
                 return;
             }
 
-            previousVisibility = IsVisible;
+            wasPreviouslyVisible = IsVisible;
 
             if (IsVisible)
             {
@@ -448,20 +402,20 @@
         /// </summary>
         /// <param name="element">The <see cref="Element"/> to return a <see cref="GameObject"/> for.</param>
         /// <returns>A <see cref="GameObject"/> to represent <paramref name="element"/>.</returns>
-        protected virtual GameObject GetElementRepresentation(Element element)
+        protected virtual GameObject GetElementRepresentation(PointerElement element)
         {
-            bool isValid = (activePointsCastData.TargetHit != null);
+            bool isValid = activePointsCastData.TargetHit != null;
 
-            switch (element.visibility)
+            switch (element.ElementVisibility)
             {
-                case Element.Visibility.OnWhenPointerActivated:
-                    return (ActivationState ? (isValid ? element.validObject : element.invalidObject) : null);
-                case Element.Visibility.AlwaysOn:
-                    return (isValid ? element.validObject : element.invalidObject);
-                case Element.Visibility.AlwaysOff:
+                case PointerElement.Visibility.OnWhenPointerActivated:
+                    return IsActivated ? (isValid ? element.ValidObject : element.InvalidObject) : null;
+                case PointerElement.Visibility.AlwaysOn:
+                    return isValid ? element.ValidObject : element.InvalidObject;
+                case PointerElement.Visibility.AlwaysOff:
                     return null;
                 default:
-                    throw new ArgumentOutOfRangeException(nameof(element.visibility), element.visibility, null);
+                    throw new ArgumentOutOfRangeException(nameof(element.ElementVisibility), element.ElementVisibility, null);
             }
         }
 
@@ -486,7 +440,7 @@
         /// <returns>A <see cref="EventData"/> object of the <see cref="ObjectPointer"/>'s current state.</returns>
         protected virtual EventData GetEventData(PointsCast.EventData data)
         {
-            Transform validDestinationTransform = destination == null || destination.validObject == null ? null : destination.validObject.transform;
+            Transform validDestinationTransform = Destination == null || Destination.ValidObject == null ? null : Destination.ValidObject.transform;
             Transform pointerTransform = transform;
 
             eventData.Transform = pointerTransform;
@@ -496,7 +450,7 @@
             eventData.Origin = pointerTransform.position;
             eventData.Direction = pointerTransform.forward;
             eventData.CollisionData = data?.TargetHit ?? default;
-            return eventData.Set(ActivationState, IsHovering, HoverDuration, data);
+            return eventData.Set(IsActivated, IsHovering, HoverDuration, data);
         }
     }
 }

--- a/Runtime/Pointer/PointerElement.cs
+++ b/Runtime/Pointer/PointerElement.cs
@@ -1,0 +1,51 @@
+﻿namespace Zinnia.Pointer
+{
+    using UnityEngine;
+    using Malimbe.MemberClearanceMethod;
+    using Malimbe.XmlDocumentationAttribute;
+    using Malimbe.PropertySerializationAttribute;
+
+    /// <summary>
+    /// Describes an element of the rendered <see cref="ObjectPointer"/>.
+    /// </summary>
+    public class PointerElement : MonoBehaviour
+    {
+        /// <summary>
+        /// The visibility of an <see cref="Element"/>.
+        /// </summary>
+        public enum Visibility
+        {
+            /// <summary>
+            /// The <see cref="Element"/> will only be visible when the <see cref="ObjectPointer"/> is activated.
+            /// </summary>
+            OnWhenPointerActivated,
+            /// <summary>
+            /// The <see cref="Element"/> will always be visible regardless of the <see cref="ObjectPointer"/> state.
+            /// </summary>
+            AlwaysOn,
+            /// <summary>
+            /// The <see cref="Element"/> will never be visible regardless of the <see cref="ObjectPointer"/> state.
+            /// </summary>
+            AlwaysOff
+        }
+
+        /// <summary>
+        /// Represents the <see cref="Element"/> when it's colliding with a valid object.
+        /// </summary>
+        [Serialized, Cleared]
+        [field: DocumentedByXml]
+        public GameObject ValidObject { get; set; }
+        /// <summary>
+        /// Represents the <see cref="Element"/> when it's colliding with an invalid object or not colliding at all.
+        /// </summary>
+        [Serialized, Cleared]
+        [field: DocumentedByXml]
+        public GameObject InvalidObject { get; set; }
+        /// <summary>
+        /// Determines when the <see cref="Element"/> is visible.
+        /// </summary>
+        [Serialized]
+        [field: DocumentedByXml]
+        public Visibility ElementVisibility { get; set; } = Visibility.OnWhenPointerActivated;
+    }
+}

--- a/Runtime/Pointer/PointerElement.cs.meta
+++ b/Runtime/Pointer/PointerElement.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ed225ba410d134e41ba2825bbd937648
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Editor/Pointer/ObjectPointerTest.cs
+++ b/Tests/Editor/Pointer/ObjectPointerTest.cs
@@ -11,6 +11,9 @@ namespace Test.Zinnia.Pointer
     {
         private GameObject containingObject;
         private ObjectPointerMock subject;
+        private PointerElement origin;
+        private PointerElement segment;
+        private PointerElement destination;
 
         private GameObject validOrigin;
         private GameObject invalidOrigin;
@@ -24,6 +27,7 @@ namespace Test.Zinnia.Pointer
         {
             Physics.autoSimulation = false;
             containingObject = new GameObject();
+            containingObject.SetActive(false);
             subject = containingObject.AddComponent<ObjectPointerMock>();
 
             validOrigin = new GameObject();
@@ -32,12 +36,28 @@ namespace Test.Zinnia.Pointer
             invalidSegment = new GameObject();
             validDestination = new GameObject();
             invalidDestination = new GameObject();
+
+            origin = containingObject.AddComponent<PointerElement>();
+            segment = containingObject.AddComponent<PointerElement>();
+            destination = containingObject.AddComponent<PointerElement>();
+
+            origin.ValidObject = validOrigin;
+            origin.InvalidObject = invalidOrigin;
+            subject.Origin = origin;
+
+            segment.ValidObject = validSegment;
+            segment.InvalidObject = invalidSegment;
+            subject.RepeatedSegment = segment;
+
+            segment.ValidObject = validDestination;
+            segment.InvalidObject = invalidDestination;
+            subject.Destination = destination;
+            containingObject.SetActive(true);
         }
 
         [TearDown]
         public void TearDown()
         {
-            Object.DestroyImmediate(subject);
             Object.DestroyImmediate(containingObject);
 
             Object.DestroyImmediate(validOrigin);
@@ -55,12 +75,12 @@ namespace Test.Zinnia.Pointer
             UnityEventListenerMock activatedListenerMock = new UnityEventListenerMock();
             UnityEventListenerMock deactivatedListenerMock = new UnityEventListenerMock();
 
-            subject.origin.validObject = validOrigin;
-            subject.origin.invalidObject = invalidOrigin;
-            subject.repeatedSegment.validObject = validSegment;
-            subject.repeatedSegment.invalidObject = invalidSegment;
-            subject.destination.validObject = validDestination;
-            subject.destination.invalidObject = invalidDestination;
+            subject.Origin.ValidObject = validOrigin;
+            subject.Origin.InvalidObject = invalidOrigin;
+            subject.RepeatedSegment.ValidObject = validSegment;
+            subject.RepeatedSegment.InvalidObject = invalidSegment;
+            subject.Destination.ValidObject = validDestination;
+            subject.Destination.InvalidObject = invalidDestination;
 
             subject.Activated.AddListener(activatedListenerMock.Listen);
             subject.Deactivated.AddListener(deactivatedListenerMock.Listen);
@@ -78,7 +98,7 @@ namespace Test.Zinnia.Pointer
             Assert.IsFalse(invalidDestination.activeInHierarchy);
 
             subject.Activate();
-            subject.ManualUpdate();
+            subject.Process();
 
             Assert.IsTrue(activatedListenerMock.Received);
             Assert.IsFalse(deactivatedListenerMock.Received);
@@ -102,7 +122,7 @@ namespace Test.Zinnia.Pointer
             PointsCast.EventData straightCast = CastPoints(castPoints);
 
             subject.HandleData(straightCast);
-            subject.ManualUpdate();
+            subject.Process();
 
             Assert.IsTrue(validOrigin.activeInHierarchy);
             Assert.IsFalse(invalidOrigin.activeInHierarchy);
@@ -114,7 +134,7 @@ namespace Test.Zinnia.Pointer
             activatedListenerMock.Reset();
             deactivatedListenerMock.Reset();
             subject.Deactivate();
-            subject.ManualUpdate();
+            subject.Process();
 
             Assert.IsFalse(activatedListenerMock.Received);
             Assert.IsTrue(deactivatedListenerMock.Received);
@@ -134,12 +154,12 @@ namespace Test.Zinnia.Pointer
         {
             UnityEventListenerMock selectListenerMock = new UnityEventListenerMock();
 
-            subject.origin.validObject = validOrigin;
-            subject.origin.invalidObject = invalidOrigin;
-            subject.repeatedSegment.validObject = validSegment;
-            subject.repeatedSegment.invalidObject = invalidSegment;
-            subject.destination.validObject = validDestination;
-            subject.destination.invalidObject = invalidDestination;
+            subject.Origin.ValidObject = validOrigin;
+            subject.Origin.InvalidObject = invalidOrigin;
+            subject.RepeatedSegment.ValidObject = validSegment;
+            subject.RepeatedSegment.InvalidObject = invalidSegment;
+            subject.Destination.ValidObject = validDestination;
+            subject.Destination.InvalidObject = invalidDestination;
 
             subject.Selected.AddListener(selectListenerMock.Listen);
 
@@ -148,7 +168,7 @@ namespace Test.Zinnia.Pointer
             Assert.IsFalse(selectListenerMock.Received);
 
             subject.Activate();
-            subject.ManualUpdate();
+            subject.Process();
             subject.Select();
 
             Assert.IsTrue(selectListenerMock.Received);
@@ -169,7 +189,7 @@ namespace Test.Zinnia.Pointer
             PointsCast.EventData straightCast = CastPoints(castPoints);
 
             subject.HandleData(straightCast);
-            subject.ManualUpdate();
+            subject.Process();
             subject.Select();
 
             Assert.IsTrue(selectListenerMock.Received);
@@ -187,7 +207,7 @@ namespace Test.Zinnia.Pointer
             subject.enabled = false;
             subject.Activate();
             Assert.IsFalse(activatedListenerMock.Received);
-            Assert.IsFalse(subject.ActivationState);
+            Assert.IsFalse(subject.IsActivated);
         }
 
         [Test]
@@ -196,12 +216,12 @@ namespace Test.Zinnia.Pointer
             UnityEventListenerMock activatedListenerMock = new UnityEventListenerMock();
             UnityEventListenerMock deactivatedListenerMock = new UnityEventListenerMock();
 
-            subject.origin.validObject = validOrigin;
-            subject.origin.invalidObject = invalidOrigin;
-            subject.repeatedSegment.validObject = validSegment;
-            subject.repeatedSegment.invalidObject = invalidSegment;
-            subject.destination.validObject = validDestination;
-            subject.destination.invalidObject = invalidDestination;
+            subject.Origin.ValidObject = validOrigin;
+            subject.Origin.InvalidObject = invalidOrigin;
+            subject.RepeatedSegment.ValidObject = validSegment;
+            subject.RepeatedSegment.InvalidObject = invalidSegment;
+            subject.Destination.ValidObject = validDestination;
+            subject.Destination.InvalidObject = invalidDestination;
 
             subject.Activated.AddListener(activatedListenerMock.Listen);
             subject.Deactivated.AddListener(deactivatedListenerMock.Listen);
@@ -219,7 +239,7 @@ namespace Test.Zinnia.Pointer
             Assert.IsFalse(invalidDestination.activeInHierarchy);
 
             subject.Activate();
-            subject.ManualUpdate();
+            subject.Process();
 
             Assert.IsTrue(activatedListenerMock.Received);
             Assert.IsFalse(deactivatedListenerMock.Received);
@@ -249,17 +269,17 @@ namespace Test.Zinnia.Pointer
         [Test]
         public void OriginAlwaysVisible()
         {
-            subject.origin.validObject = validOrigin;
-            subject.origin.invalidObject = invalidOrigin;
-            subject.repeatedSegment.validObject = validSegment;
-            subject.repeatedSegment.invalidObject = invalidSegment;
-            subject.destination.validObject = validDestination;
-            subject.destination.invalidObject = invalidDestination;
+            subject.Origin.ValidObject = validOrigin;
+            subject.Origin.InvalidObject = invalidOrigin;
+            subject.RepeatedSegment.ValidObject = validSegment;
+            subject.RepeatedSegment.InvalidObject = invalidSegment;
+            subject.Destination.ValidObject = validDestination;
+            subject.Destination.InvalidObject = invalidDestination;
 
-            subject.origin.visibility = ObjectPointer.Element.Visibility.AlwaysOn;
+            subject.Origin.ElementVisibility = PointerElement.Visibility.AlwaysOn;
 
             subject.ManualOnEnable();
-            subject.ManualUpdate();
+            subject.Process();
 
             Assert.IsFalse(validOrigin.activeInHierarchy);
             Assert.IsTrue(invalidOrigin.activeInHierarchy);
@@ -269,7 +289,7 @@ namespace Test.Zinnia.Pointer
             Assert.IsFalse(invalidDestination.activeInHierarchy);
 
             subject.Activate();
-            subject.ManualUpdate();
+            subject.Process();
 
             Assert.IsFalse(validOrigin.activeInHierarchy);
             Assert.IsTrue(invalidOrigin.activeInHierarchy);
@@ -279,7 +299,7 @@ namespace Test.Zinnia.Pointer
             Assert.IsTrue(invalidDestination.activeInHierarchy);
 
             subject.Deactivate();
-            subject.ManualUpdate();
+            subject.Process();
 
             Assert.IsFalse(validOrigin.activeInHierarchy);
             Assert.IsTrue(invalidOrigin.activeInHierarchy);
@@ -292,17 +312,17 @@ namespace Test.Zinnia.Pointer
         [Test]
         public void SegmentAlwaysVisible()
         {
-            subject.origin.validObject = validOrigin;
-            subject.origin.invalidObject = invalidOrigin;
-            subject.repeatedSegment.validObject = validSegment;
-            subject.repeatedSegment.invalidObject = invalidSegment;
-            subject.destination.validObject = validDestination;
-            subject.destination.invalidObject = invalidDestination;
+            subject.Origin.ValidObject = validOrigin;
+            subject.Origin.InvalidObject = invalidOrigin;
+            subject.RepeatedSegment.ValidObject = validSegment;
+            subject.RepeatedSegment.InvalidObject = invalidSegment;
+            subject.Destination.ValidObject = validDestination;
+            subject.Destination.InvalidObject = invalidDestination;
 
-            subject.repeatedSegment.visibility = ObjectPointer.Element.Visibility.AlwaysOn;
+            subject.RepeatedSegment.ElementVisibility = PointerElement.Visibility.AlwaysOn;
 
             subject.ManualOnEnable();
-            subject.ManualUpdate();
+            subject.Process();
 
             Assert.IsFalse(validOrigin.activeInHierarchy);
             Assert.IsFalse(invalidOrigin.activeInHierarchy);
@@ -312,7 +332,7 @@ namespace Test.Zinnia.Pointer
             Assert.IsFalse(invalidDestination.activeInHierarchy);
 
             subject.Activate();
-            subject.ManualUpdate();
+            subject.Process();
 
             Assert.IsFalse(validOrigin.activeInHierarchy);
             Assert.IsTrue(invalidOrigin.activeInHierarchy);
@@ -322,7 +342,7 @@ namespace Test.Zinnia.Pointer
             Assert.IsTrue(invalidDestination.activeInHierarchy);
 
             subject.Deactivate();
-            subject.ManualUpdate();
+            subject.Process();
 
             Assert.IsFalse(validOrigin.activeInHierarchy);
             Assert.IsFalse(invalidOrigin.activeInHierarchy);
@@ -335,17 +355,17 @@ namespace Test.Zinnia.Pointer
         [Test]
         public void DestinationAlwaysVisible()
         {
-            subject.origin.validObject = validOrigin;
-            subject.origin.invalidObject = invalidOrigin;
-            subject.repeatedSegment.validObject = validSegment;
-            subject.repeatedSegment.invalidObject = invalidSegment;
-            subject.destination.validObject = validDestination;
-            subject.destination.invalidObject = invalidDestination;
+            subject.Origin.ValidObject = validOrigin;
+            subject.Origin.InvalidObject = invalidOrigin;
+            subject.RepeatedSegment.ValidObject = validSegment;
+            subject.RepeatedSegment.InvalidObject = invalidSegment;
+            subject.Destination.ValidObject = validDestination;
+            subject.Destination.InvalidObject = invalidDestination;
 
-            subject.destination.visibility = ObjectPointer.Element.Visibility.AlwaysOn;
+            subject.Destination.ElementVisibility = PointerElement.Visibility.AlwaysOn;
 
             subject.ManualOnEnable();
-            subject.ManualUpdate();
+            subject.Process();
 
             Assert.IsFalse(validOrigin.activeInHierarchy);
             Assert.IsFalse(invalidOrigin.activeInHierarchy);
@@ -355,7 +375,7 @@ namespace Test.Zinnia.Pointer
             Assert.IsTrue(invalidDestination.activeInHierarchy);
 
             subject.Activate();
-            subject.ManualUpdate();
+            subject.Process();
 
             Assert.IsFalse(validOrigin.activeInHierarchy);
             Assert.IsTrue(invalidOrigin.activeInHierarchy);
@@ -365,7 +385,7 @@ namespace Test.Zinnia.Pointer
             Assert.IsTrue(invalidDestination.activeInHierarchy);
 
             subject.Deactivate();
-            subject.ManualUpdate();
+            subject.Process();
 
             Assert.IsFalse(validOrigin.activeInHierarchy);
             Assert.IsFalse(invalidOrigin.activeInHierarchy);
@@ -378,18 +398,18 @@ namespace Test.Zinnia.Pointer
         [Test]
         public void SegmentAndDestinationAlwaysVisible()
         {
-            subject.origin.validObject = validOrigin;
-            subject.origin.invalidObject = invalidOrigin;
-            subject.repeatedSegment.validObject = validSegment;
-            subject.repeatedSegment.invalidObject = invalidSegment;
-            subject.destination.validObject = validDestination;
-            subject.destination.invalidObject = invalidDestination;
+            subject.Origin.ValidObject = validOrigin;
+            subject.Origin.InvalidObject = invalidOrigin;
+            subject.RepeatedSegment.ValidObject = validSegment;
+            subject.RepeatedSegment.InvalidObject = invalidSegment;
+            subject.Destination.ValidObject = validDestination;
+            subject.Destination.InvalidObject = invalidDestination;
 
-            subject.repeatedSegment.visibility = ObjectPointer.Element.Visibility.AlwaysOn;
-            subject.destination.visibility = ObjectPointer.Element.Visibility.AlwaysOn;
+            subject.RepeatedSegment.ElementVisibility = PointerElement.Visibility.AlwaysOn;
+            subject.Destination.ElementVisibility = PointerElement.Visibility.AlwaysOn;
 
             subject.ManualOnEnable();
-            subject.ManualUpdate();
+            subject.Process();
 
             Assert.IsFalse(validOrigin.activeInHierarchy);
             Assert.IsFalse(invalidOrigin.activeInHierarchy);
@@ -399,7 +419,7 @@ namespace Test.Zinnia.Pointer
             Assert.IsTrue(invalidDestination.activeInHierarchy);
 
             subject.Activate();
-            subject.ManualUpdate();
+            subject.Process();
 
             Assert.IsFalse(validOrigin.activeInHierarchy);
             Assert.IsTrue(invalidOrigin.activeInHierarchy);
@@ -409,7 +429,7 @@ namespace Test.Zinnia.Pointer
             Assert.IsTrue(invalidDestination.activeInHierarchy);
 
             subject.Deactivate();
-            subject.ManualUpdate();
+            subject.Process();
 
             Assert.IsFalse(validOrigin.activeInHierarchy);
             Assert.IsFalse(invalidOrigin.activeInHierarchy);
@@ -422,19 +442,19 @@ namespace Test.Zinnia.Pointer
         [Test]
         public void ElementsAlwaysVisible()
         {
-            subject.origin.validObject = validOrigin;
-            subject.origin.invalidObject = invalidOrigin;
-            subject.repeatedSegment.validObject = validSegment;
-            subject.repeatedSegment.invalidObject = invalidSegment;
-            subject.destination.validObject = validDestination;
-            subject.destination.invalidObject = invalidDestination;
+            subject.Origin.ValidObject = validOrigin;
+            subject.Origin.InvalidObject = invalidOrigin;
+            subject.RepeatedSegment.ValidObject = validSegment;
+            subject.RepeatedSegment.InvalidObject = invalidSegment;
+            subject.Destination.ValidObject = validDestination;
+            subject.Destination.InvalidObject = invalidDestination;
 
-            subject.origin.visibility = ObjectPointer.Element.Visibility.AlwaysOn;
-            subject.repeatedSegment.visibility = ObjectPointer.Element.Visibility.AlwaysOn;
-            subject.destination.visibility = ObjectPointer.Element.Visibility.AlwaysOn;
+            subject.Origin.ElementVisibility = PointerElement.Visibility.AlwaysOn;
+            subject.RepeatedSegment.ElementVisibility = PointerElement.Visibility.AlwaysOn;
+            subject.Destination.ElementVisibility = PointerElement.Visibility.AlwaysOn;
 
             subject.ManualOnEnable();
-            subject.ManualUpdate();
+            subject.Process();
 
             Assert.IsFalse(validOrigin.activeInHierarchy);
             Assert.IsTrue(invalidOrigin.activeInHierarchy);
@@ -444,7 +464,7 @@ namespace Test.Zinnia.Pointer
             Assert.IsTrue(invalidDestination.activeInHierarchy);
 
             subject.Activate();
-            subject.ManualUpdate();
+            subject.Process();
 
             Assert.IsFalse(validOrigin.activeInHierarchy);
             Assert.IsTrue(invalidOrigin.activeInHierarchy);
@@ -454,7 +474,7 @@ namespace Test.Zinnia.Pointer
             Assert.IsTrue(invalidDestination.activeInHierarchy);
 
             subject.Deactivate();
-            subject.ManualUpdate();
+            subject.Process();
 
             Assert.IsFalse(validOrigin.activeInHierarchy);
             Assert.IsTrue(invalidOrigin.activeInHierarchy);
@@ -467,17 +487,17 @@ namespace Test.Zinnia.Pointer
         [Test]
         public void OriginAlwaysHidden()
         {
-            subject.origin.validObject = validOrigin;
-            subject.origin.invalidObject = invalidOrigin;
-            subject.repeatedSegment.validObject = validSegment;
-            subject.repeatedSegment.invalidObject = invalidSegment;
-            subject.destination.validObject = validDestination;
-            subject.destination.invalidObject = invalidDestination;
+            subject.Origin.ValidObject = validOrigin;
+            subject.Origin.InvalidObject = invalidOrigin;
+            subject.RepeatedSegment.ValidObject = validSegment;
+            subject.RepeatedSegment.InvalidObject = invalidSegment;
+            subject.Destination.ValidObject = validDestination;
+            subject.Destination.InvalidObject = invalidDestination;
 
-            subject.origin.visibility = ObjectPointer.Element.Visibility.AlwaysOff;
+            subject.Origin.ElementVisibility = PointerElement.Visibility.AlwaysOff;
 
             subject.ManualOnEnable();
-            subject.ManualUpdate();
+            subject.Process();
 
             Assert.IsFalse(validOrigin.activeInHierarchy);
             Assert.IsFalse(invalidOrigin.activeInHierarchy);
@@ -487,7 +507,7 @@ namespace Test.Zinnia.Pointer
             Assert.IsFalse(invalidDestination.activeInHierarchy);
 
             subject.Activate();
-            subject.ManualUpdate();
+            subject.Process();
 
             Assert.IsFalse(validOrigin.activeInHierarchy);
             Assert.IsFalse(invalidOrigin.activeInHierarchy);
@@ -497,7 +517,7 @@ namespace Test.Zinnia.Pointer
             Assert.IsTrue(invalidDestination.activeInHierarchy);
 
             subject.Deactivate();
-            subject.ManualUpdate();
+            subject.Process();
 
             Assert.IsFalse(validOrigin.activeInHierarchy);
             Assert.IsFalse(invalidOrigin.activeInHierarchy);
@@ -510,17 +530,17 @@ namespace Test.Zinnia.Pointer
         [Test]
         public void SegmentAlwaysHidden()
         {
-            subject.origin.validObject = validOrigin;
-            subject.origin.invalidObject = invalidOrigin;
-            subject.repeatedSegment.validObject = validSegment;
-            subject.repeatedSegment.invalidObject = invalidSegment;
-            subject.destination.validObject = validDestination;
-            subject.destination.invalidObject = invalidDestination;
+            subject.Origin.ValidObject = validOrigin;
+            subject.Origin.InvalidObject = invalidOrigin;
+            subject.RepeatedSegment.ValidObject = validSegment;
+            subject.RepeatedSegment.InvalidObject = invalidSegment;
+            subject.Destination.ValidObject = validDestination;
+            subject.Destination.InvalidObject = invalidDestination;
 
-            subject.repeatedSegment.visibility = ObjectPointer.Element.Visibility.AlwaysOff;
+            subject.RepeatedSegment.ElementVisibility = PointerElement.Visibility.AlwaysOff;
 
             subject.ManualOnEnable();
-            subject.ManualUpdate();
+            subject.Process();
 
             Assert.IsFalse(validOrigin.activeInHierarchy);
             Assert.IsFalse(invalidOrigin.activeInHierarchy);
@@ -530,7 +550,7 @@ namespace Test.Zinnia.Pointer
             Assert.IsFalse(invalidDestination.activeInHierarchy);
 
             subject.Activate();
-            subject.ManualUpdate();
+            subject.Process();
 
             Assert.IsFalse(validOrigin.activeInHierarchy);
             Assert.IsTrue(invalidOrigin.activeInHierarchy);
@@ -540,7 +560,7 @@ namespace Test.Zinnia.Pointer
             Assert.IsTrue(invalidDestination.activeInHierarchy);
 
             subject.Deactivate();
-            subject.ManualUpdate();
+            subject.Process();
 
             Assert.IsFalse(validOrigin.activeInHierarchy);
             Assert.IsFalse(invalidOrigin.activeInHierarchy);
@@ -553,17 +573,17 @@ namespace Test.Zinnia.Pointer
         [Test]
         public void DestinationAlwaysHidden()
         {
-            subject.origin.validObject = validOrigin;
-            subject.origin.invalidObject = invalidOrigin;
-            subject.repeatedSegment.validObject = validSegment;
-            subject.repeatedSegment.invalidObject = invalidSegment;
-            subject.destination.validObject = validDestination;
-            subject.destination.invalidObject = invalidDestination;
+            subject.Origin.ValidObject = validOrigin;
+            subject.Origin.InvalidObject = invalidOrigin;
+            subject.RepeatedSegment.ValidObject = validSegment;
+            subject.RepeatedSegment.InvalidObject = invalidSegment;
+            subject.Destination.ValidObject = validDestination;
+            subject.Destination.InvalidObject = invalidDestination;
 
-            subject.destination.visibility = ObjectPointer.Element.Visibility.AlwaysOff;
+            subject.Destination.ElementVisibility = PointerElement.Visibility.AlwaysOff;
 
             subject.ManualOnEnable();
-            subject.ManualUpdate();
+            subject.Process();
 
             Assert.IsFalse(validOrigin.activeInHierarchy);
             Assert.IsFalse(invalidOrigin.activeInHierarchy);
@@ -573,7 +593,7 @@ namespace Test.Zinnia.Pointer
             Assert.IsFalse(invalidDestination.activeInHierarchy);
 
             subject.Activate();
-            subject.ManualUpdate();
+            subject.Process();
 
             Assert.IsFalse(validOrigin.activeInHierarchy);
             Assert.IsTrue(invalidOrigin.activeInHierarchy);
@@ -583,7 +603,7 @@ namespace Test.Zinnia.Pointer
             Assert.IsFalse(invalidDestination.activeInHierarchy);
 
             subject.Deactivate();
-            subject.ManualUpdate();
+            subject.Process();
 
             Assert.IsFalse(validOrigin.activeInHierarchy);
             Assert.IsFalse(invalidOrigin.activeInHierarchy);
@@ -596,18 +616,18 @@ namespace Test.Zinnia.Pointer
         [Test]
         public void SegmentAndDestinationAlwaysHidden()
         {
-            subject.origin.validObject = validOrigin;
-            subject.origin.invalidObject = invalidOrigin;
-            subject.repeatedSegment.validObject = validSegment;
-            subject.repeatedSegment.invalidObject = invalidSegment;
-            subject.destination.validObject = validDestination;
-            subject.destination.invalidObject = invalidDestination;
+            subject.Origin.ValidObject = validOrigin;
+            subject.Origin.InvalidObject = invalidOrigin;
+            subject.RepeatedSegment.ValidObject = validSegment;
+            subject.RepeatedSegment.InvalidObject = invalidSegment;
+            subject.Destination.ValidObject = validDestination;
+            subject.Destination.InvalidObject = invalidDestination;
 
-            subject.repeatedSegment.visibility = ObjectPointer.Element.Visibility.AlwaysOff;
-            subject.destination.visibility = ObjectPointer.Element.Visibility.AlwaysOff;
+            subject.RepeatedSegment.ElementVisibility = PointerElement.Visibility.AlwaysOff;
+            subject.Destination.ElementVisibility = PointerElement.Visibility.AlwaysOff;
 
             subject.ManualOnEnable();
-            subject.ManualUpdate();
+            subject.Process();
 
             Assert.IsFalse(validOrigin.activeInHierarchy);
             Assert.IsFalse(invalidOrigin.activeInHierarchy);
@@ -617,7 +637,7 @@ namespace Test.Zinnia.Pointer
             Assert.IsFalse(invalidDestination.activeInHierarchy);
 
             subject.Activate();
-            subject.ManualUpdate();
+            subject.Process();
 
             Assert.IsFalse(validOrigin.activeInHierarchy);
             Assert.IsTrue(invalidOrigin.activeInHierarchy);
@@ -627,7 +647,7 @@ namespace Test.Zinnia.Pointer
             Assert.IsFalse(invalidDestination.activeInHierarchy);
 
             subject.Deactivate();
-            subject.ManualUpdate();
+            subject.Process();
 
             Assert.IsFalse(validOrigin.activeInHierarchy);
             Assert.IsFalse(invalidOrigin.activeInHierarchy);
@@ -640,19 +660,19 @@ namespace Test.Zinnia.Pointer
         [Test]
         public void ElementsAlwaysHidden()
         {
-            subject.origin.validObject = validOrigin;
-            subject.origin.invalidObject = invalidOrigin;
-            subject.repeatedSegment.validObject = validSegment;
-            subject.repeatedSegment.invalidObject = invalidSegment;
-            subject.destination.validObject = validDestination;
-            subject.destination.invalidObject = invalidDestination;
+            subject.Origin.ValidObject = validOrigin;
+            subject.Origin.InvalidObject = invalidOrigin;
+            subject.RepeatedSegment.ValidObject = validSegment;
+            subject.RepeatedSegment.InvalidObject = invalidSegment;
+            subject.Destination.ValidObject = validDestination;
+            subject.Destination.InvalidObject = invalidDestination;
 
-            subject.origin.visibility = ObjectPointer.Element.Visibility.AlwaysOff;
-            subject.repeatedSegment.visibility = ObjectPointer.Element.Visibility.AlwaysOff;
-            subject.destination.visibility = ObjectPointer.Element.Visibility.AlwaysOff;
+            subject.Origin.ElementVisibility = PointerElement.Visibility.AlwaysOff;
+            subject.RepeatedSegment.ElementVisibility = PointerElement.Visibility.AlwaysOff;
+            subject.Destination.ElementVisibility = PointerElement.Visibility.AlwaysOff;
 
             subject.ManualOnEnable();
-            subject.ManualUpdate();
+            subject.Process();
 
             Assert.IsFalse(validOrigin.activeInHierarchy);
             Assert.IsFalse(invalidOrigin.activeInHierarchy);
@@ -662,7 +682,7 @@ namespace Test.Zinnia.Pointer
             Assert.IsFalse(invalidDestination.activeInHierarchy);
 
             subject.Activate();
-            subject.ManualUpdate();
+            subject.Process();
 
             Assert.IsFalse(validOrigin.activeInHierarchy);
             Assert.IsFalse(invalidOrigin.activeInHierarchy);
@@ -672,7 +692,7 @@ namespace Test.Zinnia.Pointer
             Assert.IsFalse(invalidDestination.activeInHierarchy);
 
             subject.Deactivate();
-            subject.ManualUpdate();
+            subject.Process();
 
             Assert.IsFalse(validOrigin.activeInHierarchy);
             Assert.IsFalse(invalidOrigin.activeInHierarchy);
@@ -687,20 +707,19 @@ namespace Test.Zinnia.Pointer
         {
             UnityEventListenerMock activatedListenerMock = new UnityEventListenerMock();
 
-            subject.origin.validObject = validOrigin;
-            subject.origin.invalidObject = invalidOrigin;
-            subject.repeatedSegment.validObject = validSegment;
-            subject.repeatedSegment.invalidObject = invalidSegment;
-            subject.destination.validObject = validDestination;
-            subject.destination.invalidObject = invalidDestination;
-
-            subject.activateOnEnable = true;
+            subject.Origin.ValidObject = validOrigin;
+            subject.Origin.InvalidObject = invalidOrigin;
+            subject.RepeatedSegment.ValidObject = validSegment;
+            subject.RepeatedSegment.InvalidObject = invalidSegment;
+            subject.Destination.ValidObject = validDestination;
+            subject.Destination.InvalidObject = invalidDestination;
 
             subject.Activated.AddListener(activatedListenerMock.Listen);
 
             Assert.IsFalse(activatedListenerMock.Received);
 
             subject.ManualOnEnable();
+            subject.Activate();
 
             Assert.IsTrue(activatedListenerMock.Received);
 
@@ -719,12 +738,12 @@ namespace Test.Zinnia.Pointer
             UnityEventListenerMock exitListenerMock = new UnityEventListenerMock();
             UnityEventListenerMock hoverListenerMock = new UnityEventListenerMock();
 
-            subject.origin.validObject = validOrigin;
-            subject.origin.invalidObject = invalidOrigin;
-            subject.repeatedSegment.validObject = validSegment;
-            subject.repeatedSegment.invalidObject = invalidSegment;
-            subject.destination.validObject = validDestination;
-            subject.destination.invalidObject = invalidDestination;
+            subject.Origin.ValidObject = validOrigin;
+            subject.Origin.InvalidObject = invalidOrigin;
+            subject.RepeatedSegment.ValidObject = validSegment;
+            subject.RepeatedSegment.InvalidObject = invalidSegment;
+            subject.Destination.ValidObject = validDestination;
+            subject.Destination.InvalidObject = invalidDestination;
 
             subject.Entered.AddListener(enterListenerMock.Listen);
             subject.Exited.AddListener(exitListenerMock.Listen);
@@ -737,7 +756,7 @@ namespace Test.Zinnia.Pointer
             Assert.IsFalse(hoverListenerMock.Received);
 
             subject.Activate();
-            subject.ManualUpdate();
+            subject.Process();
 
             //No valid target so still should be false
             Assert.IsFalse(enterListenerMock.Received);
@@ -823,11 +842,6 @@ namespace Test.Zinnia.Pointer
         {
             enabled = false;
             OnDisable();
-        }
-
-        public void ManualUpdate()
-        {
-            Update();
         }
     }
 }


### PR DESCRIPTION
All usages of fields have now been switched to properties that are
serialized with Malimbe to create an appropriate backing field to
display in the Unity Inspector.

All uses of List collections have also been replaced with concrete
versions of the ObservableList, which makes it possible to track
changes occurring to the lists at runtime and provides a single
component that allows mutating the list via UnityEvents.

The ObjectPointer has also been split up so the Pointer Element
is now its own MonoBehaviour component to make it easier to
change pointer elements in the inspector.