### PR TITLE
feat(Collection): rename events in ObservableList

### DIFF
--- a/Editor/Data/Collection/ObservableListEditor.cs
+++ b/Editor/Data/Collection/ObservableListEditor.cs
@@ -131,7 +131,7 @@ This restriction is in place to ensure any subscribed listener to events on this
                     return;
                 }
 
-                Action<int> removedRaiser = CreateElementsEventRaiser(property, nameof(GameObjectObservableList.ElementRemoved));
+                Action<int> removedRaiser = CreateElementsEventRaiser(property, nameof(GameObjectObservableList.Removed));
                 for (int index = previousSize - 1; index >= newSize; index--)
                 {
                     removedRaiser(index);
@@ -139,12 +139,12 @@ This restriction is in place to ensure any subscribed listener to events on this
 
                 if (newSize == 0)
                 {
-                    CreateElementsEventRaiser(property, nameof(GameObjectObservableList.BecameEmpty))(0);
+                    CreateElementsEventRaiser(property, nameof(GameObjectObservableList.Emptied))(0);
                 }
             }
             else if (changedIndex != null)
             {
-                CreateElementsEventRaiser(property, nameof(GameObjectObservableList.ElementRemoved))(changedIndex.Value);
+                CreateElementsEventRaiser(property, nameof(GameObjectObservableList.Removed))(changedIndex.Value);
             }
         }
 
@@ -163,11 +163,11 @@ This restriction is in place to ensure any subscribed listener to events on this
                     return;
                 }
 
-                Action<int> addedRaiser = CreateElementsEventRaiser(property, nameof(GameObjectObservableList.ElementAdded));
+                Action<int> addedRaiser = CreateElementsEventRaiser(property, nameof(GameObjectObservableList.Added));
                 if (previousSize == 0)
                 {
                     addedRaiser(0);
-                    CreateElementsEventRaiser(property, nameof(GameObjectObservableList.BecamePopulated))(0);
+                    CreateElementsEventRaiser(property, nameof(GameObjectObservableList.Populated))(0);
 
                     previousSize++;
                 }
@@ -179,7 +179,7 @@ This restriction is in place to ensure any subscribed listener to events on this
             }
             else if (changedIndex != null)
             {
-                CreateElementsEventRaiser(property, nameof(GameObjectObservableList.ElementAdded))(changedIndex.Value);
+                CreateElementsEventRaiser(property, nameof(GameObjectObservableList.Added))(changedIndex.Value);
             }
         }
 

--- a/Runtime/Action/ActionRegistrar.cs
+++ b/Runtime/Action/ActionRegistrar.cs
@@ -83,8 +83,8 @@
                 return;
             }
 
-            Sources.ElementAdded.AddListener(OnSourceAdded);
-            Sources.ElementRemoved.AddListener(OnSourceRemoved);
+            Sources.Added.AddListener(OnSourceAdded);
+            Sources.Removed.AddListener(OnSourceRemoved);
         }
 
         /// <summary>
@@ -97,8 +97,8 @@
                 return;
             }
 
-            Sources.ElementAdded.RemoveListener(OnSourceAdded);
-            Sources.ElementRemoved.RemoveListener(OnSourceRemoved);
+            Sources.Added.RemoveListener(OnSourceAdded);
+            Sources.Removed.RemoveListener(OnSourceRemoved);
         }
 
         /// <summary>
@@ -111,8 +111,8 @@
                 return;
             }
 
-            SourceLimits.ElementAdded.AddListener(OnSourceLimitAdded);
-            SourceLimits.ElementRemoved.AddListener(OnSourceLimitRemoved);
+            SourceLimits.Added.AddListener(OnSourceLimitAdded);
+            SourceLimits.Removed.AddListener(OnSourceLimitRemoved);
         }
 
         /// <summary>
@@ -125,8 +125,8 @@
                 return;
             }
 
-            SourceLimits.ElementAdded.RemoveListener(OnSourceLimitAdded);
-            SourceLimits.ElementRemoved.RemoveListener(OnSourceLimitRemoved);
+            SourceLimits.Added.RemoveListener(OnSourceLimitAdded);
+            SourceLimits.Removed.RemoveListener(OnSourceLimitRemoved);
         }
 
         /// <summary>

--- a/Runtime/Action/AllAction.cs
+++ b/Runtime/Action/AllAction.cs
@@ -44,8 +44,8 @@
         /// </summary>
         protected virtual void AddActionsListeners()
         {
-            Actions.ElementAdded.AddListener(OnActionAdded);
-            Actions.ElementRemoved.AddListener(OnActionRemoved);
+            Actions.Added.AddListener(OnActionAdded);
+            Actions.Removed.AddListener(OnActionRemoved);
 
             foreach (Action action in Actions.SubscribableElements)
             {
@@ -58,8 +58,8 @@
         /// </summary>
         protected virtual void RemoveActionsListeners()
         {
-            Actions.ElementAdded.RemoveListener(OnActionAdded);
-            Actions.ElementRemoved.RemoveListener(OnActionRemoved);
+            Actions.Added.RemoveListener(OnActionAdded);
+            Actions.Removed.RemoveListener(OnActionRemoved);
 
             foreach (Action action in Actions.SubscribableElements)
             {

--- a/Runtime/Action/AnyAction.cs
+++ b/Runtime/Action/AnyAction.cs
@@ -44,8 +44,8 @@
         /// </summary>
         protected virtual void AddActionsListeners()
         {
-            Actions.ElementAdded.AddListener(OnActionAdded);
-            Actions.ElementRemoved.AddListener(OnActionRemoved);
+            Actions.Added.AddListener(OnActionAdded);
+            Actions.Removed.AddListener(OnActionRemoved);
 
             foreach (Action action in Actions.SubscribableElements)
             {
@@ -58,8 +58,8 @@
         /// </summary>
         protected virtual void RemoveActionsListeners()
         {
-            Actions.ElementAdded.RemoveListener(OnActionAdded);
-            Actions.ElementRemoved.RemoveListener(OnActionRemoved);
+            Actions.Added.RemoveListener(OnActionAdded);
+            Actions.Removed.RemoveListener(OnActionRemoved);
 
             foreach (Action action in Actions.SubscribableElements)
             {

--- a/Runtime/Data/Collection/ObservableCounter.cs
+++ b/Runtime/Data/Collection/ObservableCounter.cs
@@ -17,12 +17,12 @@
         /// Emitted when an element is added for the first time.
         /// </summary>
         [DocumentedByXml]
-        public TEvent ElementAdded = new TEvent();
+        public TEvent Added = new TEvent();
         /// <summary>
         /// Emitted when an element is removed completely.
         /// </summary>
         [DocumentedByXml]
-        public TEvent ElementRemoved = new TEvent();
+        public TEvent Removed = new TEvent();
 
         /// <summary>
         /// The elements being counted.
@@ -48,7 +48,7 @@
             else
             {
                 ElementsCounter.Add(element, 1);
-                ElementAdded?.Invoke(element);
+                Added?.Invoke(element);
             }
         }
 
@@ -78,7 +78,7 @@
             }
 
             ElementsCounter.Remove(element);
-            ElementRemoved?.Invoke(element);
+            Removed?.Invoke(element);
         }
 
         /// <summary>
@@ -93,7 +93,7 @@
                 return;
             }
 
-            ElementRemoved?.Invoke(element);
+            Removed?.Invoke(element);
         }
 
         /// <summary>
@@ -106,7 +106,7 @@
             {
                 if (!EqualityComparer<TElement>.Default.Equals(element, default))
                 {
-                    ElementRemoved?.Invoke(element);
+                    Removed?.Invoke(element);
                 }
             }
 

--- a/Runtime/Data/Collection/ObservableList.cs
+++ b/Runtime/Data/Collection/ObservableList.cs
@@ -30,22 +30,22 @@
         /// Emitted when the first element is added to the collection.
         /// </summary>
         [DocumentedByXml]
-        public TEvent BecamePopulated = new TEvent();
+        public TEvent Populated = new TEvent();
         /// <summary>
         /// Emitted when an element is added to the collection.
         /// </summary>
         [DocumentedByXml]
-        public TEvent ElementAdded = new TEvent();
+        public TEvent Added = new TEvent();
         /// <summary>
         /// Emitted when an element is removed from the collection.
         /// </summary>
         [DocumentedByXml]
-        public TEvent ElementRemoved = new TEvent();
+        public TEvent Removed = new TEvent();
         /// <summary>
         /// Emitted when the last element is removed from the collection.
         /// </summary>
         [DocumentedByXml]
-        public TEvent BecameEmpty = new TEvent();
+        public TEvent Emptied = new TEvent();
 
         /// <summary>
         /// The index to use in methods specifically specifying to use it. In case this index is out of bounds for the collection it will wrap around.
@@ -333,11 +333,11 @@
 
             foreach (TElement element in Elements)
             {
-                ElementRemoved?.Invoke(element);
+                Removed?.Invoke(element);
             }
 
             Elements.Clear();
-            BecameEmpty?.Invoke(default);
+            Emptied?.Invoke(default);
         }
 
         protected virtual void Start()
@@ -357,40 +357,40 @@
                     continue;
                 }
 
-                ElementAdded?.Invoke(element);
+                Added?.Invoke(element);
 
                 if (index == 0)
                 {
-                    BecamePopulated?.Invoke(element);
+                    Populated?.Invoke(element);
                 }
             }
         }
 
         /// <summary>
-        /// Always emits <see cref="ElementAdded"/> and additionally <see cref="BecamePopulated"/> if the first element was added to the collection.
+        /// Always emits <see cref="Added"/> and additionally <see cref="Populated"/> if the first element was added to the collection.
         /// </summary>
         /// <param name="element">The element that was added.</param>
         protected virtual void EmitAddEvents(TElement element)
         {
-            ElementAdded?.Invoke(element);
+            Added?.Invoke(element);
 
             if (Elements.Count == 1)
             {
-                BecamePopulated?.Invoke(element);
+                Populated?.Invoke(element);
             }
         }
 
         /// <summary>
-        /// Always emits <see cref="ElementRemoved"/> and additionally <see cref="BecameEmpty"/> if the last element was removed from the collection.
+        /// Always emits <see cref="Removed"/> and additionally <see cref="Emptied"/> if the last element was removed from the collection.
         /// </summary>
         /// <param name="element">The element that was removed.</param>
         protected virtual void EmitRemoveEvents(TElement element)
         {
-            ElementRemoved?.Invoke(element);
+            Removed?.Invoke(element);
 
             if (Elements.Count == 0)
             {
-                BecameEmpty?.Invoke(element);
+                Emptied?.Invoke(element);
             }
         }
     }

--- a/Runtime/Tracking/Collision/CollisionIgnorer.cs
+++ b/Runtime/Tracking/Collision/CollisionIgnorer.cs
@@ -53,8 +53,8 @@
         /// </summary>
         protected virtual void RegisterSourceListeners()
         {
-            Sources.ElementAdded.AddListener(OnSourceAdded);
-            Sources.ElementRemoved.AddListener(OnSourceRemoved);
+            Sources.Added.AddListener(OnSourceAdded);
+            Sources.Removed.AddListener(OnSourceRemoved);
         }
 
         /// <summary>
@@ -62,8 +62,8 @@
         /// </summary>
         protected virtual void UnregisterSourceListeners()
         {
-            Sources.ElementAdded.RemoveListener(OnSourceAdded);
-            Sources.ElementRemoved.RemoveListener(OnSourceRemoved);
+            Sources.Added.RemoveListener(OnSourceAdded);
+            Sources.Removed.RemoveListener(OnSourceRemoved);
         }
 
         /// <summary>
