### PR TITLE
fix(Query): ensure obscurance target has a valid compound collider

### DIFF
--- a/Runtime/Tracking/Query/ObscuranceQuery.cs
+++ b/Runtime/Tracking/Query/ObscuranceQuery.cs
@@ -123,7 +123,9 @@
         /// </summary>
         protected virtual void CheckTarget()
         {
-            if (Target != null && Target.GetComponent<Rigidbody>() == null && Target.GetComponent<Collider>() == null)
+            if (Target != null
+                && (Target.GetComponent<Rigidbody>() == null || Target.GetComponentInChildren<Collider>() == null)
+                && Target.GetComponent<Collider>() == null)
             {
                 throw new MissingColliderException(this, Target);
             }

--- a/Tests/Editor/Tracking/Query/ObscuranceQueryTest.cs
+++ b/Tests/Editor/Tracking/Query/ObscuranceQueryTest.cs
@@ -95,12 +95,110 @@ namespace Test.Zinnia.Tracking.Query
             Object.Destroy(objectB);
         }
 
+        [UnityTest]
+        public IEnumerator ObscuredThenUnobscuredCompoundColliders()
+        {
+            UnityEventListenerMock targetObscuredMock = new UnityEventListenerMock();
+            UnityEventListenerMock targetUnobscuredMock = new UnityEventListenerMock();
+            subject.TargetObscured.AddListener(targetObscuredMock.Listen);
+            subject.TargetUnobscured.AddListener(targetUnobscuredMock.Listen);
+
+            GameObject objectA = GameObject.CreatePrimitive(PrimitiveType.Cube);
+
+            GameObject objectB = new GameObject();
+            objectB.AddComponent<Rigidbody>();
+            GameObject objectC = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            objectC.transform.SetParent(objectB.transform);
+
+            objectA.transform.position = Vector3.left * 2f;
+            objectB.transform.position = Vector3.right * 2f;
+
+            subject.Source = objectA;
+            subject.Target = objectB;
+
+            Assert.IsFalse(targetObscuredMock.Received);
+            Assert.IsFalse(targetUnobscuredMock.Received);
+
+            targetObscuredMock.Reset();
+            targetUnobscuredMock.Reset();
+
+            subject.Process();
+
+            yield return new WaitForEndOfFrame();
+
+            Assert.IsFalse(targetObscuredMock.Received);
+            Assert.IsTrue(targetUnobscuredMock.Received);
+
+            targetObscuredMock.Reset();
+            targetUnobscuredMock.Reset();
+
+            subject.Process();
+
+            yield return new WaitForEndOfFrame();
+
+            Assert.IsFalse(targetObscuredMock.Received);
+            Assert.IsFalse(targetUnobscuredMock.Received);
+
+            targetObscuredMock.Reset();
+            targetUnobscuredMock.Reset();
+
+            GameObject obscurer = GameObject.CreatePrimitive(PrimitiveType.Cube);
+
+            subject.Process();
+
+            yield return new WaitForEndOfFrame();
+
+            Assert.IsTrue(targetObscuredMock.Received);
+            Assert.IsFalse(targetUnobscuredMock.Received);
+
+            targetObscuredMock.Reset();
+            targetUnobscuredMock.Reset();
+
+            Object.Destroy(obscurer);
+
+            yield return new WaitForEndOfFrame();
+
+            subject.Process();
+
+            yield return new WaitForEndOfFrame();
+
+            Assert.IsFalse(targetObscuredMock.Received);
+            Assert.IsTrue(targetUnobscuredMock.Received);
+
+            Object.Destroy(objectA);
+            Object.Destroy(objectB);
+            Object.Destroy(objectC);
+        }
+
         [Test]
         public void TargetWithoutCollider_ThrowsMissingColliderException()
         {
-            GameObject gameObject = new GameObject();
-            Assert.Throws<ObscuranceQuery.MissingColliderException>(() => subject.Target = gameObject);
-            Object.DestroyImmediate(gameObject);
+            GameObject target = new GameObject();
+            Assert.Throws<ObscuranceQuery.MissingColliderException>(() => subject.Target = target);
+            Object.DestroyImmediate(target);
+        }
+
+        [Test]
+        public void TargetWithRigidbodyWithoutCompoundCollider_ThrowsMissingColliderException()
+        {
+            GameObject target = new GameObject();
+            GameObject child = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            child.transform.SetParent(target.transform);
+
+            Assert.Throws<ObscuranceQuery.MissingColliderException>(() => subject.Target = target);
+            Object.DestroyImmediate(target);
+        }
+
+        [Test]
+        public void TargetWithoutRigidbodyWithCompoundCollider_ThrowsMissingColliderException()
+        {
+            GameObject target = new GameObject();
+            target.AddComponent<Rigidbody>();
+            GameObject child = new GameObject();
+            child.transform.SetParent(target.transform);
+
+            Assert.Throws<ObscuranceQuery.MissingColliderException>(() => subject.Target = target);
+            Object.DestroyImmediate(target);
         }
     }
 }


### PR DESCRIPTION
The ObscuranceQuery was not correctly checking to see if a Target
without a rigidbody but with a compound collider was invalid.

The tests have been updated to show the issue and to prove the fix
works.