### PR TITLE
fix(Collision): ensure ignored collisions are resumed on disable

### DIFF
--- a/Runtime/Tracking/Collision/CollisionIgnorer.cs
+++ b/Runtime/Tracking/Collision/CollisionIgnorer.cs
@@ -24,6 +24,12 @@
         [Serialized]
         [field: DocumentedByXml]
         public GameObjectObservableList Targets { get; set; }
+        /// <summary>
+        /// Whether to process inactive <see cref="GameObject"/>s when ignoring or resuming collisions.
+        /// </summary>
+        [Serialized]
+        [field: DocumentedByXml]
+        public bool ProcessInactiveGameObjects { get; set; }
 
         /// <summary>
         /// A reused instance to store the <see cref="Collider"/> collection belonging to the <see cref="Sources"/>.
@@ -141,12 +147,12 @@
         /// <param name="state">Whether to ignore collisions or not.</param>
         protected virtual void ToggleCollisions(GameObject source, GameObjectObservableList sources, GameObjectObservableList targets, bool state)
         {
-            if (source == null || (!state && sources.Contains(source)))
+            if (source == null || (!state && isActiveAndEnabled && sources.Contains(source)))
             {
                 return;
             }
 
-            source.GetComponentsInChildren(sourceColliders);
+            source.GetComponentsInChildren(ProcessInactiveGameObjects, sourceColliders);
 
             foreach (GameObject target in targets.SubscribableElements)
             {
@@ -155,7 +161,7 @@
                     continue;
                 }
 
-                target.GetComponentsInChildren(targetColliders);
+                target.GetComponentsInChildren(ProcessInactiveGameObjects, targetColliders);
 
                 foreach (Collider sourceCollider in sourceColliders)
                 {

--- a/Tests/Editor/Tracking/Collision/CollisionIgnorerTest.cs
+++ b/Tests/Editor/Tracking/Collision/CollisionIgnorerTest.cs
@@ -165,6 +165,49 @@ namespace Test.Zinnia.Tracking.Collision
             Object.Destroy(target2);
         }
 
+        [UnityTest]
+        public IEnumerator CollisionsResumedOnDisable()
+        {
+            WaitForFixedUpdate waitForFixedUpdate = new WaitForFixedUpdate();
+            GameObject source = CreateCollidable("source");
+            GameObject target = CreateCollidable("target");
+            Vector3 sourceOrigin = Vector3.left + Vector3.forward;
+            Vector3 targetOrigin = Vector3.right + Vector3.forward;
+            source.transform.position = sourceOrigin;
+            target.transform.position = targetOrigin;
+
+            CollisionChecker sourceCollisions = source.AddComponent<CollisionChecker>();
+
+            subject.Sources = containingObject.AddComponent<GameObjectObservableList>();
+            subject.Targets = containingObject.AddComponent<GameObjectObservableList>();
+
+            containingObject.SetActive(true);
+
+            subject.Sources.Add(source);
+            subject.Targets.Add(target);
+
+            yield return waitForFixedUpdate;
+            Assert.IsFalse(sourceCollisions.isColliding);
+
+            //make source touch target -> no collision
+            source.transform.position = targetOrigin;
+            yield return waitForFixedUpdate;
+            Assert.IsFalse(sourceCollisions.isColliding);
+
+            //move source out
+            source.transform.position = sourceOrigin;
+
+            subject.enabled = false;
+
+            //make source touch target -> collision
+            source.transform.position = targetOrigin;
+            yield return waitForFixedUpdate;
+            Assert.IsTrue(sourceCollisions.isColliding);
+
+            Object.Destroy(source);
+            Object.Destroy(target);
+        }
+
         protected GameObject CreateCollidable(string name)
         {
             GameObject obj = GameObject.CreatePrimitive(PrimitiveType.Cube);


### PR DESCRIPTION
The CollisionIgnorer was not resuming collisions when the component
was disabled due to a short circuit check failing because the logic
was there to prevent resuming collisions when removing an item from
the list.

The fix ensures that check is only done when the toggle is done
via the list mutation and not when disabled.

An additional parameter has also been added to optionally toggle
collisions on inactive colliders if required.