### PR TITLE
chore(Tracking): fix unresolved method error in a test

### DIFF
--- a/Tests/Editor/Tracking/Velocity/ComponentTrackerProxyTest.cs
+++ b/Tests/Editor/Tracking/Velocity/ComponentTrackerProxyTest.cs
@@ -58,7 +58,7 @@ namespace Test.Zinnia.Tracking.Velocity
 
             subject.ProxySource = sourceObject;
             Assert.AreEqual(sourceObject, subject.ProxySource);
-            subject.ClearProxySource();
+            subject.ProxySource = null;
             Assert.IsNull(subject.ProxySource);
             Object.DestroyImmediate(sourceObject);
         }


### PR DESCRIPTION
A test was incorrectly calling old API that was since replaced with
Malimbe. This still compiled so far in Unity because Malimbe injects
the called method before the test assembly is created, thus the
method is found and can be called without issues. The method is
primarily injected to help with UnityEvent usage of the logic the
method implements, thus this change can replace the call to the
injected method by the API that is available to code at all times:
The property setter.