### PR TITLE
docs(README.md): update minimum Unity version number

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -9,8 +9,8 @@
 
 ### Environment
 
- * Version of Zinnia (Github release number) (Github branch and commit hash)
- * Version of the Unity software (e.g. Unity 2018.3)
+ * Version of Zinnia (GitHub release number) (GitHub branch and commit hash)
+ * Version of the Unity software (e.g. Unity 2018.3.10f1)
 
 ### Steps to reproduce
 

--- a/README.md
+++ b/README.md
@@ -12,13 +12,13 @@
 
 Zinnia is a collection of design patterns for the [Unity] software that can be beneficial in (but not limited to) spatial computing development.
 
-  > **Requires** the Unity software version 2018.3 (or above).
+  > **Requires** the Unity software version 2018.3.10f1 (or above).
 
 ## Getting Started
 
 ### Setting up a project
 
-* Using the Unity software version 2018.3 (or above), create a new project using the 3D Template or open an existing project.
+* Using the Unity software version 2018.3.10f1 (or above), create a new project using the 3D Template or open an existing project.
 * If the project requires Virtual Reality support:
   * Ensure `Virtual Reality Supported` is checked.
     * In the Unity software select `Main Menu -> Edit -> Project Settings` to open the `Project Settings` window.


### PR DESCRIPTION
There were reports that Zinnia was not working correctly on
earlier versions of Unity 2018.3 and due to numerous XR bug fixes
in Unity 2018.3 it's best to recommend 2018.3.10f1 as it is the
least buggy in XR space.