### PR TITLE
feat(Attribute): add additional readonly options to Restricted

### DIFF
--- a/Editor/Data/Attribute/RestrictedAttributeDrawer.cs
+++ b/Editor/Data/Attribute/RestrictedAttributeDrawer.cs
@@ -10,10 +10,14 @@
         {
             EditorGUI.BeginProperty(position, label, property);
             RestrictedAttribute attrib = (RestrictedAttribute)attribute;
+            Behaviour behaviour = (Behaviour)property.serializedObject.targetObject;
 
-            bool isPlayingAndActiveAndEnabled = Application.isPlaying && property.serializedObject.targetObject is Behaviour behaviour && behaviour.isActiveAndEnabled;
+            bool isPlayingAndActiveAndEnabled = Application.isPlaying && behaviour.isActiveAndEnabled;
+            bool isPlayingAndActiveAndDisabled = Application.isPlaying && !behaviour.isActiveAndEnabled;
             bool makeReadOnly = (attrib.restrictions & RestrictedAttribute.Restrictions.ReadOnlyAlways) != 0 ||
-                ((attrib.restrictions & RestrictedAttribute.Restrictions.ReadOnlyWhenPlayingAndEnabled) != 0 && isPlayingAndActiveAndEnabled);
+                ((attrib.restrictions & RestrictedAttribute.Restrictions.ReadOnlyAtRunTime) != 0 && Application.isPlaying) ||
+                ((attrib.restrictions & RestrictedAttribute.Restrictions.ReadOnlyAtRunTimeAndEnabled) != 0 && isPlayingAndActiveAndEnabled) ||
+                ((attrib.restrictions & RestrictedAttribute.Restrictions.ReadOnlyAtRunTimeAndDisabled) != 0 && isPlayingAndActiveAndDisabled);
 
             bool muteProperty = (attrib.restrictions & RestrictedAttribute.Restrictions.Muted) != 0;
 

--- a/Runtime/Data/Attribute/RestrictedAttribute.cs
+++ b/Runtime/Data/Attribute/RestrictedAttribute.cs
@@ -15,17 +15,25 @@
         public enum Restrictions
         {
             /// <summary>
+            /// The property is de-emphasized.
+            /// </summary>
+            Muted = 1 << 0,
+            /// <summary>
             /// The property is always read-only.
             /// </summary>
-            ReadOnlyAlways = 1 << 0,
+            ReadOnlyAlways = 1 << 1,
+            /// <summary>
+            /// The property is read-only when the application is playing.
+            /// </summary>
+            ReadOnlyAtRunTime = 1 << 2,
             /// <summary>
             /// The property is read-only when the application is playing and the component is enabled.
             /// </summary>
-            ReadOnlyWhenPlayingAndEnabled = 1 << 1,
+            ReadOnlyAtRunTimeAndEnabled = 1 << 4,
             /// <summary>
-            /// The property is de-emphasized.
+            /// The property is read-only when the application is playing and the component is disabled.
             /// </summary>
-            Muted = 1 << 2
+            ReadOnlyAtRunTimeAndDisabled = 1 << 8,
         }
 
         /// <summary>
@@ -37,7 +45,7 @@
         /// Draws the property in a specified restricted way.
         /// </summary>
         /// <param name="restrictions">The restriction options to apply.</param>
-        public RestrictedAttribute(Restrictions restrictions = Restrictions.ReadOnlyWhenPlayingAndEnabled | Restrictions.Muted)
+        public RestrictedAttribute(Restrictions restrictions = Restrictions.ReadOnlyAtRunTime | Restrictions.Muted)
         {
             this.restrictions = restrictions;
         }


### PR DESCRIPTION
The Restricted attribute now has a couple of additional options for
defining a read-only field. It now can be:

* ReadOnlyAlways: Always readonly
* ReadOnlyAtRunTime: Readonly when the app is playing
* ReadOnlyAtRunTimeAndEnabled: Readonly on playing and script enabled
* ReadOnlyAtRunTimeAndDisabled: Readonly on playing and script disabled

This offers a complete solution to times where readonly may be
required. Also, the `Muted` option has been moved to the top to make
things look neater.