### PR TITLE
feat(Tracking): allow GameObject as Target in ObscuranceQuery - resolves #264

### DIFF
--- a/Tests/Editor/Tracking/Query/ObscuranceQueryTest.cs
+++ b/Tests/Editor/Tracking/Query/ObscuranceQueryTest.cs
@@ -40,7 +40,7 @@ namespace Test.Zinnia.Tracking.Query
             objectB.transform.position = Vector3.right * 2f;
 
             subject.Source = objectA;
-            subject.Target = objectB.GetComponentInChildren<Collider>();
+            subject.Target = objectB;
 
             Assert.IsFalse(targetObscuredMock.Received);
             Assert.IsFalse(targetUnobscuredMock.Received);
@@ -93,6 +93,14 @@ namespace Test.Zinnia.Tracking.Query
 
             Object.Destroy(objectA);
             Object.Destroy(objectB);
+        }
+
+        [Test]
+        public void TargetWithoutCollider_ThrowsMissingColliderException()
+        {
+            GameObject gameObject = new GameObject();
+            Assert.Throws<ObscuranceQuery.MissingColliderException>(() => subject.Target = gameObject);
+            Object.DestroyImmediate(gameObject);
         }
     }
 }


### PR DESCRIPTION
ObscuranceQuery currently requires a Collider as the target, however
this is limiting when using objects that contain compound colliders.
This change allows providing a GameObject as the target instead and
use that for the collision check. Additionally an exception is
thrown in case the target doesn't have any Rigidbody, nor Collider
on it to prevent users of the component from silently never getting
any result. More information can be found in [Unity's
documentation](https://docs.unity3d.com/Manual/CollidersOverview.html).