### PR TITLE
fix(Tracking): remove gravity from rigidbody tests

### DIFF
--- a/Tests/Editor/Tracking/Follow/Modifier/Property/Position/RigidbodyVelocityTest.cs
+++ b/Tests/Editor/Tracking/Follow/Modifier/Property/Position/RigidbodyVelocityTest.cs
@@ -21,15 +21,13 @@ namespace Test.Zinnia.Tracking.Follow.Modifier.Property.Position
             containingObject = new GameObject();
             subject = containingObject.AddComponent<RigidbodyVelocity>();
             subjectRigidbody = containingObject.AddComponent<Rigidbody>();
+            subjectRigidbody.useGravity = false;
         }
 
         [TearDown]
         public void TearDown()
         {
-            Object.DestroyImmediate(subjectRigidbody);
-            Object.DestroyImmediate(subject);
             Object.DestroyImmediate(containingObject);
-
             timeOverride.ResetTime();
         }
 

--- a/Tests/Editor/Tracking/Follow/Modifier/Property/Rotation/RigidbodyAngularVelocityTest.cs
+++ b/Tests/Editor/Tracking/Follow/Modifier/Property/Rotation/RigidbodyAngularVelocityTest.cs
@@ -21,15 +21,13 @@ namespace Test.Zinnia.Tracking.Follow.Modifier.Property.Rotation
             containingObject = new GameObject();
             subject = containingObject.AddComponent<RigidbodyAngularVelocity>();
             subjectRigidbody = containingObject.AddComponent<Rigidbody>();
+            subjectRigidbody.useGravity = false;
         }
 
         [TearDown]
         public void TearDown()
         {
-            Object.DestroyImmediate(subjectRigidbody);
-            Object.DestroyImmediate(subject);
             Object.DestroyImmediate(containingObject);
-
             timeOverride.ResetTime();
         }
 


### PR DESCRIPTION
Gravity was being applied to the rigidbodies in the tracking
modifier tests causing them to sometimes be falling at the point
of the initial position/rotation assertion, which should have been
zero.

Gravity is now turned off on the rigidbody, which will prevent it
from falling and therefore the tests will pass.