### PR TITLE
feat(Modification): remove local CurrentIndex property

### DIFF
--- a/Runtime/Tracking/Modification/GameObjectStateSwitcher.cs
+++ b/Runtime/Tracking/Modification/GameObjectStateSwitcher.cs
@@ -23,12 +23,6 @@
         [Serialized]
         [field: DocumentedByXml]
         public bool TargetState { get; set; } = true;
-        /// <summary>
-        /// The current active index in the targets collection.
-        /// </summary>
-        [Serialized]
-        [field: DocumentedByXml]
-        public int CurrentIndex { get; set; }
 
         /// <summary>
         /// Switches to the next target in the collection and sets to the appropriate state.
@@ -36,10 +30,10 @@
         [RequiresBehaviourState]
         public virtual void SwitchNext()
         {
-            CurrentIndex++;
-            if (CurrentIndex >= Targets.NonSubscribableElements.Count)
+            Targets.CurrentIndex++;
+            if (Targets.CurrentIndex >= Targets.NonSubscribableElements.Count)
             {
-                CurrentIndex = 0;
+                Targets.CurrentIndex = 0;
             }
 
             Switch();
@@ -51,10 +45,10 @@
         [RequiresBehaviourState]
         public virtual void SwitchPrevious()
         {
-            CurrentIndex--;
-            if (CurrentIndex < 0)
+            Targets.CurrentIndex--;
+            if (Targets.CurrentIndex < 0)
             {
-                CurrentIndex = Targets.NonSubscribableElements.Count - 1;
+                Targets.CurrentIndex = Targets.NonSubscribableElements.Count - 1;
             }
 
             Switch();
@@ -67,7 +61,7 @@
         [RequiresBehaviourState]
         public virtual void SwitchTo(int index)
         {
-            CurrentIndex = Mathf.Clamp(index, 0, Targets.NonSubscribableElements.Count - 1);
+            Targets.CurrentIndex = Mathf.Clamp(index, 0, Targets.NonSubscribableElements.Count - 1);
             Switch();
         }
 
@@ -77,7 +71,7 @@
         [RequiresBehaviourState]
         public virtual void SwitchToCurrentIndex()
         {
-            SwitchTo(CurrentIndex);
+            SwitchTo(Targets.CurrentIndex);
         }
 
         /// <summary>
@@ -87,7 +81,7 @@
         {
             for (int index = 0; index < Targets.NonSubscribableElements.Count; index++)
             {
-                Targets.NonSubscribableElements[index].SetActive(index == CurrentIndex ? TargetState : !TargetState);
+                Targets.NonSubscribableElements[index].SetActive(index == Targets.CurrentIndex ? TargetState : !TargetState);
             }
         }
     }

--- a/Tests/Editor/Tracking/Modification/GameObjectStateSwitcherTest.cs
+++ b/Tests/Editor/Tracking/Modification/GameObjectStateSwitcherTest.cs
@@ -43,7 +43,7 @@ namespace Test.Zinnia.Tracking.Modification
             targets.Add(objectC);
 
             subject.TargetState = true;
-            subject.CurrentIndex = 0;
+            subject.Targets.CurrentIndex = 0;
 
             subject.SwitchToCurrentIndex();
 
@@ -90,7 +90,7 @@ namespace Test.Zinnia.Tracking.Modification
             targets.Add(objectC);
 
             subject.TargetState = true;
-            subject.CurrentIndex = 0;
+            subject.Targets.CurrentIndex = 0;
 
             subject.SwitchToCurrentIndex();
 
@@ -137,7 +137,7 @@ namespace Test.Zinnia.Tracking.Modification
             targets.Add(objectC);
 
             subject.TargetState = true;
-            subject.CurrentIndex = 0;
+            subject.Targets.CurrentIndex = 0;
 
             subject.SwitchToCurrentIndex();
 
@@ -196,7 +196,7 @@ namespace Test.Zinnia.Tracking.Modification
             targets.Add(objectC);
 
             subject.TargetState = false;
-            subject.CurrentIndex = 0;
+            subject.Targets.CurrentIndex = 0;
 
             subject.SwitchToCurrentIndex();
 
@@ -231,7 +231,7 @@ namespace Test.Zinnia.Tracking.Modification
             targets.Add(objectC);
 
             subject.TargetState = true;
-            subject.CurrentIndex = 1;
+            subject.Targets.CurrentIndex = 1;
 
             subject.SwitchToCurrentIndex();
 
@@ -266,7 +266,7 @@ namespace Test.Zinnia.Tracking.Modification
             targets.Add(objectC);
 
             subject.TargetState = true;
-            subject.CurrentIndex = 2;
+            subject.Targets.CurrentIndex = 2;
 
             subject.SwitchToCurrentIndex();
 
@@ -301,7 +301,7 @@ namespace Test.Zinnia.Tracking.Modification
             targets.Add(objectC);
 
             subject.TargetState = true;
-            subject.CurrentIndex = 0;
+            subject.Targets.CurrentIndex = 0;
 
             Assert.IsTrue(objectA.activeInHierarchy);
             Assert.IsTrue(objectB.activeInHierarchy);
@@ -334,7 +334,7 @@ namespace Test.Zinnia.Tracking.Modification
             targets.Add(objectC);
 
             subject.TargetState = true;
-            subject.CurrentIndex = 1;
+            subject.Targets.CurrentIndex = 1;
 
             Assert.IsTrue(objectA.activeInHierarchy);
             Assert.IsTrue(objectB.activeInHierarchy);
@@ -367,7 +367,7 @@ namespace Test.Zinnia.Tracking.Modification
             targets.Add(objectC);
 
             subject.TargetState = true;
-            subject.CurrentIndex = 2;
+            subject.Targets.CurrentIndex = 2;
 
             Assert.IsTrue(objectA.activeInHierarchy);
             Assert.IsTrue(objectB.activeInHierarchy);
@@ -400,7 +400,7 @@ namespace Test.Zinnia.Tracking.Modification
             targets.Add(objectC);
 
             subject.TargetState = true;
-            subject.CurrentIndex = 0;
+            subject.Targets.CurrentIndex = 0;
 
             subject.gameObject.SetActive(false);
 
@@ -435,7 +435,7 @@ namespace Test.Zinnia.Tracking.Modification
             targets.Add(objectC);
 
             subject.TargetState = true;
-            subject.CurrentIndex = 0;
+            subject.Targets.CurrentIndex = 0;
 
             subject.enabled = false;
 


### PR DESCRIPTION
The GameObjectStateSwitcher does not need to hold an internal
CurrentIndex property as there is a CurrentIndex property on the
ObservableList and as the GameObjectStateSwitcher uses a
GameObjectObservableList to traverse the collection, it's more
appropriate to use the CurrentIndex on that ObservableList.