### PR TITLE
fix(Rule): ensure layer rule matches correctly against layer mask

### DIFF
--- a/Runtime/Rule/AnyLayerRule.cs
+++ b/Runtime/Rule/AnyLayerRule.cs
@@ -19,7 +19,7 @@
         /// <inheritdoc />
         protected override bool Accepts(GameObject targetGameObject)
         {
-            return (targetGameObject.layer & LayerMask.value) != 0;
+            return (LayerMask & (1 << targetGameObject.layer)) != 0;
         }
     }
 }

--- a/Tests/Editor/Rule/AnyLayerRuleTest.cs
+++ b/Tests/Editor/Rule/AnyLayerRuleTest.cs
@@ -15,10 +15,7 @@ namespace Test.Zinnia.Rule
         [SetUp]
         public void SetUp()
         {
-            containingObject = new GameObject
-            {
-                layer = LayerMask.NameToLayer("UI")
-            };
+            containingObject = new GameObject();
             container = new RuleContainer();
             subject = containingObject.AddComponent<AnyLayerRule>();
             container.Interface = subject;
@@ -33,27 +30,63 @@ namespace Test.Zinnia.Rule
         [Test]
         public void AcceptsMatch()
         {
-            subject.LayerMask = LayerMask.NameToLayer("UI");
+            containingObject.layer = LayerMask.NameToLayer("UI");
+            subject.LayerMask = LayerMask.GetMask("UI");
+            Assert.IsTrue(container.Accepts(containingObject));
+        }
+
+        [Test]
+        public void AcceptsMatchMultipleLayers()
+        {
+            containingObject.layer = LayerMask.NameToLayer("UI") | LayerMask.NameToLayer("Water");
+            subject.LayerMask = LayerMask.GetMask("UI");
+            Assert.IsTrue(container.Accepts(containingObject));
+        }
+
+        [Test]
+        public void AcceptsMatchMultipleLayerMask()
+        {
+            containingObject.layer = LayerMask.NameToLayer("UI");
+            subject.LayerMask = LayerMask.GetMask("UI") | LayerMask.GetMask("Water");
             Assert.IsTrue(container.Accepts(containingObject));
         }
 
         [Test]
         public void RefusesEmpty()
         {
+            containingObject.layer = LayerMask.NameToLayer("UI");
             Assert.IsFalse(container.Accepts(containingObject));
         }
 
         [Test]
         public void RefusesDifferent()
         {
-            subject.LayerMask = LayerMask.NameToLayer("Ignore Raycast");
+            containingObject.layer = LayerMask.NameToLayer("UI");
+            subject.LayerMask = LayerMask.GetMask("Ignore Raycast");
+            Assert.IsFalse(container.Accepts(containingObject));
+        }
+
+        [Test]
+        public void RefusesDifferentMultipleLayers()
+        {
+            containingObject.layer = LayerMask.NameToLayer("UI") | LayerMask.NameToLayer("Water");
+            subject.LayerMask = LayerMask.GetMask("Ignore Raycast");
+            Assert.IsFalse(container.Accepts(containingObject));
+        }
+
+        [Test]
+        public void RefusesDifferentMultipleLayerMask()
+        {
+            containingObject.layer = LayerMask.NameToLayer("UI");
+            subject.LayerMask = LayerMask.GetMask("Ignore Raycast") | LayerMask.GetMask("Water");
             Assert.IsFalse(container.Accepts(containingObject));
         }
 
         [Test]
         public void RefusesInactiveGameObject()
         {
-            subject.LayerMask = LayerMask.NameToLayer("UI");
+            containingObject.layer = LayerMask.NameToLayer("UI");
+            subject.LayerMask = LayerMask.GetMask("UI");
             subject.gameObject.SetActive(false);
             Assert.IsFalse(container.Accepts(containingObject));
         }
@@ -61,7 +94,8 @@ namespace Test.Zinnia.Rule
         [Test]
         public void RefusesInactiveComponent()
         {
-            subject.LayerMask = LayerMask.NameToLayer("UI");
+            containingObject.layer = LayerMask.NameToLayer("UI");
+            subject.LayerMask = LayerMask.GetMask("UI");
             subject.enabled = false;
             Assert.IsFalse(container.Accepts(containingObject));
         }


### PR DESCRIPTION
The AnyLayerRule was not correctly matching against the specified
LayerMask and the tests were also incorrect and therefore not
highlighting the issue.

In the tests where it would set up the LayerMask by doing
`subject.LayerMask = LayerMask.NameToLayer("UI")` this would not
actually set the LayerMask property to `UI` instead it would set
it to `Default` and `Ignore Raycast`. The correct way to set the
LayerMask property is to use `LayerMask.GetMask("UI")` which then
will select the correct property and highlight the issue in the
AnyLayerRule.

The AnyLayerRule is then fixed by checking the LayerMask property
is equal to the existing LayerMask with the target layer pushed
on to it.

This makes all of the tests pass and also works by testing with
scene objects.