### PR TITLE
fix(Collision): provide access modifier on internal lists

### DIFF
--- a/Runtime/Tracking/Collision/CollisionIgnorer.cs
+++ b/Runtime/Tracking/Collision/CollisionIgnorer.cs
@@ -28,11 +28,11 @@
         /// <summary>
         /// A reused instance to store the <see cref="Collider"/> collection belonging to the <see cref="Sources"/>.
         /// </summary>
-        List<Collider> sourceColliders = new List<Collider>();
+        protected List<Collider> sourceColliders = new List<Collider>();
         /// <summary>
         /// A reused instance to store the <see cref="Collider"/> collection belonging to the <see cref="Targets"/>.
         /// </summary>
-        List<Collider> targetColliders = new List<Collider>();
+        protected List<Collider> targetColliders = new List<Collider>();
 
         protected virtual void OnEnable()
         {


### PR DESCRIPTION
The CollisionIgnorer didn't specify the access modifier for the two
Collider lists being used internally which would mean they were set
to the default of `private` which prevents using them in any classes
that extend it.

They have now been set to `protected` so extending the class and using
these fields is possible.