### PR TITLE
fix(Modification): switch from behaviour to component observable list

### DIFF
--- a/Runtime/Tracking/Modification/ComponentEnabledStateModifier.cs
+++ b/Runtime/Tracking/Modification/ComponentEnabledStateModifier.cs
@@ -18,7 +18,7 @@
         /// </summary>
         [Serialized]
         [field: DocumentedByXml]
-        public SerializableTypeBehaviourObservableList Types { get; set; }
+        public SerializableTypeComponentObservableList Types { get; set; }
 
         /// <summary>
         /// The target to modify the enabled states for the provided <see cref="Types"/>.

--- a/Tests/Editor/Tracking/Modification/ComponentEnabledStateModifierTest.cs
+++ b/Tests/Editor/Tracking/Modification/ComponentEnabledStateModifierTest.cs
@@ -30,7 +30,7 @@ namespace Test.Zinnia.Tracking.Modification
         public IEnumerator SetEnabledStateOfBehaviour()
         {
             Behaviour behaviour = containingObject.AddComponent<Light>();
-            subject.Types = containingObject.AddComponent<SerializableTypeBehaviourObservableList>();
+            subject.Types = containingObject.AddComponent<SerializableTypeComponentObservableList>();
             yield return null;
 
             subject.Types.Add(typeof(Light));
@@ -47,7 +47,7 @@ namespace Test.Zinnia.Tracking.Modification
         public IEnumerator SetEnabledStateOfRenderer()
         {
             MeshRenderer renderer = containingObject.AddComponent<MeshRenderer>();
-            subject.Types = containingObject.AddComponent<SerializableTypeBehaviourObservableList>();
+            subject.Types = containingObject.AddComponent<SerializableTypeComponentObservableList>();
             yield return null;
 
             subject.Types.Add(typeof(MeshRenderer));
@@ -65,7 +65,7 @@ namespace Test.Zinnia.Tracking.Modification
         {
             MeshRenderer renderer = containingObject.AddComponent<MeshRenderer>();
             Behaviour behaviour = containingObject.AddComponent<Light>();
-            subject.Types = containingObject.AddComponent<SerializableTypeBehaviourObservableList>();
+            subject.Types = containingObject.AddComponent<SerializableTypeComponentObservableList>();
             yield return null;
 
             subject.Types.Add(typeof(Light));
@@ -86,7 +86,7 @@ namespace Test.Zinnia.Tracking.Modification
         public IEnumerator SetEnabledStateOfInvalidType()
         {
             Behaviour behaviour = containingObject.AddComponent<Light>();
-            subject.Types = containingObject.AddComponent<SerializableTypeBehaviourObservableList>();
+            subject.Types = containingObject.AddComponent<SerializableTypeComponentObservableList>();
             yield return null;
 
             subject.Types.Add(typeof(Renderer));
@@ -101,7 +101,7 @@ namespace Test.Zinnia.Tracking.Modification
         public IEnumerator SetEnabledStateInvalidTarget()
         {
             Behaviour behaviour = containingObject.AddComponent<Light>();
-            subject.Types = containingObject.AddComponent<SerializableTypeBehaviourObservableList>();
+            subject.Types = containingObject.AddComponent<SerializableTypeComponentObservableList>();
             yield return null;
 
             subject.Types.Add(typeof(Light));
@@ -115,7 +115,7 @@ namespace Test.Zinnia.Tracking.Modification
         public IEnumerator SetEnabledStateInactiveGameObject()
         {
             Behaviour behaviour = containingObject.AddComponent<Light>();
-            subject.Types = containingObject.AddComponent<SerializableTypeBehaviourObservableList>();
+            subject.Types = containingObject.AddComponent<SerializableTypeComponentObservableList>();
             yield return null;
 
             subject.Types.Add(typeof(Light));
@@ -133,7 +133,7 @@ namespace Test.Zinnia.Tracking.Modification
         public IEnumerator SetEnabledStateInactiveComponent()
         {
             Behaviour behaviour = containingObject.AddComponent<Light>();
-            subject.Types = containingObject.AddComponent<SerializableTypeBehaviourObservableList>();
+            subject.Types = containingObject.AddComponent<SerializableTypeComponentObservableList>();
             yield return null;
 
             subject.Types.Add(typeof(Light));


### PR DESCRIPTION
The ComponentEnabledStateModifier originally used a
SerializedTypeBehaviourObservableList but this only allows picking
classes that extend Behaviour and Renderers in Unity do not extend
Behaviour. Instead, a SerializedTypeComponentObservableList is now used
which allows picking any Behaviours and any Renderers.

The component already ensures it does nothing if a component with no
enabled type is picked.