### PR TITLE
feat(Cast): provide validity data along with hit data - fixes #104

### DIFF
--- a/Runtime/Cast/FixedLineCast.cs
+++ b/Runtime/Cast/FixedLineCast.cs
@@ -23,7 +23,7 @@ namespace Zinnia.Cast
         /// <param name="data">The data to extract the new current length from.</param>
         public virtual void SetCurrentLength(EventData data)
         {
-            TargetHit = data?.TargetHit;
+            TargetHit = data?.HitData;
             if (data?.Points.Count >= 2)
             {
                 CurrentLength = Vector3.Distance(data.Points[0], data.Points[1]);

--- a/Runtime/Cast/ParabolicLineCast.cs
+++ b/Runtime/Cast/ParabolicLineCast.cs
@@ -155,7 +155,7 @@
                 break;
             }
 
-            ResultsChanged?.Invoke(eventData.Set(TargetHit, Points));
+            ResultsChanged?.Invoke(eventData.Set(TargetHit, IsTargetHitValid, Points));
         }
 
         /// <summary>

--- a/Runtime/Cast/StraightLineCast.cs
+++ b/Runtime/Cast/StraightLineCast.cs
@@ -17,8 +17,9 @@
         [field: DocumentedByXml]
         public float MaximumLength { get; set; } = 100f;
 
-        protected virtual void OnEnable()
+        protected override void OnEnable()
         {
+            base.OnEnable();
             points.Add(Vector3.zero);
             points.Add(Vector3.zero);
         }
@@ -32,7 +33,7 @@
         protected override void DoCastPoints()
         {
             GeneratePoints();
-            ResultsChanged?.Invoke(eventData.Set(TargetHit, Points));
+            ResultsChanged?.Invoke(eventData.Set(TargetHit, IsTargetHitValid, Points));
         }
 
         /// <summary>

--- a/Runtime/Pointer/ObjectPointer.cs
+++ b/Runtime/Pointer/ObjectPointer.cs
@@ -253,7 +253,7 @@
         [RequiresBehaviourState]
         public virtual void Select()
         {
-            SelectedTarget = IsActivated ? HoverTarget : null;
+            SelectedTarget = IsActivated && activePointsCastData.IsValid ? HoverTarget : null;
             Selected?.Invoke(SelectedTarget);
         }
 
@@ -267,10 +267,10 @@
             if (IsVisible)
             {
                 previousPointsCastData.Set(activePointsCastData);
-                if (data.TargetHit != null)
+                if (data.HitData != null)
                 {
-                    Transform targetTransform = data.TargetHit.Value.transform;
-                    if (targetTransform != null && targetTransform != activePointsCastData?.TargetHit?.transform)
+                    Transform targetTransform = data.HitData.Value.transform;
+                    if (targetTransform != null && targetTransform != activePointsCastData?.HitData?.transform)
                     {
                         TryEmitExit(previousPointsCastData);
                         Entered?.Invoke(GetEventData(data));
@@ -284,7 +284,6 @@
                 {
                     TryEmitExit(previousPointsCastData);
                 }
-
                 activePointsCastData.Set(data);
             }
             else
@@ -367,7 +366,7 @@
         /// <param name="data">The current points cast data.</param>
         protected virtual void TryEmitExit(PointsCast.EventData data)
         {
-            if (activePointsCastData.TargetHit?.transform != null)
+            if (activePointsCastData.HitData?.transform != null)
             {
                 Exited?.Invoke(GetEventData(data));
                 IsHovering = false;
@@ -404,7 +403,7 @@
         /// <returns>A <see cref="GameObject"/> to represent <paramref name="element"/>.</returns>
         protected virtual GameObject GetElementRepresentation(PointerElement element)
         {
-            bool isValid = activePointsCastData.TargetHit != null;
+            bool isValid = activePointsCastData.HitData != null;
 
             switch (element.ElementVisibility)
             {
@@ -444,12 +443,12 @@
             Transform pointerTransform = transform;
 
             eventData.Transform = pointerTransform;
-            eventData.PositionOverride = validDestinationTransform == null ? data.TargetHit?.point : validDestinationTransform.position;
+            eventData.PositionOverride = validDestinationTransform == null ? data.HitData?.point : validDestinationTransform.position;
             eventData.RotationOverride = validDestinationTransform == null ? Quaternion.identity : validDestinationTransform.localRotation;
             eventData.ScaleOverride = validDestinationTransform == null ? Vector3.one : validDestinationTransform.lossyScale;
             eventData.Origin = pointerTransform.position;
             eventData.Direction = pointerTransform.forward;
-            eventData.CollisionData = data?.TargetHit ?? default;
+            eventData.CollisionData = data?.HitData ?? default;
             return eventData.Set(IsActivated, IsHovering, HoverDuration, data);
         }
     }

--- a/Runtime/Tracking/Modification/PointNormalRotator.cs
+++ b/Runtime/Tracking/Modification/PointNormalRotator.cs
@@ -26,12 +26,12 @@
         [RequiresBehaviourState]
         public virtual void HandleData(PointsCast.EventData data)
         {
-            if (Target == null || data.TargetHit == null)
+            if (Target == null || data.HitData == null)
             {
                 return;
             }
 
-            Target.transform.rotation = Quaternion.FromToRotation(Vector3.up, data.TargetHit.Value.normal);
+            Target.transform.rotation = Quaternion.FromToRotation(Vector3.up, data.HitData.Value.normal);
         }
     }
 }

--- a/Tests/Editor/Cast/ParabolicLineCastTest.cs
+++ b/Tests/Editor/Cast/ParabolicLineCastTest.cs
@@ -64,6 +64,7 @@ namespace Test.Zinnia.Cast
             }
 
             Assert.AreEqual(validSurface.transform, subject.TargetHit.Value.transform);
+            Assert.IsTrue(subject.IsTargetHitValid);
             Assert.IsTrue(castResultsChangedMock.Received);
         }
 
