### PR TITLE
feat(Collection): provide default value for Clear parameter

### DIFF
--- a/Runtime/Data/Collection/ObservableList.cs
+++ b/Runtime/Data/Collection/ObservableList.cs
@@ -384,16 +384,16 @@
         /// <summary>
         /// Removes all elements from the collection.
         /// </summary>
-        /// <param name="removeFromFront">Whether to start the removal from the start or the end of the collection.</param>
+        /// <param name="removeFromEndToStart">Whether to reverse the collection when clearing so the removal goes from end to start.</param>
         [RequiresBehaviourState]
-        public virtual void Clear(bool removeFromFront)
+        public virtual void Clear(bool removeFromEndToStart = false)
         {
             if (Elements.Count == 0)
             {
                 return;
             }
 
-            if (!removeFromFront)
+            if (removeFromEndToStart)
             {
                 Elements.Reverse();
             }

--- a/Tests/Editor/Data/Collection/GameObjectObservableListTest.cs
+++ b/Tests/Editor/Data/Collection/GameObjectObservableListTest.cs
@@ -955,7 +955,7 @@ namespace Test.Zinnia.Data.Collection
             GameObject elementOne = new GameObject();
             GameObject elementTwo = new GameObject();
 
-            subject.Clear(false);
+            subject.Clear(true);
 
             Assert.IsFalse(populatedMock.Received);
             Assert.IsFalse(addedMock.Received);
@@ -973,7 +973,7 @@ namespace Test.Zinnia.Data.Collection
 
             Assert.AreEqual(3, subject.NonSubscribableElements.Count);
 
-            subject.Clear(false);
+            subject.Clear(true);
 
             Assert.IsFalse(populatedMock.Received);
             Assert.IsFalse(addedMock.Received);
@@ -1001,7 +1001,7 @@ namespace Test.Zinnia.Data.Collection
             GameObject elementOne = new GameObject();
             GameObject elementTwo = new GameObject();
 
-            subject.Clear(true);
+            subject.Clear();
 
             Assert.IsFalse(populatedMock.Received);
             Assert.IsFalse(addedMock.Received);
@@ -1019,7 +1019,7 @@ namespace Test.Zinnia.Data.Collection
 
             Assert.AreEqual(3, subject.NonSubscribableElements.Count);
 
-            subject.Clear(true);
+            subject.Clear();
 
             Assert.IsFalse(populatedMock.Received);
             Assert.IsFalse(addedMock.Received);

--- a/Tests/Editor/Process/Component/GameObjectSourceTargetProcessorTest.cs
+++ b/Tests/Editor/Process/Component/GameObjectSourceTargetProcessorTest.cs
@@ -106,7 +106,7 @@ namespace Test.Zinnia.Process.Component
             Assert.AreEqual(1, subject.Sources.NonSubscribableElements.Count);
             Assert.AreEqual(source, subject.Sources.NonSubscribableElements[0]);
 
-            subject.Sources.Clear(false);
+            subject.Sources.Clear();
 
             Assert.IsEmpty(subject.Sources.NonSubscribableElements);
 
@@ -189,7 +189,7 @@ namespace Test.Zinnia.Process.Component
             Assert.AreEqual(1, subject.Targets.NonSubscribableElements.Count);
             Assert.AreEqual(target, subject.Targets.NonSubscribableElements[0]);
 
-            subject.Targets.Clear(false);
+            subject.Targets.Clear();
 
             Assert.IsEmpty(subject.Targets.NonSubscribableElements);
 

--- a/Tests/Editor/Tracking/Follow/ObjectFollowerTest.cs
+++ b/Tests/Editor/Tracking/Follow/ObjectFollowerTest.cs
@@ -100,7 +100,7 @@ namespace Test.Zinnia.Tracking.Follow
             Assert.AreEqual(1, subject.TargetOffsets.NonSubscribableElements.Count);
             Assert.AreEqual(offset, subject.TargetOffsets.NonSubscribableElements[0]);
 
-            subject.TargetOffsets.Clear(false);
+            subject.TargetOffsets.Clear();
             Assert.IsEmpty(subject.TargetOffsets.NonSubscribableElements);
             Object.DestroyImmediate(offset);
         }


### PR DESCRIPTION
The ObservableList Clear method now has a default value for the Clear
parameter set to false to just reduce the amount of times Clear(false)
is required, when simply Clear() can be used, which is the standard
operation.