### PR TITLE
feat(Extension): ability to queue a behaviour action to run on enable

### DIFF
--- a/Runtime/Extension/BehaviourExtensions.cs
+++ b/Runtime/Extension/BehaviourExtensions.cs
@@ -1,0 +1,38 @@
+﻿namespace Zinnia.Extension
+{
+    using UnityEngine;
+    using System;
+
+    /// <summary>
+    /// Extended methods for <see cref="Behaviour"/>.
+    /// </summary>
+    public static class BehaviourExtensions
+    {
+        /// <summary>
+        /// Executes the given <see cref="Action"/> when the <see cref="Behaviour"/> becomes active and enabled or immediately runs if the <see cref="Behaviour"/> is already active and enabled.
+        /// </summary>
+        /// <param name="behaviour">The <see cref="Behaviour"/> to check against.</param>
+        /// <param name="action">The <see cref="Action"/> to execute.</param>
+        public static void RunWhenActiveAndEnabled(this Behaviour behaviour, Action action)
+        {
+            void OnBeforeRender()
+            {
+                if (!behaviour.isActiveAndEnabled)
+                {
+                    return;
+                }
+
+                Application.onBeforeRender -= OnBeforeRender;
+                action();
+            }
+
+            if (behaviour.isActiveAndEnabled)
+            {
+                action();
+                return;
+            }
+
+            Application.onBeforeRender += OnBeforeRender;
+        }
+    }
+}

--- a/Runtime/Extension/BehaviourExtensions.cs.meta
+++ b/Runtime/Extension/BehaviourExtensions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c0f176b5e6098764e9131c24513c4e22
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Editor/Extension/BehaviourExtensionsTest.cs
+++ b/Tests/Editor/Extension/BehaviourExtensionsTest.cs
@@ -1,0 +1,74 @@
+﻿using Zinnia.Extension;
+
+namespace Test.Zinnia.Extension
+{
+    using UnityEngine;
+    using UnityEngine.TestTools;
+    using System.Collections;
+    using NUnit.Framework;
+
+    public class BehaviourExtensionsTest
+    {
+        [UnityTest]
+        public IEnumerator RunWhenActiveAndEnabled()
+        {
+            GameObject container = new GameObject();
+            container.SetActive(false);
+            MockBehaviour mockBehaviour = container.AddComponent<MockBehaviour>();
+            yield return null;
+
+            mockBehaviour.ExecuteOnlyWhenEnabled();
+
+            Assert.IsFalse(mockBehaviour.hasEnabled);
+            Assert.IsFalse(mockBehaviour.hasExecuted);
+
+            container.SetActive(true);
+            yield return null;
+
+            Assert.IsTrue(mockBehaviour.hasEnabled);
+            Assert.IsFalse(mockBehaviour.hasExecuted);
+
+            container.SetActive(false);
+            yield return null;
+
+            Assert.IsFalse(mockBehaviour.hasEnabled);
+            Assert.IsFalse(mockBehaviour.hasExecuted);
+
+            mockBehaviour.RunWhenActiveAndEnabled(() => mockBehaviour.ExecuteOnlyWhenEnabled());
+
+            container.SetActive(true);
+            yield return null;
+
+            Assert.IsTrue(mockBehaviour.hasEnabled);
+            Assert.IsTrue(mockBehaviour.hasExecuted);
+
+            Object.DestroyImmediate(container);
+        }
+    }
+
+    public class MockBehaviour : MonoBehaviour
+    {
+        public bool hasEnabled;
+        public bool hasExecuted;
+
+        public void ExecuteOnlyWhenEnabled()
+        {
+            if (!isActiveAndEnabled)
+            {
+                return;
+            }
+
+            hasExecuted = true;
+        }
+
+        private void OnEnable()
+        {
+            hasEnabled = true;
+        }
+
+        private void OnDisable()
+        {
+            hasEnabled = false;
+        }
+    }
+}

--- a/Tests/Editor/Extension/BehaviourExtensionsTest.cs.meta
+++ b/Tests/Editor/Extension/BehaviourExtensionsTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 612afef6a7ddbda4a83774bb4b8353b9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
The BehaviourExtensions provide a mechanism to queue up a behaviour
action on a component to run when the component becomes enabled. This
makes it possible to run methods on disabled components by waiting
for them to become enabled and then running the appropriate method.

This is very useful for calling ObservableList methods such as Add
in the OnEnable method of other components in case there is a race
condition of which component becomes enabled first.