### PR TITLE
chore(Association): explain why the test results in a warning log

### DIFF
--- a/Tests/Editor/Association/GameObjectsAssociationActivatorTest.cs
+++ b/Tests/Editor/Association/GameObjectsAssociationActivatorTest.cs
@@ -96,8 +96,10 @@ namespace Test.Zinnia.Association
 
             subject.Associations.Add(associationMock);
 
+            Debug.Log("This test is expecting a warning to be logged next.");
             LogAssert.Expect(LogType.Warning, new Regex("multiple association"));
             subject.ManualAwake();
+            Debug.Log("Warning log recognized, the test is successful.");
         }
 
         [Test]


### PR DESCRIPTION
One of the tests for `GameObjectsAssociationActivator` tests whether
an expected warning log message is actually logged. As this warning
log can be seen as a (partial) failure in the test by users running
the tests, the test has been adjusted to log additional information
before and after the expected warning log. These messages explain
that the warning is indeed expected and intended.