### PR TITLE
fix(Data): ensure correct list state when emitting inspector events - fixes #333

### DIFF
--- a/Runtime/Data/Collection/ObservableList.cs
+++ b/Runtime/Data/Collection/ObservableList.cs
@@ -210,10 +210,8 @@
             }
 
             index = Elements.GetWrappedAndClampedIndex(index);
-
-            EmitRemoveEvents(Elements[index]);
-            Elements[index] = element;
-            EmitAddEvents(element);
+            RemoveAt(index);
+            AddAt(element, index);
         }
 
         /// <summary>


### PR DESCRIPTION
When changing the size of an ObservableList via the inspector the
custom inspector would not call the events while the list is in the
expected state. The fix is to revert changes Unity already did
through serialization, then call the same API a code change would
call. This ensures the events are raised while the list is in the
same state it would be if the change is done via code or a
UnityEvent listener.