### PR TITLE
feat(Collection): add method to set element or add if empty to list

### DIFF
--- a/Runtime/Data/Collection/ObservableList.cs
+++ b/Runtime/Data/Collection/ObservableList.cs
@@ -254,16 +254,85 @@
         }
 
         /// <summary>
+        /// Sets the given element at the given index or adds the element if the collection is empty.
+        /// </summary>
+        /// <remarks>
+        /// Allows the use of a clamped index to prevent indices being out of bounds and doing negative queries such as `-1` sets the last element.
+        /// </remarks>
+        /// <param name="element">The element to set.</param>
+        /// <param name="index">The index in the collection to set at. In case this index is out of bounds for the collection it will be clamped within the index bounds.</param>
+        [RequiresBehaviourState]
+        public virtual void SetAtOrAddIfEmpty(TElement element, int index)
+        {
+            if (Elements.Count == 0)
+            {
+                Add(element);
+                return;
+            }
+
+            SetAt(element, index);
+        }
+
+        /// <summary>
+        /// Sets the given element at the given index as long as it does not already exist in the collection or adds the element if the collection is empty.
+        /// </summary>
+        /// <remarks>
+        /// Allows the use of a clamped index to prevent indices being out of bounds and doing negative queries such as `-1` sets the last element.
+        /// </remarks>
+        /// <param name="element">The unique element to set.</param>
+        /// <param name="index">The index in the collection to set at. In case this index is out of bounds for the collection it will be clamped within the index bounds.</param>
+        [RequiresBehaviourState]
+        public virtual void SetUniqueAtOrAddIfEmpty(TElement element, int index)
+        {
+            if (Elements.Contains(element))
+            {
+                return;
+            }
+
+            SetAtOrAddIfEmpty(element, index);
+        }
+
+        /// <summary>
+        /// Sets the given element at the <see cref="CurrentIndex"/> or adds the element if the collection is empty.
+        /// </summary>
+        /// <param name="element">The element to set.</param>
+        [RequiresBehaviourState]
+        public virtual void SetAtCurrentIndexOrAddIfEmpty(TElement element)
+        {
+            SetAtOrAddIfEmpty(element, CurrentIndex);
+        }
+
+        /// <summary>
+        /// Sets the given element at the <see cref="CurrentIndex"/> as long as it does not already exist in the collection or adds the element if the collection is empty.
+        /// </summary>
+        /// <param name="element">The unique element to set.</param>
+        [RequiresBehaviourState]
+        public virtual void SetUniqueAtCurrentIndexOrAddIfEmpty(TElement element)
+        {
+            SetUniqueAtOrAddIfEmpty(element, CurrentIndex);
+        }
+
+        /// <summary>
         /// Removes the first occurrence of an element from the collection.
         /// </summary>
         /// <param name="element">The element to remove.</param>
         [RequiresBehaviourState]
-        public virtual void Remove(TElement element)
+        public virtual bool Remove(TElement element)
         {
             if (Elements.Remove(element))
             {
                 EmitRemoveEvents(element);
+                return true;
             }
+            return false;
+        }
+
+        /// <summary>
+        /// Removes the first occurrence of an element from the collection.
+        /// </summary>
+        public virtual void DoRemove(TElement element)
+        {
+            Remove(element);
         }
 
         /// <summary>

--- a/Tests/Editor/Data/Collection/GameObjectObservableListTest.cs
+++ b/Tests/Editor/Data/Collection/GameObjectObservableListTest.cs
@@ -472,10 +472,10 @@ namespace Test.Zinnia.Data.Collection
             subject.Added.AddListener(addedMock.Listen);
             subject.Removed.AddListener(removedMock.Listen);
 
-            GameObject elementOne = new GameObject();
-            GameObject elementTwo = new GameObject();
-            GameObject elementThree = new GameObject();
-            GameObject elementFour = new GameObject();
+            GameObject elementOne = new GameObject("One");
+            GameObject elementTwo = new GameObject("Two");
+            GameObject elementThree = new GameObject("Three");
+            GameObject elementFour = new GameObject("Four");
 
             subject.Add(elementOne);
             subject.Add(elementTwo);
@@ -501,6 +501,50 @@ namespace Test.Zinnia.Data.Collection
             Object.DestroyImmediate(elementTwo);
             Object.DestroyImmediate(elementThree);
             Object.DestroyImmediate(elementFour);
+        }
+
+        [Test]
+        public void SetAtEmptyCollection()
+        {
+            UnityEventListenerMock addedMock = new UnityEventListenerMock();
+            UnityEventListenerMock removedMock = new UnityEventListenerMock();
+            subject.Added.AddListener(addedMock.Listen);
+            subject.Removed.AddListener(removedMock.Listen);
+
+            GameObject elementOne = new GameObject("One");
+
+            Assert.IsEmpty(subject.NonSubscribableElements);
+
+            subject.SetAt(elementOne, 1);
+
+            Assert.IsEmpty(subject.NonSubscribableElements);
+
+            Assert.IsFalse(addedMock.Received);
+            Assert.IsFalse(removedMock.Received);
+
+            Object.DestroyImmediate(elementOne);
+        }
+
+        [Test]
+        public void SetAtOrAddIfEmptyCollection()
+        {
+            UnityEventListenerMock addedMock = new UnityEventListenerMock();
+            UnityEventListenerMock removedMock = new UnityEventListenerMock();
+            subject.Added.AddListener(addedMock.Listen);
+            subject.Removed.AddListener(removedMock.Listen);
+
+            GameObject elementOne = new GameObject("One");
+
+            Assert.IsEmpty(subject.NonSubscribableElements);
+
+            subject.SetAtOrAddIfEmpty(elementOne, 1);
+
+            Assert.AreEqual(elementOne, subject.NonSubscribableElements[0]);
+
+            Assert.IsTrue(addedMock.Received);
+            Assert.IsFalse(removedMock.Received);
+
+            Object.DestroyImmediate(elementOne);
         }
 
         [Test]


### PR DESCRIPTION
The ObservableList now has a new method that allows setting an element
in the collection or adding it to the collection if the collection is
empty.

This is a somewhat obscure requirement and it in fact does two
operations but is required due to the limitations of UnityEvents where
only rudimentary logic is possible.

The Remove method has also been updated so it returns a bool and a
DoRemove method has been added that returns nothing so it can still
be used in UnityEvents.