@@ -71,8 +71,8 @@
         /// </summary>
         protected virtual void RegisterTargetListeners()
         {
-            Targets.ElementAdded.AddListener(OnTargetAdded);
-            Targets.ElementRemoved.AddListener(OnTargetRemoved);
+            Targets.Added.AddListener(OnTargetAdded);
+            Targets.Removed.AddListener(OnTargetRemoved);
         }
 
         /// <summary>
@@ -80,8 +80,8 @@
         /// </summary>
         protected virtual void UnregisterTargetListeners()
         {
-            Targets.ElementAdded.RemoveListener(OnTargetAdded);
-            Targets.ElementRemoved.RemoveListener(OnTargetRemoved);
+            Targets.Added.RemoveListener(OnTargetAdded);
+            Targets.Removed.RemoveListener(OnTargetRemoved);
         }
 
         /// <summary>

--- a/Tests/Editor/Data/Collection/GameObjectObservableCounterTest.cs
+++ b/Tests/Editor/Data/Collection/GameObjectObservableCounterTest.cs
@@ -28,29 +28,29 @@ namespace Test.Zinnia.Data.Collection
         [Test]
         public void IncreaseCount()
         {
-            UnityEventListenerMock elementAddedMock = new UnityEventListenerMock();
-            UnityEventListenerMock elementRemovedMock = new UnityEventListenerMock();
-            subject.ElementAdded.AddListener(elementAddedMock.Listen);
-            subject.ElementRemoved.AddListener(elementRemovedMock.Listen);
+            UnityEventListenerMock addedMock = new UnityEventListenerMock();
+            UnityEventListenerMock removedMock = new UnityEventListenerMock();
+            subject.ElementAdded.AddListener(addedMock.Listen);
+            subject.ElementRemoved.AddListener(removedMock.Listen);
             GameObject elementOne = new GameObject();
 
-            Assert.IsFalse(elementAddedMock.Received);
-            Assert.IsFalse(elementRemovedMock.Received);
+            Assert.IsFalse(addedMock.Received);
+            Assert.IsFalse(removedMock.Received);
             Assert.AreEqual(0, subject.GetCount(elementOne));
 
             subject.IncreaseCount(elementOne);
 
-            Assert.IsTrue(elementAddedMock.Received);
-            Assert.IsFalse(elementRemovedMock.Received);
+            Assert.IsTrue(addedMock.Received);
+            Assert.IsFalse(removedMock.Received);
             Assert.AreEqual(1, subject.GetCount(elementOne));
 
-            elementAddedMock.Reset();
-            elementRemovedMock.Reset();
+            addedMock.Reset();
+            removedMock.Reset();
 
             subject.IncreaseCount(elementOne);
 
-            Assert.IsFalse(elementAddedMock.Received);
-            Assert.IsFalse(elementRemovedMock.Received);
+            Assert.IsFalse(addedMock.Received);
+            Assert.IsFalse(removedMock.Received);
             Assert.AreEqual(2, subject.GetCount(elementOne));
 
             Object.DestroyImmediate(elementOne);
@@ -59,35 +59,35 @@ namespace Test.Zinnia.Data.Collection
         [Test]
         public void DecreaseCount()
         {
-            UnityEventListenerMock elementAddedMock = new UnityEventListenerMock();
-            UnityEventListenerMock elementRemovedMock = new UnityEventListenerMock();
-            subject.ElementAdded.AddListener(elementAddedMock.Listen);
-            subject.ElementRemoved.AddListener(elementRemovedMock.Listen);
+            UnityEventListenerMock addedMock = new UnityEventListenerMock();
+            UnityEventListenerMock removedMock = new UnityEventListenerMock();
+            subject.ElementAdded.AddListener(addedMock.Listen);
+            subject.ElementRemoved.AddListener(removedMock.Listen);
             GameObject elementOne = new GameObject();
 
             subject.IncreaseCount(elementOne);
             subject.IncreaseCount(elementOne);
 
-            elementAddedMock.Reset();
-            elementRemovedMock.Reset();
+            addedMock.Reset();
+            removedMock.Reset();
 
-            Assert.IsFalse(elementAddedMock.Received);
-            Assert.IsFalse(elementRemovedMock.Received);
+            Assert.IsFalse(addedMock.Received);
+            Assert.IsFalse(removedMock.Received);
             Assert.AreEqual(2, subject.GetCount(elementOne));
 
             subject.DecreaseCount(elementOne);
 
-            Assert.IsFalse(elementAddedMock.Received);
-            Assert.IsFalse(elementRemovedMock.Received);
+            Assert.IsFalse(addedMock.Received);
+            Assert.IsFalse(removedMock.Received);
             Assert.AreEqual(1, subject.GetCount(elementOne));
 
-            elementAddedMock.Reset();
-            elementRemovedMock.Reset();
+            addedMock.Reset();
+            removedMock.Reset();
 
             subject.DecreaseCount(elementOne);
 
-            Assert.IsFalse(elementAddedMock.Received);
-            Assert.IsTrue(elementRemovedMock.Received);
+            Assert.IsFalse(addedMock.Received);
+            Assert.IsTrue(removedMock.Received);
             Assert.AreEqual(0, subject.GetCount(elementOne));
 
             Assert.IsFalse(subject.ElementsCounter.ContainsKey(elementOne));
@@ -98,26 +98,26 @@ namespace Test.Zinnia.Data.Collection
         [Test]
         public void RemoveFromCount()
         {
-            UnityEventListenerMock elementAddedMock = new UnityEventListenerMock();
-            UnityEventListenerMock elementRemovedMock = new UnityEventListenerMock();
-            subject.ElementAdded.AddListener(elementAddedMock.Listen);
-            subject.ElementRemoved.AddListener(elementRemovedMock.Listen);
+            UnityEventListenerMock addedMock = new UnityEventListenerMock();
+            UnityEventListenerMock removedMock = new UnityEventListenerMock();
+            subject.ElementAdded.AddListener(addedMock.Listen);
+            subject.ElementRemoved.AddListener(removedMock.Listen);
             GameObject elementOne = new GameObject();
 
             subject.IncreaseCount(elementOne);
             subject.IncreaseCount(elementOne);
 
-            elementAddedMock.Reset();
-            elementRemovedMock.Reset();
+            addedMock.Reset();
+            removedMock.Reset();
 
-            Assert.IsFalse(elementAddedMock.Received);
-            Assert.IsFalse(elementRemovedMock.Received);
+            Assert.IsFalse(addedMock.Received);
+            Assert.IsFalse(removedMock.Received);
             Assert.AreEqual(2, subject.GetCount(elementOne));
 
             subject.RemoveFromCount(elementOne);
 
-            Assert.IsFalse(elementAddedMock.Received);
-            Assert.IsTrue(elementRemovedMock.Received);
+            Assert.IsFalse(addedMock.Received);
+            Assert.IsTrue(removedMock.Received);
             Assert.AreEqual(0, subject.GetCount(elementOne));
 
             Assert.IsFalse(subject.ElementsCounter.ContainsKey(elementOne));
@@ -128,10 +128,10 @@ namespace Test.Zinnia.Data.Collection
         [Test]
         public void Clear()
         {
-            UnityEventListenerMock elementAddedMock = new UnityEventListenerMock();
-            UnityEventListenerMock elementRemovedMock = new UnityEventListenerMock();
-            subject.ElementAdded.AddListener(elementAddedMock.Listen);
-            subject.ElementRemoved.AddListener(elementRemovedMock.Listen);
+            UnityEventListenerMock addedMock = new UnityEventListenerMock();
+            UnityEventListenerMock removedMock = new UnityEventListenerMock();
+            subject.ElementAdded.AddListener(addedMock.Listen);
+            subject.ElementRemoved.AddListener(removedMock.Listen);
             GameObject elementOne = new GameObject();
             GameObject elementTwo = new GameObject();
 
@@ -140,18 +140,18 @@ namespace Test.Zinnia.Data.Collection
             subject.IncreaseCount(elementTwo);
             subject.IncreaseCount(elementTwo);
 
-            elementAddedMock.Reset();
-            elementRemovedMock.Reset();
+            addedMock.Reset();
+            removedMock.Reset();
 
-            Assert.IsFalse(elementAddedMock.Received);
-            Assert.IsFalse(elementRemovedMock.Received);
+            Assert.IsFalse(addedMock.Received);
+            Assert.IsFalse(removedMock.Received);
             Assert.AreEqual(2, subject.GetCount(elementOne));
             Assert.AreEqual(2, subject.GetCount(elementTwo));
 
             subject.Clear();
 
-            Assert.IsFalse(elementAddedMock.Received);
-            Assert.IsTrue(elementRemovedMock.Received);
+            Assert.IsFalse(addedMock.Received);
+            Assert.IsTrue(removedMock.Received);
             Assert.AreEqual(0, subject.GetCount(elementOne));
             Assert.AreEqual(0, subject.GetCount(elementTwo));
 
@@ -165,31 +165,31 @@ namespace Test.Zinnia.Data.Collection
         [Test]
         public void IncreaseCountInactiveGameObject()
         {
-            UnityEventListenerMock elementAddedMock = new UnityEventListenerMock();
-            UnityEventListenerMock elementRemovedMock = new UnityEventListenerMock();
-            subject.ElementAdded.AddListener(elementAddedMock.Listen);
-            subject.ElementRemoved.AddListener(elementRemovedMock.Listen);
+            UnityEventListenerMock addedMock = new UnityEventListenerMock();
+            UnityEventListenerMock removedMock = new UnityEventListenerMock();
+            subject.ElementAdded.AddListener(addedMock.Listen);
+            subject.ElementRemoved.AddListener(removedMock.Listen);
             GameObject elementOne = new GameObject();
 
             subject.gameObject.SetActive(false);
 
-            Assert.IsFalse(elementAddedMock.Received);
-            Assert.IsFalse(elementRemovedMock.Received);
+            Assert.IsFalse(addedMock.Received);
+            Assert.IsFalse(removedMock.Received);
             Assert.AreEqual(0, subject.GetCount(elementOne));
 
             subject.IncreaseCount(elementOne);
 
-            Assert.IsFalse(elementAddedMock.Received);
-            Assert.IsFalse(elementRemovedMock.Received);
+            Assert.IsFalse(addedMock.Received);
+            Assert.IsFalse(removedMock.Received);
             Assert.AreEqual(0, subject.GetCount(elementOne));
 
-            elementAddedMock.Reset();
-            elementRemovedMock.Reset();
+            addedMock.Reset();
+            removedMock.Reset();
 
             subject.IncreaseCount(elementOne);
 
-            Assert.IsFalse(elementAddedMock.Received);
-            Assert.IsFalse(elementRemovedMock.Received);
+            Assert.IsFalse(addedMock.Received);
+            Assert.IsFalse(removedMock.Received);
             Assert.AreEqual(0, subject.GetCount(elementOne));
 
             Assert.IsFalse(subject.ElementsCounter.ContainsKey(elementOne));
@@ -200,31 +200,31 @@ namespace Test.Zinnia.Data.Collection
         [Test]
         public void IncreaseCountInactiveComponent()
         {
-            UnityEventListenerMock elementAddedMock = new UnityEventListenerMock();
-            UnityEventListenerMock elementRemovedMock = new UnityEventListenerMock();
-            subject.ElementAdded.AddListener(elementAddedMock.Listen);
-            subject.ElementRemoved.AddListener(elementRemovedMock.Listen);
+            UnityEventListenerMock addedMock = new UnityEventListenerMock();
+            UnityEventListenerMock removedMock = new UnityEventListenerMock();
+            subject.ElementAdded.AddListener(addedMock.Listen);
+            subject.ElementRemoved.AddListener(removedMock.Listen);
             GameObject elementOne = new GameObject();
 
             subject.enabled = false;
 
-            Assert.IsFalse(elementAddedMock.Received);
-            Assert.IsFalse(elementRemovedMock.Received);
+            Assert.IsFalse(addedMock.Received);
+            Assert.IsFalse(removedMock.Received);
             Assert.AreEqual(0, subject.GetCount(elementOne));
 
             subject.IncreaseCount(elementOne);
 
-            Assert.IsFalse(elementAddedMock.Received);
-            Assert.IsFalse(elementRemovedMock.Received);
+            Assert.IsFalse(addedMock.Received);
+            Assert.IsFalse(removedMock.Received);
             Assert.AreEqual(0, subject.GetCount(elementOne));
 
-            elementAddedMock.Reset();
-            elementRemovedMock.Reset();
+            addedMock.Reset();
+            removedMock.Reset();
 
             subject.IncreaseCount(elementOne);
 
-            Assert.IsFalse(elementAddedMock.Received);
-            Assert.IsFalse(elementRemovedMock.Received);
+            Assert.IsFalse(addedMock.Received);
+            Assert.IsFalse(removedMock.Received);
             Assert.AreEqual(0, subject.GetCount(elementOne));
 
             Assert.IsFalse(subject.ElementsCounter.ContainsKey(elementOne));
@@ -235,37 +235,37 @@ namespace Test.Zinnia.Data.Collection
         [Test]
         public void DecreaseCountInactiveGameObject()
         {
-            UnityEventListenerMock elementAddedMock = new UnityEventListenerMock();
-            UnityEventListenerMock elementRemovedMock = new UnityEventListenerMock();
-            subject.ElementAdded.AddListener(elementAddedMock.Listen);
-            subject.ElementRemoved.AddListener(elementRemovedMock.Listen);
+            UnityEventListenerMock addedMock = new UnityEventListenerMock();
+            UnityEventListenerMock removedMock = new UnityEventListenerMock();
+            subject.ElementAdded.AddListener(addedMock.Listen);
+            subject.ElementRemoved.AddListener(removedMock.Listen);
             GameObject elementOne = new GameObject();
 
             subject.IncreaseCount(elementOne);
             subject.IncreaseCount(elementOne);
 
-            elementAddedMock.Reset();
-            elementRemovedMock.Reset();
+            addedMock.Reset();
+            removedMock.Reset();
 
-            Assert.IsFalse(elementAddedMock.Received);
-            Assert.IsFalse(elementRemovedMock.Received);
+            Assert.IsFalse(addedMock.Received);
+            Assert.IsFalse(removedMock.Received);
             Assert.AreEqual(2, subject.GetCount(elementOne));
 
             subject.gameObject.SetActive(false);
 
             subject.DecreaseCount(elementOne);
 
-            Assert.IsFalse(elementAddedMock.Received);
-            Assert.IsFalse(elementRemovedMock.Received);
+            Assert.IsFalse(addedMock.Received);
+            Assert.IsFalse(removedMock.Received);
             Assert.AreEqual(2, subject.GetCount(elementOne));
 
-            elementAddedMock.Reset();
-            elementRemovedMock.Reset();
+            addedMock.Reset();
+            removedMock.Reset();
 
             subject.DecreaseCount(elementOne);
 
-            Assert.IsFalse(elementAddedMock.Received);
-            Assert.IsFalse(elementRemovedMock.Received);
+            Assert.IsFalse(addedMock.Received);
+            Assert.IsFalse(removedMock.Received);
             Assert.AreEqual(2, subject.GetCount(elementOne));
 
             Assert.IsTrue(subject.ElementsCounter.ContainsKey(elementOne));
@@ -276,37 +276,37 @@ namespace Test.Zinnia.Data.Collection
         [Test]
         public void DecreaseCountInactiveComponent()
         {
-            UnityEventListenerMock elementAddedMock = new UnityEventListenerMock();
-            UnityEventListenerMock elementRemovedMock = new UnityEventListenerMock();
-            subject.ElementAdded.AddListener(elementAddedMock.Listen);
-            subject.ElementRemoved.AddListener(elementRemovedMock.Listen);
+            UnityEventListenerMock addedMock = new UnityEventListenerMock();
+            UnityEventListenerMock removedMock = new UnityEventListenerMock();
+            subject.ElementAdded.AddListener(addedMock.Listen);
+            subject.ElementRemoved.AddListener(removedMock.Listen);
             GameObject elementOne = new GameObject();
 
             subject.IncreaseCount(elementOne);
             subject.IncreaseCount(elementOne);
 
-            elementAddedMock.Reset();
-            elementRemovedMock.Reset();
+            addedMock.Reset();
+            removedMock.Reset();
 
-            Assert.IsFalse(elementAddedMock.Received);
-            Assert.IsFalse(elementRemovedMock.Received);
+            Assert.IsFalse(addedMock.Received);
+            Assert.IsFalse(removedMock.Received);
             Assert.AreEqual(2, subject.GetCount(elementOne));
 
             subject.enabled = false;
 
             subject.DecreaseCount(elementOne);
 
-            Assert.IsFalse(elementAddedMock.Received);
-            Assert.IsFalse(elementRemovedMock.Received);
+            Assert.IsFalse(addedMock.Received);
+            Assert.IsFalse(removedMock.Received);
             Assert.AreEqual(2, subject.GetCount(elementOne));
 
-            elementAddedMock.Reset();
-            elementRemovedMock.Reset();
+            addedMock.Reset();
+            removedMock.Reset();
 
             subject.DecreaseCount(elementOne);
 
-            Assert.IsFalse(elementAddedMock.Received);
-            Assert.IsFalse(elementRemovedMock.Received);
+            Assert.IsFalse(addedMock.Received);
+            Assert.IsFalse(removedMock.Received);
             Assert.AreEqual(2, subject.GetCount(elementOne));
 
             Assert.IsTrue(subject.ElementsCounter.ContainsKey(elementOne));
@@ -317,28 +317,28 @@ namespace Test.Zinnia.Data.Collection
         [Test]
         public void RemoveFromCountInactiveGameObject()
         {
-            UnityEventListenerMock elementAddedMock = new UnityEventListenerMock();
-            UnityEventListenerMock elementRemovedMock = new UnityEventListenerMock();
-            subject.ElementAdded.AddListener(elementAddedMock.Listen);
-            subject.ElementRemoved.AddListener(elementRemovedMock.Listen);
+            UnityEventListenerMock addedMock = new UnityEventListenerMock();
+            UnityEventListenerMock removedMock = new UnityEventListenerMock();
+            subject.ElementAdded.AddListener(addedMock.Listen);
+            subject.ElementRemoved.AddListener(removedMock.Listen);
             GameObject elementOne = new GameObject();
 
             subject.IncreaseCount(elementOne);
             subject.IncreaseCount(elementOne);
 
-            elementAddedMock.Reset();
-            elementRemovedMock.Reset();
+            addedMock.Reset();
+            removedMock.Reset();
 
             subject.gameObject.SetActive(false);
 
-            Assert.IsFalse(elementAddedMock.Received);
-            Assert.IsFalse(elementRemovedMock.Received);
+            Assert.IsFalse(addedMock.Received);
+            Assert.IsFalse(removedMock.Received);
             Assert.AreEqual(2, subject.GetCount(elementOne));
 
             subject.RemoveFromCount(elementOne);
 
-            Assert.IsFalse(elementAddedMock.Received);
-            Assert.IsFalse(elementRemovedMock.Received);
+            Assert.IsFalse(addedMock.Received);
+            Assert.IsFalse(removedMock.Received);
             Assert.AreEqual(2, subject.GetCount(elementOne));
 
             Assert.IsTrue(subject.ElementsCounter.ContainsKey(elementOne));
@@ -349,28 +349,28 @@ namespace Test.Zinnia.Data.Collection
         [Test]
         public void RemoveFromCountInactiveComponent()
         {
-            UnityEventListenerMock elementAddedMock = new UnityEventListenerMock();
-            UnityEventListenerMock elementRemovedMock = new UnityEventListenerMock();
-            subject.ElementAdded.AddListener(elementAddedMock.Listen);
-            subject.ElementRemoved.AddListener(elementRemovedMock.Listen);
+            UnityEventListenerMock addedMock = new UnityEventListenerMock();
+            UnityEventListenerMock removedMock = new UnityEventListenerMock();
+            subject.ElementAdded.AddListener(addedMock.Listen);
+            subject.ElementRemoved.AddListener(removedMock.Listen);
             GameObject elementOne = new GameObject();
 
             subject.IncreaseCount(elementOne);
             subject.IncreaseCount(elementOne);
 
-            elementAddedMock.Reset();
-            elementRemovedMock.Reset();
+            addedMock.Reset();
+            removedMock.Reset();
 
             subject.enabled = false;
 
-            Assert.IsFalse(elementAddedMock.Received);
-            Assert.IsFalse(elementRemovedMock.Received);
+            Assert.IsFalse(addedMock.Received);
+            Assert.IsFalse(removedMock.Received);
             Assert.AreEqual(2, subject.GetCount(elementOne));
 
             subject.RemoveFromCount(elementOne);
 
-            Assert.IsFalse(elementAddedMock.Received);
-            Assert.IsFalse(elementRemovedMock.Received);
+            Assert.IsFalse(addedMock.Received);
+            Assert.IsFalse(removedMock.Received);
             Assert.AreEqual(2, subject.GetCount(elementOne));
 
             Assert.IsTrue(subject.ElementsCounter.ContainsKey(elementOne));
@@ -381,10 +381,10 @@ namespace Test.Zinnia.Data.Collection
         [Test]
         public void ClearInactiveGameObject()
         {
-            UnityEventListenerMock elementAddedMock = new UnityEventListenerMock();
-            UnityEventListenerMock elementRemovedMock = new UnityEventListenerMock();
-            subject.ElementAdded.AddListener(elementAddedMock.Listen);
-            subject.ElementRemoved.AddListener(elementRemovedMock.Listen);
+            UnityEventListenerMock addedMock = new UnityEventListenerMock();
+            UnityEventListenerMock removedMock = new UnityEventListenerMock();
+            subject.ElementAdded.AddListener(addedMock.Listen);
+            subject.ElementRemoved.AddListener(removedMock.Listen);
             GameObject elementOne = new GameObject();
             GameObject elementTwo = new GameObject();
 
@@ -393,20 +393,20 @@ namespace Test.Zinnia.Data.Collection
             subject.IncreaseCount(elementTwo);
             subject.IncreaseCount(elementTwo);
 
-            elementAddedMock.Reset();
-            elementRemovedMock.Reset();
+            addedMock.Reset();
+            removedMock.Reset();
 
             subject.gameObject.SetActive(false);
 
-            Assert.IsFalse(elementAddedMock.Received);
-            Assert.IsFalse(elementRemovedMock.Received);
+            Assert.IsFalse(addedMock.Received);
+            Assert.IsFalse(removedMock.Received);
             Assert.AreEqual(2, subject.GetCount(elementOne));
             Assert.AreEqual(2, subject.GetCount(elementTwo));
 
             subject.Clear();
 
-            Assert.IsFalse(elementAddedMock.Received);
-            Assert.IsFalse(elementRemovedMock.Received);
+            Assert.IsFalse(addedMock.Received);
+            Assert.IsFalse(removedMock.Received);
             Assert.AreEqual(2, subject.GetCount(elementOne));
             Assert.AreEqual(2, subject.GetCount(elementTwo));
 
@@ -420,10 +420,10 @@ namespace Test.Zinnia.Data.Collection
         [Test]
         public void ClearInactiveComponent()
         {
-            UnityEventListenerMock elementAddedMock = new UnityEventListenerMock();
-            UnityEventListenerMock elementRemovedMock = new UnityEventListenerMock();
-            subject.ElementAdded.AddListener(elementAddedMock.Listen);
-            subject.ElementRemoved.AddListener(elementRemovedMock.Listen);
+            UnityEventListenerMock addedMock = new UnityEventListenerMock();
+            UnityEventListenerMock removedMock = new UnityEventListenerMock();
+            subject.ElementAdded.AddListener(addedMock.Listen);
+            subject.ElementRemoved.AddListener(removedMock.Listen);
             GameObject elementOne = new GameObject();
             GameObject elementTwo = new GameObject();
 
@@ -432,20 +432,20 @@ namespace Test.Zinnia.Data.Collection
             subject.IncreaseCount(elementTwo);
             subject.IncreaseCount(elementTwo);
 
-            elementAddedMock.Reset();
-            elementRemovedMock.Reset();
+            addedMock.Reset();
+            removedMock.Reset();
 
             subject.enabled = false;
 
-            Assert.IsFalse(elementAddedMock.Received);
-            Assert.IsFalse(elementRemovedMock.Received);
+            Assert.IsFalse(addedMock.Received);
+            Assert.IsFalse(removedMock.Received);
             Assert.AreEqual(2, subject.GetCount(elementOne));
             Assert.AreEqual(2, subject.GetCount(elementTwo));
 
             subject.Clear();
 
-            Assert.IsFalse(elementAddedMock.Received);
-            Assert.IsFalse(elementRemovedMock.Received);
+            Assert.IsFalse(addedMock.Received);
+            Assert.IsFalse(removedMock.Received);
             Assert.AreEqual(2, subject.GetCount(elementOne));
             Assert.AreEqual(2, subject.GetCount(elementTwo));
 

--- a/Tests/Editor/Data/Collection/GameObjectObservableListTest.cs
+++ b/Tests/Editor/Data/Collection/GameObjectObservableListTest.cs
@@ -75,14 +75,14 @@ namespace Test.Zinnia.Data.Collection
         [Test]
         public void AddToEnd()
         {
-            UnityEventListenerMock becamePopulatedMock = new UnityEventListenerMock();
-            UnityEventListenerMock elementAddedMock = new UnityEventListenerMock();
-            UnityEventListenerMock elementRemovedMock = new UnityEventListenerMock();
-            UnityEventListenerMock becameEmptyMock = new UnityEventListenerMock();
-            subject.BecamePopulated.AddListener(becamePopulatedMock.Listen);
-            subject.ElementAdded.AddListener(elementAddedMock.Listen);
-            subject.ElementRemoved.AddListener(elementRemovedMock.Listen);
-            subject.BecameEmpty.AddListener(becameEmptyMock.Listen);
+            UnityEventListenerMock populatedMock = new UnityEventListenerMock();
+            UnityEventListenerMock addedMock = new UnityEventListenerMock();
+            UnityEventListenerMock removedMock = new UnityEventListenerMock();
+            UnityEventListenerMock emptiedMock = new UnityEventListenerMock();
+            subject.Populated.AddListener(populatedMock.Listen);
+            subject.Added.AddListener(addedMock.Listen);
+            subject.Removed.AddListener(removedMock.Listen);
+            subject.Emptied.AddListener(emptiedMock.Listen);
 
             GameObject elementOne = new GameObject();
             GameObject elementTwo = new GameObject();
@@ -92,25 +92,25 @@ namespace Test.Zinnia.Data.Collection
             subject.Add(elementOne);
 
             Assert.AreEqual(1, subject.NonSubscribableElements.Count);
-            Assert.IsTrue(becamePopulatedMock.Received);
-            Assert.IsTrue(elementAddedMock.Received);
-            Assert.IsFalse(elementRemovedMock.Received);
-            Assert.IsFalse(becameEmptyMock.Received);
+            Assert.IsTrue(populatedMock.Received);
+            Assert.IsTrue(addedMock.Received);
+            Assert.IsFalse(removedMock.Received);
+            Assert.IsFalse(emptiedMock.Received);
 
-            becamePopulatedMock.Reset();
-            elementAddedMock.Reset();
-            elementRemovedMock.Reset();
-            becameEmptyMock.Reset();
+            populatedMock.Reset();
+            addedMock.Reset();
+            removedMock.Reset();
+            emptiedMock.Reset();
 
             subject.Add(elementTwo);
 
             Assert.AreEqual(2, subject.NonSubscribableElements.Count);
             Assert.AreEqual(elementTwo, subject.NonSubscribableElements[1]);
 
-            Assert.IsFalse(becamePopulatedMock.Received);
-            Assert.IsTrue(elementAddedMock.Received);
-            Assert.IsFalse(elementRemovedMock.Received);
-            Assert.IsFalse(becameEmptyMock.Received);
+            Assert.IsFalse(populatedMock.Received);
+            Assert.IsTrue(addedMock.Received);
+            Assert.IsFalse(removedMock.Received);
+            Assert.IsFalse(emptiedMock.Received);
 
             Object.DestroyImmediate(elementOne);
             Object.DestroyImmediate(elementTwo);
@@ -119,14 +119,14 @@ namespace Test.Zinnia.Data.Collection
         [Test]
         public void AddUnique()
         {
-            UnityEventListenerMock becamePopulatedMock = new UnityEventListenerMock();
-            UnityEventListenerMock elementAddedMock = new UnityEventListenerMock();
-            UnityEventListenerMock elementRemovedMock = new UnityEventListenerMock();
-            UnityEventListenerMock becameEmptyMock = new UnityEventListenerMock();
-            subject.BecamePopulated.AddListener(becamePopulatedMock.Listen);
-            subject.ElementAdded.AddListener(elementAddedMock.Listen);
-            subject.ElementRemoved.AddListener(elementRemovedMock.Listen);
-            subject.BecameEmpty.AddListener(becameEmptyMock.Listen);
+            UnityEventListenerMock populatedMock = new UnityEventListenerMock();
+            UnityEventListenerMock addedMock = new UnityEventListenerMock();
+            UnityEventListenerMock removedMock = new UnityEventListenerMock();
+            UnityEventListenerMock emptiedMock = new UnityEventListenerMock();
+            subject.Populated.AddListener(populatedMock.Listen);
+            subject.Added.AddListener(addedMock.Listen);
+            subject.Removed.AddListener(removedMock.Listen);
+            subject.Emptied.AddListener(emptiedMock.Listen);
 
             GameObject elementOne = new GameObject();
             GameObject elementTwo = new GameObject();
@@ -136,40 +136,40 @@ namespace Test.Zinnia.Data.Collection
             subject.AddUnique(elementOne);
 
             Assert.AreEqual(1, subject.NonSubscribableElements.Count);
-            Assert.IsTrue(becamePopulatedMock.Received);
-            Assert.IsTrue(elementAddedMock.Received);
-            Assert.IsFalse(elementRemovedMock.Received);
-            Assert.IsFalse(becameEmptyMock.Received);
+            Assert.IsTrue(populatedMock.Received);
+            Assert.IsTrue(addedMock.Received);
+            Assert.IsFalse(removedMock.Received);
+            Assert.IsFalse(emptiedMock.Received);
 
-            becamePopulatedMock.Reset();
-            elementAddedMock.Reset();
-            elementRemovedMock.Reset();
-            becameEmptyMock.Reset();
-
-            subject.AddUnique(elementTwo);
-
-            Assert.AreEqual(2, subject.NonSubscribableElements.Count);
-            Assert.AreEqual(elementTwo, subject.NonSubscribableElements[1]);
-
-            Assert.IsFalse(becamePopulatedMock.Received);
-            Assert.IsTrue(elementAddedMock.Received);
-            Assert.IsFalse(elementRemovedMock.Received);
-            Assert.IsFalse(becameEmptyMock.Received);
-
-            becamePopulatedMock.Reset();
-            elementAddedMock.Reset();
-            elementRemovedMock.Reset();
-            becameEmptyMock.Reset();
+            populatedMock.Reset();
+            addedMock.Reset();
+            removedMock.Reset();
+            emptiedMock.Reset();
 
             subject.AddUnique(elementTwo);
 
             Assert.AreEqual(2, subject.NonSubscribableElements.Count);
             Assert.AreEqual(elementTwo, subject.NonSubscribableElements[1]);
 
-            Assert.IsFalse(becamePopulatedMock.Received);
-            Assert.IsFalse(elementAddedMock.Received);
-            Assert.IsFalse(elementRemovedMock.Received);
-            Assert.IsFalse(becameEmptyMock.Received);
+            Assert.IsFalse(populatedMock.Received);
+            Assert.IsTrue(addedMock.Received);
+            Assert.IsFalse(removedMock.Received);
+            Assert.IsFalse(emptiedMock.Received);
+
+            populatedMock.Reset();
+            addedMock.Reset();
+            removedMock.Reset();
+            emptiedMock.Reset();
+
+            subject.AddUnique(elementTwo);
+
+            Assert.AreEqual(2, subject.NonSubscribableElements.Count);
+            Assert.AreEqual(elementTwo, subject.NonSubscribableElements[1]);
+
+            Assert.IsFalse(populatedMock.Received);
+            Assert.IsFalse(addedMock.Received);
+            Assert.IsFalse(removedMock.Received);
+            Assert.IsFalse(emptiedMock.Received);
 
             Object.DestroyImmediate(elementOne);
             Object.DestroyImmediate(elementTwo);
@@ -178,14 +178,14 @@ namespace Test.Zinnia.Data.Collection
         [Test]
         public void AddToStart()
         {
-            UnityEventListenerMock becamePopulatedMock = new UnityEventListenerMock();
-            UnityEventListenerMock elementAddedMock = new UnityEventListenerMock();
-            UnityEventListenerMock elementRemovedMock = new UnityEventListenerMock();
-            UnityEventListenerMock becameEmptyMock = new UnityEventListenerMock();
-            subject.BecamePopulated.AddListener(becamePopulatedMock.Listen);
-            subject.ElementAdded.AddListener(elementAddedMock.Listen);
-            subject.ElementRemoved.AddListener(elementRemovedMock.Listen);
-            subject.BecameEmpty.AddListener(becameEmptyMock.Listen);
+            UnityEventListenerMock populatedMock = new UnityEventListenerMock();
+            UnityEventListenerMock addedMock = new UnityEventListenerMock();
+            UnityEventListenerMock removedMock = new UnityEventListenerMock();
+            UnityEventListenerMock emptiedMock = new UnityEventListenerMock();
+            subject.Populated.AddListener(populatedMock.Listen);
+            subject.Added.AddListener(addedMock.Listen);
+            subject.Removed.AddListener(removedMock.Listen);
+            subject.Emptied.AddListener(emptiedMock.Listen);
 
             GameObject elementOne = new GameObject();
             GameObject elementTwo = new GameObject();
@@ -195,25 +195,25 @@ namespace Test.Zinnia.Data.Collection
             subject.AddAt(elementOne, 0);
 
             Assert.AreEqual(1, subject.NonSubscribableElements.Count);
-            Assert.IsTrue(becamePopulatedMock.Received);
-            Assert.IsTrue(elementAddedMock.Received);
-            Assert.IsFalse(elementRemovedMock.Received);
-            Assert.IsFalse(becameEmptyMock.Received);
+            Assert.IsTrue(populatedMock.Received);
+            Assert.IsTrue(addedMock.Received);
+            Assert.IsFalse(removedMock.Received);
+            Assert.IsFalse(emptiedMock.Received);
 
-            becamePopulatedMock.Reset();
-            elementAddedMock.Reset();
-            elementRemovedMock.Reset();
-            becameEmptyMock.Reset();
+            populatedMock.Reset();
+            addedMock.Reset();
+            removedMock.Reset();
+            emptiedMock.Reset();
 
             subject.AddAt(elementTwo, 0);
 
             Assert.AreEqual(2, subject.NonSubscribableElements.Count);
             Assert.AreEqual(elementTwo, subject.NonSubscribableElements[0]);
 
-            Assert.IsFalse(becamePopulatedMock.Received);
-            Assert.IsTrue(elementAddedMock.Received);
-            Assert.IsFalse(elementRemovedMock.Received);
-            Assert.IsFalse(becameEmptyMock.Received);
+            Assert.IsFalse(populatedMock.Received);
+            Assert.IsTrue(addedMock.Received);
+            Assert.IsFalse(removedMock.Received);
+            Assert.IsFalse(emptiedMock.Received);
 
             Object.DestroyImmediate(elementOne);
             Object.DestroyImmediate(elementTwo);
@@ -222,14 +222,14 @@ namespace Test.Zinnia.Data.Collection
         [Test]
         public void AddUniqueToStart()
         {
-            UnityEventListenerMock becamePopulatedMock = new UnityEventListenerMock();
-            UnityEventListenerMock elementAddedMock = new UnityEventListenerMock();
-            UnityEventListenerMock elementRemovedMock = new UnityEventListenerMock();
-            UnityEventListenerMock becameEmptyMock = new UnityEventListenerMock();
-            subject.BecamePopulated.AddListener(becamePopulatedMock.Listen);
-            subject.ElementAdded.AddListener(elementAddedMock.Listen);
-            subject.ElementRemoved.AddListener(elementRemovedMock.Listen);
-            subject.BecameEmpty.AddListener(becameEmptyMock.Listen);
+            UnityEventListenerMock populatedMock = new UnityEventListenerMock();
+            UnityEventListenerMock addedMock = new UnityEventListenerMock();
+            UnityEventListenerMock removedMock = new UnityEventListenerMock();
+            UnityEventListenerMock emptiedMock = new UnityEventListenerMock();
+            subject.Populated.AddListener(populatedMock.Listen);
+            subject.Added.AddListener(addedMock.Listen);
+            subject.Removed.AddListener(removedMock.Listen);
+            subject.Emptied.AddListener(emptiedMock.Listen);
 
             GameObject elementOne = new GameObject();
             GameObject elementTwo = new GameObject();
@@ -239,40 +239,40 @@ namespace Test.Zinnia.Data.Collection
             subject.AddUniqueAt(elementOne, 0);
 
             Assert.AreEqual(1, subject.NonSubscribableElements.Count);
-            Assert.IsTrue(becamePopulatedMock.Received);
-            Assert.IsTrue(elementAddedMock.Received);
-            Assert.IsFalse(elementRemovedMock.Received);
-            Assert.IsFalse(becameEmptyMock.Received);
+            Assert.IsTrue(populatedMock.Received);
+            Assert.IsTrue(addedMock.Received);
+            Assert.IsFalse(removedMock.Received);
+            Assert.IsFalse(emptiedMock.Received);
 
-            becamePopulatedMock.Reset();
-            elementAddedMock.Reset();
-            elementRemovedMock.Reset();
-            becameEmptyMock.Reset();
+            populatedMock.Reset();
+            addedMock.Reset();
+            removedMock.Reset();
+            emptiedMock.Reset();
 
             subject.AddUniqueAt(elementTwo, 0);
 
             Assert.AreEqual(2, subject.NonSubscribableElements.Count);
             Assert.AreEqual(elementTwo, subject.NonSubscribableElements[0]);
 
-            Assert.IsFalse(becamePopulatedMock.Received);
-            Assert.IsTrue(elementAddedMock.Received);
-            Assert.IsFalse(elementRemovedMock.Received);
-            Assert.IsFalse(becameEmptyMock.Received);
+            Assert.IsFalse(populatedMock.Received);
+            Assert.IsTrue(addedMock.Received);
+            Assert.IsFalse(removedMock.Received);
+            Assert.IsFalse(emptiedMock.Received);
 
-            becamePopulatedMock.Reset();
-            elementAddedMock.Reset();
-            elementRemovedMock.Reset();
-            becameEmptyMock.Reset();
+            populatedMock.Reset();
+            addedMock.Reset();
+            removedMock.Reset();
+            emptiedMock.Reset();
 
             subject.AddUniqueAt(elementOne, 0);
 
             Assert.AreEqual(2, subject.NonSubscribableElements.Count);
             Assert.AreEqual(elementTwo, subject.NonSubscribableElements[0]);
 
-            Assert.IsFalse(becamePopulatedMock.Received);
-            Assert.IsFalse(elementAddedMock.Received);
-            Assert.IsFalse(elementRemovedMock.Received);
-            Assert.IsFalse(becameEmptyMock.Received);
+            Assert.IsFalse(populatedMock.Received);
+            Assert.IsFalse(addedMock.Received);
+            Assert.IsFalse(removedMock.Received);
+            Assert.IsFalse(emptiedMock.Received);
 
             Object.DestroyImmediate(elementOne);
             Object.DestroyImmediate(elementTwo);
@@ -281,14 +281,14 @@ namespace Test.Zinnia.Data.Collection
         [Test]
         public void AddAtCurrentIndex()
         {
-            UnityEventListenerMock becamePopulatedMock = new UnityEventListenerMock();
-            UnityEventListenerMock elementAddedMock = new UnityEventListenerMock();
-            UnityEventListenerMock elementRemovedMock = new UnityEventListenerMock();
-            UnityEventListenerMock becameEmptyMock = new UnityEventListenerMock();
-            subject.BecamePopulated.AddListener(becamePopulatedMock.Listen);
-            subject.ElementAdded.AddListener(elementAddedMock.Listen);
-            subject.ElementRemoved.AddListener(elementRemovedMock.Listen);
-            subject.BecameEmpty.AddListener(becameEmptyMock.Listen);
+            UnityEventListenerMock populatedMock = new UnityEventListenerMock();
+            UnityEventListenerMock addedMock = new UnityEventListenerMock();
+            UnityEventListenerMock removedMock = new UnityEventListenerMock();
+            UnityEventListenerMock emptiedMock = new UnityEventListenerMock();
+            subject.Populated.AddListener(populatedMock.Listen);
+            subject.Added.AddListener(addedMock.Listen);
+            subject.Removed.AddListener(removedMock.Listen);
+            subject.Emptied.AddListener(emptiedMock.Listen);
 
             subject.CurrentIndex = 0;
 
@@ -300,24 +300,24 @@ namespace Test.Zinnia.Data.Collection
             subject.AddAtCurrentIndex(elementOne);
 
             Assert.AreEqual(1, subject.NonSubscribableElements.Count);
-            Assert.IsTrue(becamePopulatedMock.Received);
-            Assert.IsTrue(elementAddedMock.Received);
-            Assert.IsFalse(elementRemovedMock.Received);
-            Assert.IsFalse(becameEmptyMock.Received);
+            Assert.IsTrue(populatedMock.Received);
+            Assert.IsTrue(addedMock.Received);
+            Assert.IsFalse(removedMock.Received);
+            Assert.IsFalse(emptiedMock.Received);
 
-            becamePopulatedMock.Reset();
-            elementAddedMock.Reset();
-            elementRemovedMock.Reset();
-            becameEmptyMock.Reset();
+            populatedMock.Reset();
+            addedMock.Reset();
+            removedMock.Reset();
+            emptiedMock.Reset();
 
             subject.AddAtCurrentIndex(elementTwo);
             Assert.AreEqual(2, subject.NonSubscribableElements.Count);
             Assert.AreEqual(elementTwo, subject.NonSubscribableElements[0]);
 
-            Assert.IsFalse(becamePopulatedMock.Received);
-            Assert.IsTrue(elementAddedMock.Received);
-            Assert.IsFalse(elementRemovedMock.Received);
-            Assert.IsFalse(becameEmptyMock.Received);
+            Assert.IsFalse(populatedMock.Received);
+            Assert.IsTrue(addedMock.Received);
+            Assert.IsFalse(removedMock.Received);
+            Assert.IsFalse(emptiedMock.Received);
 
             Object.DestroyImmediate(elementOne);
             Object.DestroyImmediate(elementTwo);
@@ -326,14 +326,14 @@ namespace Test.Zinnia.Data.Collection
         [Test]
         public void AddUniqueAtCurrentIndex()
         {
-            UnityEventListenerMock becamePopulatedMock = new UnityEventListenerMock();
-            UnityEventListenerMock elementAddedMock = new UnityEventListenerMock();
-            UnityEventListenerMock elementRemovedMock = new UnityEventListenerMock();
-            UnityEventListenerMock becameEmptyMock = new UnityEventListenerMock();
-            subject.BecamePopulated.AddListener(becamePopulatedMock.Listen);
-            subject.ElementAdded.AddListener(elementAddedMock.Listen);
-            subject.ElementRemoved.AddListener(elementRemovedMock.Listen);
-            subject.BecameEmpty.AddListener(becameEmptyMock.Listen);
+            UnityEventListenerMock populatedMock = new UnityEventListenerMock();
+            UnityEventListenerMock addedMock = new UnityEventListenerMock();
+            UnityEventListenerMock removedMock = new UnityEventListenerMock();
+            UnityEventListenerMock emptiedMock = new UnityEventListenerMock();
+            subject.Populated.AddListener(populatedMock.Listen);
+            subject.Added.AddListener(addedMock.Listen);
+            subject.Removed.AddListener(removedMock.Listen);
+            subject.Emptied.AddListener(emptiedMock.Listen);
 
             subject.CurrentIndex = 0;
 
@@ -345,38 +345,38 @@ namespace Test.Zinnia.Data.Collection
             subject.AddUniqueAtCurrentIndex(elementOne);
 
             Assert.AreEqual(1, subject.NonSubscribableElements.Count);
-            Assert.IsTrue(becamePopulatedMock.Received);
-            Assert.IsTrue(elementAddedMock.Received);
-            Assert.IsFalse(elementRemovedMock.Received);
-            Assert.IsFalse(becameEmptyMock.Received);
+            Assert.IsTrue(populatedMock.Received);
+            Assert.IsTrue(addedMock.Received);
+            Assert.IsFalse(removedMock.Received);
+            Assert.IsFalse(emptiedMock.Received);
 
-            becamePopulatedMock.Reset();
-            elementAddedMock.Reset();
-            elementRemovedMock.Reset();
-            becameEmptyMock.Reset();
-
-            subject.AddUniqueAtCurrentIndex(elementTwo);
-            Assert.AreEqual(2, subject.NonSubscribableElements.Count);
-            Assert.AreEqual(elementTwo, subject.NonSubscribableElements[0]);
-
-            Assert.IsFalse(becamePopulatedMock.Received);
-            Assert.IsTrue(elementAddedMock.Received);
-            Assert.IsFalse(elementRemovedMock.Received);
-            Assert.IsFalse(becameEmptyMock.Received);
-
-            becamePopulatedMock.Reset();
-            elementAddedMock.Reset();
-            elementRemovedMock.Reset();
-            becameEmptyMock.Reset();
+            populatedMock.Reset();
+            addedMock.Reset();
+            removedMock.Reset();
+            emptiedMock.Reset();
 
             subject.AddUniqueAtCurrentIndex(elementTwo);
             Assert.AreEqual(2, subject.NonSubscribableElements.Count);
             Assert.AreEqual(elementTwo, subject.NonSubscribableElements[0]);
 
-            Assert.IsFalse(becamePopulatedMock.Received);
-            Assert.IsFalse(elementAddedMock.Received);
-            Assert.IsFalse(elementRemovedMock.Received);
-            Assert.IsFalse(becameEmptyMock.Received);
+            Assert.IsFalse(populatedMock.Received);
+            Assert.IsTrue(addedMock.Received);
+            Assert.IsFalse(removedMock.Received);
+            Assert.IsFalse(emptiedMock.Received);
+
+            populatedMock.Reset();
+            addedMock.Reset();
+            removedMock.Reset();
+            emptiedMock.Reset();
+
+            subject.AddUniqueAtCurrentIndex(elementTwo);
+            Assert.AreEqual(2, subject.NonSubscribableElements.Count);
+            Assert.AreEqual(elementTwo, subject.NonSubscribableElements[0]);
+
+            Assert.IsFalse(populatedMock.Received);
+            Assert.IsFalse(addedMock.Received);
+            Assert.IsFalse(removedMock.Received);
+            Assert.IsFalse(emptiedMock.Received);
 
             Object.DestroyImmediate(elementOne);
             Object.DestroyImmediate(elementTwo);
@@ -385,10 +385,10 @@ namespace Test.Zinnia.Data.Collection
         [Test]
         public void SetAt()
         {
-            UnityEventListenerMock elementAddedMock = new UnityEventListenerMock();
-            UnityEventListenerMock elementRemovedMock = new UnityEventListenerMock();
-            subject.ElementAdded.AddListener(elementAddedMock.Listen);
-            subject.ElementRemoved.AddListener(elementRemovedMock.Listen);
+            UnityEventListenerMock addedMock = new UnityEventListenerMock();
+            UnityEventListenerMock removedMock = new UnityEventListenerMock();
+            subject.Added.AddListener(addedMock.Listen);
+            subject.Removed.AddListener(removedMock.Listen);
 
             GameObject elementOne = new GameObject();
             GameObject elementTwo = new GameObject();
@@ -399,8 +399,8 @@ namespace Test.Zinnia.Data.Collection
             subject.Add(elementTwo);
             subject.Add(elementThree);
 
-            elementAddedMock.Reset();
-            elementRemovedMock.Reset();
+            addedMock.Reset();
+            removedMock.Reset();
 
             Assert.AreEqual(elementOne, subject.NonSubscribableElements[0]);
             Assert.AreEqual(elementTwo, subject.NonSubscribableElements[1]);
@@ -412,8 +412,8 @@ namespace Test.Zinnia.Data.Collection
             Assert.AreEqual(elementFour, subject.NonSubscribableElements[1]);
             Assert.AreEqual(elementThree, subject.NonSubscribableElements[2]);
 
-            Assert.IsTrue(elementAddedMock.Received);
-            Assert.IsTrue(elementRemovedMock.Received);
+            Assert.IsTrue(addedMock.Received);
+            Assert.IsTrue(removedMock.Received);
 
             Object.DestroyImmediate(elementOne);
             Object.DestroyImmediate(elementTwo);
@@ -424,10 +424,10 @@ namespace Test.Zinnia.Data.Collection
         [Test]
         public void SetUniqueAt()
         {
-            UnityEventListenerMock elementAddedMock = new UnityEventListenerMock();
-            UnityEventListenerMock elementRemovedMock = new UnityEventListenerMock();
-            subject.ElementAdded.AddListener(elementAddedMock.Listen);
-            subject.ElementRemoved.AddListener(elementRemovedMock.Listen);
+            UnityEventListenerMock addedMock = new UnityEventListenerMock();
+            UnityEventListenerMock removedMock = new UnityEventListenerMock();
+            subject.Added.AddListener(addedMock.Listen);
+            subject.Removed.AddListener(removedMock.Listen);
 
             GameObject elementOne = new GameObject();
             GameObject elementTwo = new GameObject();
@@ -437,8 +437,8 @@ namespace Test.Zinnia.Data.Collection
             subject.Add(elementTwo);
             subject.Add(elementThree);
 
-            elementAddedMock.Reset();
-            elementRemovedMock.Reset();
+            addedMock.Reset();
+            removedMock.Reset();
 
             Assert.AreEqual(elementOne, subject.NonSubscribableElements[0]);
             Assert.AreEqual(elementTwo, subject.NonSubscribableElements[1]);
@@ -450,8 +450,8 @@ namespace Test.Zinnia.Data.Collection
             Assert.AreEqual(elementTwo, subject.NonSubscribableElements[1]);
             Assert.AreEqual(elementThree, subject.NonSubscribableElements[2]);
 
-            Assert.IsFalse(elementAddedMock.Received);
-            Assert.IsFalse(elementRemovedMock.Received);
+            Assert.IsFalse(addedMock.Received);
+            Assert.IsFalse(removedMock.Received);
 
             Object.DestroyImmediate(elementOne);
             Object.DestroyImmediate(elementTwo);
@@ -461,10 +461,10 @@ namespace Test.Zinnia.Data.Collection
         [Test]
         public void SetAtCurrentIndex()
         {
-            UnityEventListenerMock elementAddedMock = new UnityEventListenerMock();
-            UnityEventListenerMock elementRemovedMock = new UnityEventListenerMock();
-            subject.ElementAdded.AddListener(elementAddedMock.Listen);
-            subject.ElementRemoved.AddListener(elementRemovedMock.Listen);
+            UnityEventListenerMock addedMock = new UnityEventListenerMock();
+            UnityEventListenerMock removedMock = new UnityEventListenerMock();
+            subject.Added.AddListener(addedMock.Listen);
+            subject.Removed.AddListener(removedMock.Listen);
 
             subject.CurrentIndex = 1;
 
@@ -477,8 +477,8 @@ namespace Test.Zinnia.Data.Collection
             subject.Add(elementTwo);
             subject.Add(elementThree);
 
-            elementAddedMock.Reset();
-            elementRemovedMock.Reset();
+            addedMock.Reset();
+            removedMock.Reset();
 
             Assert.AreEqual(elementOne, subject.NonSubscribableElements[0]);
             Assert.AreEqual(elementTwo, subject.NonSubscribableElements[1]);
@@ -490,8 +490,8 @@ namespace Test.Zinnia.Data.Collection
             Assert.AreEqual(elementFour, subject.NonSubscribableElements[1]);
             Assert.AreEqual(elementThree, subject.NonSubscribableElements[2]);
 
-            Assert.IsTrue(elementAddedMock.Received);
-            Assert.IsTrue(elementRemovedMock.Received);
+            Assert.IsTrue(addedMock.Received);
+            Assert.IsTrue(removedMock.Received);
 
             Object.DestroyImmediate(elementOne);
             Object.DestroyImmediate(elementTwo);
@@ -502,10 +502,10 @@ namespace Test.Zinnia.Data.Collection
         [Test]
         public void SetUniqueAtCurrentIndex()
         {
-            UnityEventListenerMock elementAddedMock = new UnityEventListenerMock();
-            UnityEventListenerMock elementRemovedMock = new UnityEventListenerMock();
-            subject.ElementAdded.AddListener(elementAddedMock.Listen);
-            subject.ElementRemoved.AddListener(elementRemovedMock.Listen);
+            UnityEventListenerMock addedMock = new UnityEventListenerMock();
+            UnityEventListenerMock removedMock = new UnityEventListenerMock();
+            subject.Added.AddListener(addedMock.Listen);
+            subject.Removed.AddListener(removedMock.Listen);
 
             subject.CurrentIndex = 1;
 
@@ -517,8 +517,8 @@ namespace Test.Zinnia.Data.Collection
             subject.Add(elementTwo);
             subject.Add(elementThree);
 
-            elementAddedMock.Reset();
-            elementRemovedMock.Reset();
+            addedMock.Reset();
+            removedMock.Reset();
 
             Assert.AreEqual(elementOne, subject.NonSubscribableElements[0]);
             Assert.AreEqual(elementTwo, subject.NonSubscribableElements[1]);
@@ -530,8 +530,8 @@ namespace Test.Zinnia.Data.Collection
             Assert.AreEqual(elementTwo, subject.NonSubscribableElements[1]);
             Assert.AreEqual(elementThree, subject.NonSubscribableElements[2]);
 
-            Assert.IsFalse(elementAddedMock.Received);
-            Assert.IsFalse(elementRemovedMock.Received);
+            Assert.IsFalse(addedMock.Received);
+            Assert.IsFalse(removedMock.Received);
 
             Object.DestroyImmediate(elementOne);
             Object.DestroyImmediate(elementTwo);
@@ -541,80 +541,80 @@ namespace Test.Zinnia.Data.Collection
         [Test]
         public void RemoveFirst()
         {
-            UnityEventListenerMock becamePopulatedMock = new UnityEventListenerMock();
-            UnityEventListenerMock elementAddedMock = new UnityEventListenerMock();
-            UnityEventListenerMock elementRemovedMock = new UnityEventListenerMock();
-            UnityEventListenerMock becameEmptyMock = new UnityEventListenerMock();
-            subject.BecamePopulated.AddListener(becamePopulatedMock.Listen);
-            subject.ElementAdded.AddListener(elementAddedMock.Listen);
-            subject.ElementRemoved.AddListener(elementRemovedMock.Listen);
-            subject.BecameEmpty.AddListener(becameEmptyMock.Listen);
+            UnityEventListenerMock populatedMock = new UnityEventListenerMock();
+            UnityEventListenerMock addedMock = new UnityEventListenerMock();
+            UnityEventListenerMock removedMock = new UnityEventListenerMock();
+            UnityEventListenerMock emptiedMock = new UnityEventListenerMock();
+            subject.Populated.AddListener(populatedMock.Listen);
+            subject.Added.AddListener(addedMock.Listen);
+            subject.Removed.AddListener(removedMock.Listen);
+            subject.Emptied.AddListener(emptiedMock.Listen);
 
             GameObject elementOne = new GameObject();
             GameObject elementTwo = new GameObject();
 
             subject.Remove(elementOne);
 
-            Assert.IsFalse(becamePopulatedMock.Received);
-            Assert.IsFalse(elementAddedMock.Received);
-            Assert.IsFalse(elementRemovedMock.Received);
-            Assert.IsFalse(becameEmptyMock.Received);
+            Assert.IsFalse(populatedMock.Received);
+            Assert.IsFalse(addedMock.Received);
+            Assert.IsFalse(removedMock.Received);
+            Assert.IsFalse(emptiedMock.Received);
 
             subject.Add(elementOne);
             subject.Add(elementTwo);
             subject.Add(elementOne);
 
-            becamePopulatedMock.Reset();
-            elementAddedMock.Reset();
-            elementRemovedMock.Reset();
-            becameEmptyMock.Reset();
+            populatedMock.Reset();
+            addedMock.Reset();
+            removedMock.Reset();
+            emptiedMock.Reset();
 
             Assert.AreEqual(3, subject.NonSubscribableElements.Count);
 
             subject.Remove(elementOne);
 
-            Assert.IsFalse(becamePopulatedMock.Received);
-            Assert.IsFalse(elementAddedMock.Received);
-            Assert.IsTrue(elementRemovedMock.Received);
-            Assert.IsFalse(becameEmptyMock.Received);
+            Assert.IsFalse(populatedMock.Received);
+            Assert.IsFalse(addedMock.Received);
+            Assert.IsTrue(removedMock.Received);
+            Assert.IsFalse(emptiedMock.Received);
 
             Assert.AreEqual(2, subject.NonSubscribableElements.Count);
             Assert.AreEqual(elementTwo, subject.NonSubscribableElements[0]);
             Assert.AreEqual(elementOne, subject.NonSubscribableElements[1]);
 
-            becamePopulatedMock.Reset();
-            elementAddedMock.Reset();
-            elementRemovedMock.Reset();
-            becameEmptyMock.Reset();
+            populatedMock.Reset();
+            addedMock.Reset();
+            removedMock.Reset();
+            emptiedMock.Reset();
 
             subject.Remove(elementOne);
 
-            Assert.IsFalse(becamePopulatedMock.Received);
-            Assert.IsFalse(elementAddedMock.Received);
-            Assert.IsTrue(elementRemovedMock.Received);
-            Assert.IsFalse(becameEmptyMock.Received);
+            Assert.IsFalse(populatedMock.Received);
+            Assert.IsFalse(addedMock.Received);
+            Assert.IsTrue(removedMock.Received);
+            Assert.IsFalse(emptiedMock.Received);
 
             Assert.AreEqual(1, subject.NonSubscribableElements.Count);
             Assert.AreEqual(elementTwo, subject.NonSubscribableElements[0]);
 
-            becamePopulatedMock.Reset();
-            elementAddedMock.Reset();
-            elementRemovedMock.Reset();
-            becameEmptyMock.Reset();
+            populatedMock.Reset();
+            addedMock.Reset();
+            removedMock.Reset();
+            emptiedMock.Reset();
 
             subject.Remove(elementTwo);
 
-            Assert.IsFalse(becamePopulatedMock.Received);
-            Assert.IsFalse(elementAddedMock.Received);
-            Assert.IsTrue(elementRemovedMock.Received);
-            Assert.IsTrue(becameEmptyMock.Received);
+            Assert.IsFalse(populatedMock.Received);
+            Assert.IsFalse(addedMock.Received);
+            Assert.IsTrue(removedMock.Received);
+            Assert.IsTrue(emptiedMock.Received);
 
             Assert.AreEqual(0, subject.NonSubscribableElements.Count);
 
-            becamePopulatedMock.Reset();
-            elementAddedMock.Reset();
-            elementRemovedMock.Reset();
-            becameEmptyMock.Reset();
+            populatedMock.Reset();
+            addedMock.Reset();
+            removedMock.Reset();
+            emptiedMock.Reset();
 
             Object.DestroyImmediate(elementOne);
             Object.DestroyImmediate(elementTwo);
@@ -623,80 +623,80 @@ namespace Test.Zinnia.Data.Collection
         [Test]
         public void RemoveLast()
         {
-            UnityEventListenerMock becamePopulatedMock = new UnityEventListenerMock();
-            UnityEventListenerMock elementAddedMock = new UnityEventListenerMock();
-            UnityEventListenerMock elementRemovedMock = new UnityEventListenerMock();
-            UnityEventListenerMock becameEmptyMock = new UnityEventListenerMock();
-            subject.BecamePopulated.AddListener(becamePopulatedMock.Listen);
-            subject.ElementAdded.AddListener(elementAddedMock.Listen);
-            subject.ElementRemoved.AddListener(elementRemovedMock.Listen);
-            subject.BecameEmpty.AddListener(becameEmptyMock.Listen);
+            UnityEventListenerMock populatedMock = new UnityEventListenerMock();
+            UnityEventListenerMock addedMock = new UnityEventListenerMock();
+            UnityEventListenerMock removedMock = new UnityEventListenerMock();
+            UnityEventListenerMock emptiedMock = new UnityEventListenerMock();
+            subject.Populated.AddListener(populatedMock.Listen);
+            subject.Added.AddListener(addedMock.Listen);
+            subject.Removed.AddListener(removedMock.Listen);
+            subject.Emptied.AddListener(emptiedMock.Listen);
 
             GameObject elementOne = new GameObject();
             GameObject elementTwo = new GameObject();
 
             subject.RemoveLastOccurrence(elementOne);
 
-            Assert.IsFalse(becamePopulatedMock.Received);
-            Assert.IsFalse(elementAddedMock.Received);
-            Assert.IsFalse(elementRemovedMock.Received);
-            Assert.IsFalse(becameEmptyMock.Received);
+            Assert.IsFalse(populatedMock.Received);
+            Assert.IsFalse(addedMock.Received);
+            Assert.IsFalse(removedMock.Received);
+            Assert.IsFalse(emptiedMock.Received);
 
             subject.Add(elementOne);
             subject.Add(elementTwo);
             subject.Add(elementOne);
 
-            becamePopulatedMock.Reset();
-            elementAddedMock.Reset();
-            elementRemovedMock.Reset();
-            becameEmptyMock.Reset();
+            populatedMock.Reset();
+            addedMock.Reset();
+            removedMock.Reset();
+            emptiedMock.Reset();
 
             Assert.AreEqual(3, subject.NonSubscribableElements.Count);
 
             subject.RemoveLastOccurrence(elementOne);
 
-            Assert.IsFalse(becamePopulatedMock.Received);
-            Assert.IsFalse(elementAddedMock.Received);
-            Assert.IsTrue(elementRemovedMock.Received);
-            Assert.IsFalse(becameEmptyMock.Received);
+            Assert.IsFalse(populatedMock.Received);
+            Assert.IsFalse(addedMock.Received);
+            Assert.IsTrue(removedMock.Received);
+            Assert.IsFalse(emptiedMock.Received);
 
             Assert.AreEqual(2, subject.NonSubscribableElements.Count);
             Assert.AreEqual(elementOne, subject.NonSubscribableElements[0]);
             Assert.AreEqual(elementTwo, subject.NonSubscribableElements[1]);
 
-            becamePopulatedMock.Reset();
-            elementAddedMock.Reset();
-            elementRemovedMock.Reset();
-            becameEmptyMock.Reset();
+            populatedMock.Reset();
+            addedMock.Reset();
+            removedMock.Reset();
+            emptiedMock.Reset();
 
             subject.RemoveLastOccurrence(elementOne);
 
-            Assert.IsFalse(becamePopulatedMock.Received);
-            Assert.IsFalse(elementAddedMock.Received);
-            Assert.IsTrue(elementRemovedMock.Received);
-            Assert.IsFalse(becameEmptyMock.Received);
+            Assert.IsFalse(populatedMock.Received);
+            Assert.IsFalse(addedMock.Received);
+            Assert.IsTrue(removedMock.Received);
+            Assert.IsFalse(emptiedMock.Received);
 
             Assert.AreEqual(1, subject.NonSubscribableElements.Count);
             Assert.AreEqual(elementTwo, subject.NonSubscribableElements[0]);
 
-            becamePopulatedMock.Reset();
-            elementAddedMock.Reset();
-            elementRemovedMock.Reset();
-            becameEmptyMock.Reset();
+            populatedMock.Reset();
+            addedMock.Reset();
+            removedMock.Reset();
+            emptiedMock.Reset();
 
             subject.RemoveLastOccurrence(elementTwo);
 
-            Assert.IsFalse(becamePopulatedMock.Received);
-            Assert.IsFalse(elementAddedMock.Received);
-            Assert.IsTrue(elementRemovedMock.Received);
-            Assert.IsTrue(becameEmptyMock.Received);
+            Assert.IsFalse(populatedMock.Received);
+            Assert.IsFalse(addedMock.Received);
+            Assert.IsTrue(removedMock.Received);
+            Assert.IsTrue(emptiedMock.Received);
 
             Assert.AreEqual(0, subject.NonSubscribableElements.Count);
 
-            becamePopulatedMock.Reset();
-            elementAddedMock.Reset();
-            elementRemovedMock.Reset();
-            becameEmptyMock.Reset();
+            populatedMock.Reset();
+            addedMock.Reset();
+            removedMock.Reset();
+            emptiedMock.Reset();
 
             Object.DestroyImmediate(elementOne);
             Object.DestroyImmediate(elementTwo);
@@ -705,14 +705,14 @@ namespace Test.Zinnia.Data.Collection
         [Test]
         public void RemoveAt()
         {
-            UnityEventListenerMock becamePopulatedMock = new UnityEventListenerMock();
-            UnityEventListenerMock elementAddedMock = new UnityEventListenerMock();
-            UnityEventListenerMock elementRemovedMock = new UnityEventListenerMock();
-            UnityEventListenerMock becameEmptyMock = new UnityEventListenerMock();
-            subject.BecamePopulated.AddListener(becamePopulatedMock.Listen);
-            subject.ElementAdded.AddListener(elementAddedMock.Listen);
-            subject.ElementRemoved.AddListener(elementRemovedMock.Listen);
-            subject.BecameEmpty.AddListener(becameEmptyMock.Listen);
+            UnityEventListenerMock populatedMock = new UnityEventListenerMock();
+            UnityEventListenerMock addedMock = new UnityEventListenerMock();
+            UnityEventListenerMock removedMock = new UnityEventListenerMock();
+            UnityEventListenerMock emptiedMock = new UnityEventListenerMock();
+            subject.Populated.AddListener(populatedMock.Listen);
+            subject.Added.AddListener(addedMock.Listen);
+            subject.Removed.AddListener(removedMock.Listen);
+            subject.Emptied.AddListener(emptiedMock.Listen);
 
             GameObject elementOne = new GameObject();
             GameObject elementTwo = new GameObject();
@@ -720,37 +720,37 @@ namespace Test.Zinnia.Data.Collection
 
             Assert.AreEqual(0, subject.NonSubscribableElements.Count);
 
-            Assert.IsFalse(becamePopulatedMock.Received);
-            Assert.IsFalse(elementAddedMock.Received);
-            Assert.IsFalse(elementRemovedMock.Received);
-            Assert.IsFalse(becameEmptyMock.Received);
+            Assert.IsFalse(populatedMock.Received);
+            Assert.IsFalse(addedMock.Received);
+            Assert.IsFalse(removedMock.Received);
+            Assert.IsFalse(emptiedMock.Received);
 
             subject.Add(elementOne);
             subject.Add(elementTwo);
             subject.Add(elementThree);
 
-            becamePopulatedMock.Reset();
-            elementAddedMock.Reset();
-            elementRemovedMock.Reset();
-            becameEmptyMock.Reset();
+            populatedMock.Reset();
+            addedMock.Reset();
+            removedMock.Reset();
+            emptiedMock.Reset();
 
             Assert.AreEqual(3, subject.NonSubscribableElements.Count);
 
             subject.RemoveAt(1);
 
-            Assert.IsFalse(becamePopulatedMock.Received);
-            Assert.IsFalse(elementAddedMock.Received);
-            Assert.IsTrue(elementRemovedMock.Received);
-            Assert.IsFalse(becameEmptyMock.Received);
+            Assert.IsFalse(populatedMock.Received);
+            Assert.IsFalse(addedMock.Received);
+            Assert.IsTrue(removedMock.Received);
+            Assert.IsFalse(emptiedMock.Received);
 
             Assert.AreEqual(2, subject.NonSubscribableElements.Count);
             Assert.AreEqual(elementOne, subject.NonSubscribableElements[0]);
             Assert.AreEqual(elementThree, subject.NonSubscribableElements[1]);
 
-            becamePopulatedMock.Reset();
-            elementAddedMock.Reset();
-            elementRemovedMock.Reset();
-            becameEmptyMock.Reset();
+            populatedMock.Reset();
+            addedMock.Reset();
+            removedMock.Reset();
+            emptiedMock.Reset();
 
             Object.DestroyImmediate(elementOne);
             Object.DestroyImmediate(elementTwo);
@@ -760,14 +760,14 @@ namespace Test.Zinnia.Data.Collection
         [Test]
         public void RemoveAtCurrentIndex()
         {
-            UnityEventListenerMock becamePopulatedMock = new UnityEventListenerMock();
-            UnityEventListenerMock elementAddedMock = new UnityEventListenerMock();
-            UnityEventListenerMock elementRemovedMock = new UnityEventListenerMock();
-            UnityEventListenerMock becameEmptyMock = new UnityEventListenerMock();
-            subject.BecamePopulated.AddListener(becamePopulatedMock.Listen);
-            subject.ElementAdded.AddListener(elementAddedMock.Listen);
-            subject.ElementRemoved.AddListener(elementRemovedMock.Listen);
-            subject.BecameEmpty.AddListener(becameEmptyMock.Listen);
+            UnityEventListenerMock populatedMock = new UnityEventListenerMock();
+            UnityEventListenerMock addedMock = new UnityEventListenerMock();
+            UnityEventListenerMock removedMock = new UnityEventListenerMock();
+            UnityEventListenerMock emptiedMock = new UnityEventListenerMock();
+            subject.Populated.AddListener(populatedMock.Listen);
+            subject.Added.AddListener(addedMock.Listen);
+            subject.Removed.AddListener(removedMock.Listen);
+            subject.Emptied.AddListener(emptiedMock.Listen);
 
             subject.CurrentIndex = 1;
 
@@ -777,37 +777,37 @@ namespace Test.Zinnia.Data.Collection
 
             Assert.AreEqual(0, subject.NonSubscribableElements.Count);
 
-            Assert.IsFalse(becamePopulatedMock.Received);
-            Assert.IsFalse(elementAddedMock.Received);
-            Assert.IsFalse(elementRemovedMock.Received);
-            Assert.IsFalse(becameEmptyMock.Received);
+            Assert.IsFalse(populatedMock.Received);
+            Assert.IsFalse(addedMock.Received);
+            Assert.IsFalse(removedMock.Received);
+            Assert.IsFalse(emptiedMock.Received);
 
             subject.Add(elementOne);
             subject.Add(elementTwo);
             subject.Add(elementThree);
 
-            becamePopulatedMock.Reset();
-            elementAddedMock.Reset();
-            elementRemovedMock.Reset();
-            becameEmptyMock.Reset();
+            populatedMock.Reset();
+            addedMock.Reset();
+            removedMock.Reset();
+            emptiedMock.Reset();
 
             Assert.AreEqual(3, subject.NonSubscribableElements.Count);
 
             subject.RemoveAtCurrentIndex();
 
-            Assert.IsFalse(becamePopulatedMock.Received);
-            Assert.IsFalse(elementAddedMock.Received);
-            Assert.IsTrue(elementRemovedMock.Received);
-            Assert.IsFalse(becameEmptyMock.Received);
+            Assert.IsFalse(populatedMock.Received);
+            Assert.IsFalse(addedMock.Received);
+            Assert.IsTrue(removedMock.Received);
+            Assert.IsFalse(emptiedMock.Received);
 
             Assert.AreEqual(2, subject.NonSubscribableElements.Count);
             Assert.AreEqual(elementOne, subject.NonSubscribableElements[0]);
             Assert.AreEqual(elementThree, subject.NonSubscribableElements[1]);
 
-            becamePopulatedMock.Reset();
-            elementAddedMock.Reset();
-            elementRemovedMock.Reset();
-            becameEmptyMock.Reset();
+            populatedMock.Reset();
+            addedMock.Reset();
+            removedMock.Reset();
+            emptiedMock.Reset();
 
             Object.DestroyImmediate(elementOne);
             Object.DestroyImmediate(elementTwo);
@@ -817,42 +817,42 @@ namespace Test.Zinnia.Data.Collection
         [Test]
         public void ClearFromBack()
         {
-            UnityEventListenerMock becamePopulatedMock = new UnityEventListenerMock();
-            UnityEventListenerMock elementAddedMock = new UnityEventListenerMock();
-            UnityEventListenerMock elementRemovedMock = new UnityEventListenerMock();
-            UnityEventListenerMock becameEmptyMock = new UnityEventListenerMock();
-            subject.BecamePopulated.AddListener(becamePopulatedMock.Listen);
-            subject.ElementAdded.AddListener(elementAddedMock.Listen);
-            subject.ElementRemoved.AddListener(elementRemovedMock.Listen);
-            subject.BecameEmpty.AddListener(becameEmptyMock.Listen);
+            UnityEventListenerMock populatedMock = new UnityEventListenerMock();
+            UnityEventListenerMock addedMock = new UnityEventListenerMock();
+            UnityEventListenerMock removedMock = new UnityEventListenerMock();
+            UnityEventListenerMock emptiedMock = new UnityEventListenerMock();
+            subject.Populated.AddListener(populatedMock.Listen);
+            subject.Added.AddListener(addedMock.Listen);
+            subject.Removed.AddListener(removedMock.Listen);
+            subject.Emptied.AddListener(emptiedMock.Listen);
 
             GameObject elementOne = new GameObject();
             GameObject elementTwo = new GameObject();
 
             subject.Clear(false);
 
-            Assert.IsFalse(becamePopulatedMock.Received);
-            Assert.IsFalse(elementAddedMock.Received);
-            Assert.IsFalse(elementRemovedMock.Received);
-            Assert.IsFalse(becameEmptyMock.Received);
+            Assert.IsFalse(populatedMock.Received);
+            Assert.IsFalse(addedMock.Received);
+            Assert.IsFalse(removedMock.Received);
+            Assert.IsFalse(emptiedMock.Received);
 
             subject.Add(elementOne);
             subject.Add(elementTwo);
             subject.Add(elementOne);
 
-            becamePopulatedMock.Reset();
-            elementAddedMock.Reset();
-            elementRemovedMock.Reset();
-            becameEmptyMock.Reset();
+            populatedMock.Reset();
+            addedMock.Reset();
+            removedMock.Reset();
+            emptiedMock.Reset();
 
             Assert.AreEqual(3, subject.NonSubscribableElements.Count);
 
             subject.Clear(false);
 
-            Assert.IsFalse(becamePopulatedMock.Received);
-            Assert.IsFalse(elementAddedMock.Received);
-            Assert.IsTrue(elementRemovedMock.Received);
-            Assert.IsTrue(becameEmptyMock.Received);
+            Assert.IsFalse(populatedMock.Received);
+            Assert.IsFalse(addedMock.Received);
+            Assert.IsTrue(removedMock.Received);
+            Assert.IsTrue(emptiedMock.Received);
 
             Assert.AreEqual(0, subject.NonSubscribableElements.Count);
 
@@ -863,42 +863,42 @@ namespace Test.Zinnia.Data.Collection
         [Test]
         public void ClearFromFront()
         {
-            UnityEventListenerMock becamePopulatedMock = new UnityEventListenerMock();
-            UnityEventListenerMock elementAddedMock = new UnityEventListenerMock();
-            UnityEventListenerMock elementRemovedMock = new UnityEventListenerMock();
-            UnityEventListenerMock becameEmptyMock = new UnityEventListenerMock();
-            subject.BecamePopulated.AddListener(becamePopulatedMock.Listen);
-            subject.ElementAdded.AddListener(elementAddedMock.Listen);
-            subject.ElementRemoved.AddListener(elementRemovedMock.Listen);
-            subject.BecameEmpty.AddListener(becameEmptyMock.Listen);
+            UnityEventListenerMock populatedMock = new UnityEventListenerMock();
+            UnityEventListenerMock addedMock = new UnityEventListenerMock();
+            UnityEventListenerMock removedMock = new UnityEventListenerMock();
+            UnityEventListenerMock emptiedMock = new UnityEventListenerMock();
+            subject.Populated.AddListener(populatedMock.Listen);
+            subject.Added.AddListener(addedMock.Listen);
+            subject.Removed.AddListener(removedMock.Listen);
+            subject.Emptied.AddListener(emptiedMock.Listen);
 
             GameObject elementOne = new GameObject();
             GameObject elementTwo = new GameObject();
 
             subject.Clear(true);
 
-            Assert.IsFalse(becamePopulatedMock.Received);
-            Assert.IsFalse(elementAddedMock.Received);
-            Assert.IsFalse(elementRemovedMock.Received);
-            Assert.IsFalse(becameEmptyMock.Received);
+            Assert.IsFalse(populatedMock.Received);
+            Assert.IsFalse(addedMock.Received);
+            Assert.IsFalse(removedMock.Received);
+            Assert.IsFalse(emptiedMock.Received);
 
             subject.Add(elementOne);
             subject.Add(elementTwo);
             subject.Add(elementOne);
 
-            becamePopulatedMock.Reset();
-            elementAddedMock.Reset();
-            elementRemovedMock.Reset();
-            becameEmptyMock.Reset();
+            populatedMock.Reset();
+            addedMock.Reset();
+            removedMock.Reset();
+            emptiedMock.Reset();
 
             Assert.AreEqual(3, subject.NonSubscribableElements.Count);
 
             subject.Clear(true);
 
-            Assert.IsFalse(becamePopulatedMock.Received);
-            Assert.IsFalse(elementAddedMock.Received);
-            Assert.IsTrue(elementRemovedMock.Received);
-            Assert.IsTrue(becameEmptyMock.Received);
+            Assert.IsFalse(populatedMock.Received);
+            Assert.IsFalse(addedMock.Received);
+            Assert.IsTrue(removedMock.Received);
+            Assert.IsTrue(emptiedMock.Received);
 
             Assert.AreEqual(0, subject.NonSubscribableElements.Count);
 
@@ -915,26 +915,26 @@ namespace Test.Zinnia.Data.Collection
             mock.Add(elementOne);
             mock.Add(elementTwo);
 
-            UnityEventListenerMock becamePopulatedMock = new UnityEventListenerMock();
-            UnityEventListenerMock elementAddedMock = new UnityEventListenerMock();
-            UnityEventListenerMock elementRemovedMock = new UnityEventListenerMock();
-            UnityEventListenerMock becameEmptyMock = new UnityEventListenerMock();
-            mock.BecamePopulated.AddListener(becamePopulatedMock.Listen);
-            mock.ElementAdded.AddListener(elementAddedMock.Listen);
-            mock.ElementRemoved.AddListener(elementRemovedMock.Listen);
-            mock.BecameEmpty.AddListener(becameEmptyMock.Listen);
+            UnityEventListenerMock populatedMock = new UnityEventListenerMock();
+            UnityEventListenerMock addedMock = new UnityEventListenerMock();
+            UnityEventListenerMock removedMock = new UnityEventListenerMock();
+            UnityEventListenerMock emptiedMock = new UnityEventListenerMock();
+            mock.Populated.AddListener(populatedMock.Listen);
+            mock.Added.AddListener(addedMock.Listen);
+            mock.Removed.AddListener(removedMock.Listen);
+            mock.Emptied.AddListener(emptiedMock.Listen);
 
-            Assert.IsFalse(becamePopulatedMock.Received);
-            Assert.IsFalse(elementAddedMock.Received);
-            Assert.IsFalse(elementRemovedMock.Received);
-            Assert.IsFalse(becameEmptyMock.Received);
+            Assert.IsFalse(populatedMock.Received);
+            Assert.IsFalse(addedMock.Received);
+            Assert.IsFalse(removedMock.Received);
+            Assert.IsFalse(emptiedMock.Received);
 
             mock.ManualStart();
 
-            Assert.IsTrue(becamePopulatedMock.Received);
-            Assert.IsTrue(elementAddedMock.Received);
-            Assert.IsFalse(elementRemovedMock.Received);
-            Assert.IsFalse(becameEmptyMock.Received);
+            Assert.IsTrue(populatedMock.Received);
+            Assert.IsTrue(addedMock.Received);
+            Assert.IsFalse(removedMock.Received);
+            Assert.IsFalse(emptiedMock.Received);
 
             Object.DestroyImmediate(elementOne);
             Object.DestroyImmediate(elementTwo);


### PR DESCRIPTION
The events in the ObservableList have been renamed to more appropriate
event names to make it clearer and more precise of their use.