@@ -178,7 +179,8 @@ namespace Test.Zinnia.Cast
                 Assert.AreEqual(expectedPoints[index].ToString(), subject.Points[index].ToString(), "Index " + index);
             }
 
-            Assert.IsNull(subject.TargetHit);
+            Assert.AreEqual(validSurface.transform, subject.TargetHit.Value.transform);
+            Assert.IsFalse(subject.IsTargetHitValid);
             Assert.IsTrue(castResultsChangedMock.Received);
         }
 

--- a/Tests/Editor/Cast/StraightLineCastTest.cs
+++ b/Tests/Editor/Cast/StraightLineCastTest.cs
@@ -53,6 +53,7 @@ namespace Test.Zinnia.Cast
             Assert.AreEqual(expectedStart, subject.Points[0]);
             Assert.AreEqual(expectedEnd, subject.Points[1]);
             Assert.AreEqual(validSurface.transform, subject.TargetHit.Value.transform);
+            Assert.IsTrue(subject.IsTargetHitValid);
             Assert.IsTrue(castResultsChangedMock.Received);
         }
 
@@ -113,7 +114,8 @@ namespace Test.Zinnia.Cast
 
             Assert.AreEqual(expectedStart, subject.Points[0]);
             Assert.AreEqual(expectedEnd, subject.Points[1]);
-            Assert.IsNull(subject.TargetHit);
+            Assert.AreEqual(validSurface.transform, subject.TargetHit.Value.transform);
+            Assert.IsFalse(subject.IsTargetHitValid);
             Assert.IsTrue(castResultsChangedMock.Received);
         }
 

--- a/Tests/Editor/Tracking/Modification/PointNormalRotatorTest.cs
+++ b/Tests/Editor/Tracking/Modification/PointNormalRotatorTest.cs
@@ -41,7 +41,7 @@ namespace Test.Zinnia.Tracking.Modification
 
             PointsCast.EventData data = new PointsCast.EventData
             {
-                TargetHit = cast
+                HitData = cast
             };
 
             subject.HandleData(data);
@@ -67,7 +67,7 @@ namespace Test.Zinnia.Tracking.Modification
 
             PointsCast.EventData data = new PointsCast.EventData
             {
-                TargetHit = cast
+                HitData = cast
             };
 
             subject.enabled = false;


### PR DESCRIPTION
The PointsCast now allows target collisions that do not pass the
validity rules to emit their data instead of null but along with a
new IsValid flag so it's possible to know whether the collision is
with a valid target.

This data is now used in the ObjectPointer so it's possible with the
ObjectPointer to know when you're hovering over an invalid target
but selecting an InvalidTarget still emits `Selected(null)` as an
invalid target is considered the same as no target at all.