### PR TITLE
fix(Tracking): reset distance check when pinch points change

### DIFF
--- a/Runtime/Tracking/Modification/PinchScaler.cs
+++ b/Runtime/Tracking/Modification/PinchScaler.cs
@@ -1,6 +1,7 @@
 ﻿namespace Zinnia.Tracking.Modification
 {
     using UnityEngine;
+    using Malimbe.MemberChangeMethod;
     using Malimbe.MemberClearanceMethod;
     using Malimbe.XmlDocumentationAttribute;
     using Malimbe.PropertySerializationAttribute;
@@ -132,6 +133,24 @@
         protected virtual Vector3 GetTargetScale()
         {
             return UseLocalScale ? Target.transform.localScale : Target.transform.lossyScale;
+        }
+
+        /// <summary>
+        /// Called after <see cref="PrimaryPoint"/> has been changed.
+        /// </summary>
+        [CalledAfterChangeOf(nameof(PrimaryPoint))]
+        protected virtual void OnAfterPrimaryPointChange()
+        {
+            previousDistance = null;
+        }
+
+        /// <summary>
+        /// Called after <see cref="SecondaryPoint"/> has been changed.
+        /// </summary>
+        [CalledAfterChangeOf(nameof(SecondaryPoint))]
+        protected virtual void OnAfterSecondaryPointChange()
+        {
+            previousDistance = null;
         }
     }
 }


### PR DESCRIPTION
The PinchScaler was not reporting the correct distances between
pinch points if either the primary or secondary point changed
(or was cleared) as the code would only reset the previous
distance back to null if the component was disabled. It should
also reset the previous distance check to null if either the
primary or secondary points change so the previous distance in
the process calculation is recreated to have the correct initial
distance delta.