### PR TITLE
feat(CameraRig): add observable list for linked alias association

### DIFF
--- a/Runtime/Tracking/CameraRig/Collection.meta
+++ b/Runtime/Tracking/CameraRig/Collection.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c14b584a835e7c34196755d386605b91
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Tracking/CameraRig/Collection/LinkedAliasAssociationCollectionObservableList.cs
+++ b/Runtime/Tracking/CameraRig/Collection/LinkedAliasAssociationCollectionObservableList.cs
@@ -1,0 +1,21 @@
+﻿namespace Zinnia.Tracking.CameraRig.Collection
+{
+    using UnityEngine.Events;
+    using System;
+    using System.Collections.Generic;
+    using Zinnia.Data.Collection;
+
+    /// <summary>
+    /// Allows observing changes to a <see cref="List{T}"/> of <see cref="LinkedAliasAssociationCollection"/>s.
+    /// </summary>
+    public class LinkedAliasAssociationCollectionObservableList : DefaultObservableList<LinkedAliasAssociationCollection, LinkedAliasAssociationCollectionObservableList.UnityEvent>
+    {
+        /// <summary>
+        /// Defines the event with the <see cref="LinkedAliasAssociationCollection"/>.
+        /// </summary>
+        [Serializable]
+        public class UnityEvent : UnityEvent<LinkedAliasAssociationCollection>
+        {
+        }
+    }
+}

--- a/Runtime/Tracking/CameraRig/Collection/LinkedAliasAssociationCollectionObservableList.cs.meta
+++ b/Runtime/Tracking/CameraRig/Collection/LinkedAliasAssociationCollectionObservableList.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3e8c5b75d4472e54986eae4cf8048212
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
The LinkedAliasAssociationCollection now has an ObservableList type for
holding a collection of linked alias associations.