### PR TITLE
chore(Rule): remove TODO comment

### DIFF
--- a/Tests/Editor/Rule/AnyComponentTypeRuleTest.cs
+++ b/Tests/Editor/Rule/AnyComponentTypeRuleTest.cs
@@ -9,7 +9,6 @@ namespace Test.Zinnia.Rule
     using System.Collections;
     using NUnit.Framework;
 
-    // TODO: Test all SearchOptions
     public class AnyComponentTypeRuleTest
     {
         private GameObject containingObject;


### PR DESCRIPTION
An old to-do comment has been resolved (indirectly) in the past and
thus the comment can be removed.