### PR TITLE
fix(Collision): utilize both colliding objects in equality check

### DIFF
--- a/Runtime/Tracking/Collision/CollisionNotifier.cs
+++ b/Runtime/Tracking/Collision/CollisionNotifier.cs
@@ -80,7 +80,7 @@
                     return true;
                 }
 
-                return Equals(ColliderData.GetContainingTransform(), other.ColliderData.GetContainingTransform());
+                return Equals(ColliderData.GetContainingTransform(), other.ColliderData.GetContainingTransform()) && ((ForwardSource == null && other.ForwardSource == null) || Equals(ForwardSource, other.ForwardSource));
             }
 
             /// <inheritdoc />
@@ -118,9 +118,7 @@
         /// Defines the event with the <see cref="EventData"/>.
         /// </summary>
         [Serializable]
-        public class UnityEvent : UnityEvent<EventData>
-        {
-        }
+        public class UnityEvent : UnityEvent<EventData> { }
 
         /// <summary>
         /// The types of collisions that events will be emitted for.
@@ -210,6 +208,10 @@
             return collisionNotifiers;
         }
 
+        /// <summary>
+        /// Processes any collision start events on the given data and propagates it to any linked <see cref="CollisionNotifier"/>.
+        /// </summary>
+        /// <param name="data">The collision data.</param>
         protected virtual void OnCollisionStarted(EventData data)
         {
             if (!CanEmit(data))
@@ -225,6 +227,10 @@
             }
         }
 
+        /// <summary>
+        /// Processes any collision change events on the given data and propagates it to any linked <see cref="CollisionNotifier"/>.
+        /// </summary>
+        /// <param name="data">The collision data.</param>
         protected virtual void OnCollisionChanged(EventData data)
         {
             if (!CanEmit(data))
@@ -240,6 +246,10 @@
             }
         }
 
+        /// <summary>
+        /// Processes any collision stop events on the given data and propagates it to any linked <see cref="CollisionNotifier"/>.
+        /// </summary>
+        /// <param name="data">The collision data.</param>
         protected virtual void OnCollisionStopped(EventData data)
         {
             if (!CanEmit(data))

--- a/Tests/Editor/Tracking/Collision/CollisionNotifierTest.cs
+++ b/Tests/Editor/Tracking/Collision/CollisionNotifierTest.cs
@@ -1,0 +1,164 @@
+﻿using Zinnia.Tracking.Collision;
+
+namespace Test.Zinnia.Tracking.Collision
+{
+    using UnityEngine;
+    using NUnit.Framework;
+    using Test.Zinnia.Utility.Mock;
+
+    public class CollisionNotifierTest
+    {
+        private GameObject containingObject;
+        private CollisionNotifierMock subject;
+
+        [SetUp]
+        public void SetUp()
+        {
+            containingObject = new GameObject();
+            containingObject.SetActive(false);
+            subject = containingObject.AddComponent<CollisionNotifierMock>();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            Object.DestroyImmediate(containingObject);
+        }
+
+        [Test]
+        public void CollisionStarted()
+        {
+            GameObject linkedContainer = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            CollisionNotifier linkedNotifier = linkedContainer.AddComponent<CollisionNotifier>();
+
+            GameObject unlinkedContainer = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            CollisionNotifier unlinkedNotifier = unlinkedContainer.AddComponent<CollisionNotifier>();
+
+            UnityEventListenerMock collisionStartedListenerMock = new UnityEventListenerMock();
+            subject.CollisionStarted.AddListener(collisionStartedListenerMock.Listen);
+
+            UnityEventListenerMock linkedCollisionStartedListenerMock = new UnityEventListenerMock();
+            linkedNotifier.CollisionStarted.AddListener(linkedCollisionStartedListenerMock.Listen);
+
+            UnityEventListenerMock unlinkedCollisionStartedListenerMock = new UnityEventListenerMock();
+            unlinkedNotifier.CollisionStarted.AddListener(unlinkedCollisionStartedListenerMock.Listen);
+
+            subject.CollisionStartedMock(linkedContainer.GetComponent<Collider>());
+
+            Assert.IsTrue(collisionStartedListenerMock.Received);
+            Assert.IsTrue(linkedCollisionStartedListenerMock.Received);
+            Assert.IsFalse(unlinkedCollisionStartedListenerMock.Received);
+
+            Object.DestroyImmediate(linkedContainer);
+            Object.DestroyImmediate(unlinkedContainer);
+        }
+
+        [Test]
+        public void CollisionStopped()
+        {
+            GameObject linkedContainer = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            CollisionNotifier linkedNotifier = linkedContainer.AddComponent<CollisionNotifier>();
+
+            GameObject unlinkedContainer = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            CollisionNotifier unlinkedNotifier = unlinkedContainer.AddComponent<CollisionNotifier>();
+
+            UnityEventListenerMock collisionStoppedListenerMock = new UnityEventListenerMock();
+            subject.CollisionStopped.AddListener(collisionStoppedListenerMock.Listen);
+
+            UnityEventListenerMock linkedCollisionStoppedListenerMock = new UnityEventListenerMock();
+            linkedNotifier.CollisionStopped.AddListener(linkedCollisionStoppedListenerMock.Listen);
+
+            UnityEventListenerMock unlinkedCollisionStoppedListenerMock = new UnityEventListenerMock();
+            unlinkedNotifier.CollisionStopped.AddListener(unlinkedCollisionStoppedListenerMock.Listen);
+
+            subject.CollisionStoppedMock(linkedContainer.GetComponent<Collider>());
+
+            Assert.IsTrue(collisionStoppedListenerMock.Received);
+            Assert.IsTrue(linkedCollisionStoppedListenerMock.Received);
+            Assert.IsFalse(unlinkedCollisionStoppedListenerMock.Received);
+
+            Object.DestroyImmediate(linkedContainer);
+            Object.DestroyImmediate(unlinkedContainer);
+        }
+
+        [Test]
+        public void CollisionChanged()
+        {
+            GameObject linkedContainer = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            CollisionNotifier linkedNotifier = linkedContainer.AddComponent<CollisionNotifier>();
+
+            GameObject unlinkedContainer = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            CollisionNotifier unlinkedNotifier = unlinkedContainer.AddComponent<CollisionNotifier>();
+
+            UnityEventListenerMock collisionChangedListenerMock = new UnityEventListenerMock();
+            subject.CollisionChanged.AddListener(collisionChangedListenerMock.Listen);
+
+            UnityEventListenerMock linkedCollisionChangedListenerMock = new UnityEventListenerMock();
+            linkedNotifier.CollisionChanged.AddListener(linkedCollisionChangedListenerMock.Listen);
+
+            UnityEventListenerMock unlinkedCollisionChangedListenerMock = new UnityEventListenerMock();
+            unlinkedNotifier.CollisionChanged.AddListener(unlinkedCollisionChangedListenerMock.Listen);
+
+            subject.CollisionChangedMock(linkedContainer.GetComponent<Collider>());
+
+            Assert.IsTrue(collisionChangedListenerMock.Received);
+            Assert.IsTrue(linkedCollisionChangedListenerMock.Received);
+            Assert.IsFalse(unlinkedCollisionChangedListenerMock.Received);
+
+            Object.DestroyImmediate(linkedContainer);
+            Object.DestroyImmediate(unlinkedContainer);
+        }
+
+        [Test]
+        public void EventDataEquals()
+        {
+            GameObject forwardSourceA = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            GameObject forwardSourceB = GameObject.CreatePrimitive(PrimitiveType.Cube);
+
+            CollisionNotifier.EventData eventAA = new CollisionNotifier.EventData();
+            CollisionNotifier.EventData eventBB = new CollisionNotifier.EventData();
+            CollisionNotifier.EventData eventAB = new CollisionNotifier.EventData();
+            CollisionNotifier.EventData eventBA = new CollisionNotifier.EventData();
+
+            eventAA.Set(forwardSourceA.GetComponent<Component>(), true, null, forwardSourceA.GetComponent<Collider>());
+            eventBB.Set(forwardSourceB.GetComponent<Component>(), true, null, forwardSourceB.GetComponent<Collider>());
+            eventAB.Set(forwardSourceA.GetComponent<Component>(), true, null, forwardSourceB.GetComponent<Collider>());
+            eventBA.Set(forwardSourceB.GetComponent<Component>(), true, null, forwardSourceA.GetComponent<Collider>());
+
+            Assert.IsTrue(eventAA.Equals(eventAA));
+            Assert.IsTrue(eventBB.Equals(eventBB));
+            Assert.IsTrue(eventAB.Equals(eventAB));
+            Assert.IsTrue(eventBA.Equals(eventBA));
+
+            Assert.IsFalse(eventAA.Equals(eventBB));
+            Assert.IsFalse(eventAA.Equals(eventAB));
+            Assert.IsFalse(eventAA.Equals(eventBA));
+
+            Assert.IsFalse(eventBB.Equals(eventAB));
+            Assert.IsFalse(eventBB.Equals(eventBA));
+
+            Assert.IsFalse(eventAB.Equals(eventBA));
+
+            Object.DestroyImmediate(forwardSourceA);
+            Object.DestroyImmediate(forwardSourceB);
+        }
+
+        public class CollisionNotifierMock : CollisionNotifier
+        {
+            public virtual void CollisionStartedMock(Collider collider)
+            {
+                OnCollisionStarted(eventData.Set(this, false, null, collider));
+            }
+
+            public virtual void CollisionStoppedMock(Collider collider)
+            {
+                OnCollisionStopped(eventData.Set(this, false, null, collider));
+            }
+
+            public virtual void CollisionChangedMock(Collider collider)
+            {
+                OnCollisionChanged(eventData.Set(this, false, null, collider));
+            }
+        }
+    }
+}

--- a/Tests/Editor/Tracking/Collision/CollisionNotifierTest.cs.meta
+++ b/Tests/Editor/Tracking/Collision/CollisionNotifierTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fba850a16ee0589498e4da80525dced0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Editor/Tracking/Collision/CollisionTrackerTest.cs
+++ b/Tests/Editor/Tracking/Collision/CollisionTrackerTest.cs
@@ -1,0 +1,139 @@
+﻿using Zinnia.Tracking.Collision;
+
+namespace Test.Zinnia.Tracking.Collision
+{
+    using UnityEngine;
+    using UnityEngine.TestTools;
+    using System.Collections;
+    using NUnit.Framework;
+    using Test.Zinnia.Utility.Mock;
+
+    public class CollisionTrackerTest
+    {
+        [UnityTest]
+        public IEnumerator CollisionStates()
+        {
+            WaitForFixedUpdate yieldInstruction = new WaitForFixedUpdate();
+
+            GameObject trackerContainer = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            trackerContainer.GetComponent<Collider>().isTrigger = true;
+            trackerContainer.AddComponent<Rigidbody>().isKinematic = true;
+            trackerContainer.transform.position = Vector3.forward;
+            CollisionTracker tracker = trackerContainer.AddComponent<CollisionTracker>();
+
+            GameObject notifierContainer = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            notifierContainer.GetComponent<Collider>().isTrigger = true;
+            notifierContainer.AddComponent<Rigidbody>().isKinematic = true;
+            notifierContainer.transform.position = Vector3.back;
+            CollisionNotifier notifier = notifierContainer.AddComponent<CollisionNotifier>();
+
+            UnityEventListenerMock trackerCollisionStartedListenerMock = new UnityEventListenerMock();
+            UnityEventListenerMock trackerCollisionChangedListenerMock = new UnityEventListenerMock();
+            UnityEventListenerMock trackerCollisionStoppedListenerMock = new UnityEventListenerMock();
+            tracker.CollisionStarted.AddListener(trackerCollisionStartedListenerMock.Listen);
+            tracker.CollisionChanged.AddListener(trackerCollisionChangedListenerMock.Listen);
+            tracker.CollisionStopped.AddListener(trackerCollisionStoppedListenerMock.Listen);
+
+            UnityEventListenerMock notifierCollisionStartedListenerMock = new UnityEventListenerMock();
+            UnityEventListenerMock notifierCollisionChangedListenerMock = new UnityEventListenerMock();
+            UnityEventListenerMock notifierCollisionStoppedListenerMock = new UnityEventListenerMock();
+            notifier.CollisionStarted.AddListener(notifierCollisionStartedListenerMock.Listen);
+            notifier.CollisionChanged.AddListener(notifierCollisionChangedListenerMock.Listen);
+            notifier.CollisionStopped.AddListener(notifierCollisionStoppedListenerMock.Listen);
+
+            yield return yieldInstruction;
+
+            Assert.IsFalse(trackerCollisionStartedListenerMock.Received);
+            Assert.IsFalse(trackerCollisionChangedListenerMock.Received);
+            Assert.IsFalse(trackerCollisionStoppedListenerMock.Received);
+
+            Assert.IsFalse(notifierCollisionStartedListenerMock.Received);
+            Assert.IsFalse(notifierCollisionChangedListenerMock.Received);
+            Assert.IsFalse(notifierCollisionStoppedListenerMock.Received);
+
+            trackerCollisionStartedListenerMock.Reset();
+            trackerCollisionChangedListenerMock.Reset();
+            trackerCollisionStoppedListenerMock.Reset();
+
+            notifierCollisionStartedListenerMock.Reset();
+            notifierCollisionChangedListenerMock.Reset();
+            notifierCollisionStoppedListenerMock.Reset();
+
+            trackerContainer.transform.position = Vector3.zero;
+            notifierContainer.transform.position = Vector3.zero;
+
+            yield return yieldInstruction;
+
+            Assert.IsTrue(trackerCollisionStartedListenerMock.Received);
+            Assert.IsTrue(trackerCollisionChangedListenerMock.Received);
+            Assert.IsFalse(trackerCollisionStoppedListenerMock.Received);
+
+            Assert.IsTrue(notifierCollisionStartedListenerMock.Received);
+            Assert.IsTrue(notifierCollisionChangedListenerMock.Received);
+            Assert.IsFalse(notifierCollisionStoppedListenerMock.Received);
+
+            trackerCollisionStartedListenerMock.Reset();
+            trackerCollisionChangedListenerMock.Reset();
+            trackerCollisionStoppedListenerMock.Reset();
+
+            notifierCollisionStartedListenerMock.Reset();
+            notifierCollisionChangedListenerMock.Reset();
+            notifierCollisionStoppedListenerMock.Reset();
+
+            yield return yieldInstruction;
+
+            Assert.IsFalse(trackerCollisionStartedListenerMock.Received);
+            Assert.IsTrue(trackerCollisionChangedListenerMock.Received);
+            Assert.IsFalse(trackerCollisionStoppedListenerMock.Received);
+
+            Assert.IsFalse(notifierCollisionStartedListenerMock.Received);
+            Assert.IsTrue(notifierCollisionChangedListenerMock.Received);
+            Assert.IsFalse(notifierCollisionStoppedListenerMock.Received);
+
+            trackerCollisionStartedListenerMock.Reset();
+            trackerCollisionChangedListenerMock.Reset();
+            trackerCollisionStoppedListenerMock.Reset();
+
+            notifierCollisionStartedListenerMock.Reset();
+            notifierCollisionChangedListenerMock.Reset();
+            notifierCollisionStoppedListenerMock.Reset();
+
+            trackerContainer.transform.position = Vector3.one * 0.25f;
+            notifierContainer.transform.position = Vector3.one * -0.25f;
+
+            yield return yieldInstruction;
+
+            Assert.IsFalse(trackerCollisionStartedListenerMock.Received);
+            Assert.IsTrue(trackerCollisionChangedListenerMock.Received);
+            Assert.IsFalse(trackerCollisionStoppedListenerMock.Received);
+
+            Assert.IsFalse(notifierCollisionStartedListenerMock.Received);
+            Assert.IsTrue(notifierCollisionChangedListenerMock.Received);
+            Assert.IsFalse(notifierCollisionStoppedListenerMock.Received);
+
+            trackerCollisionStartedListenerMock.Reset();
+            trackerCollisionChangedListenerMock.Reset();
+            trackerCollisionStoppedListenerMock.Reset();
+
+            notifierCollisionStartedListenerMock.Reset();
+            notifierCollisionChangedListenerMock.Reset();
+            notifierCollisionStoppedListenerMock.Reset();
+
+            trackerContainer.transform.position = Vector3.forward;
+            notifierContainer.transform.position = Vector3.back;
+
+            yield return yieldInstruction;
+
+            Assert.IsFalse(trackerCollisionStartedListenerMock.Received);
+            Assert.IsFalse(trackerCollisionChangedListenerMock.Received);
+            Assert.IsTrue(trackerCollisionStoppedListenerMock.Received);
+
+            Assert.IsFalse(notifierCollisionStartedListenerMock.Received);
+            Assert.IsFalse(notifierCollisionChangedListenerMock.Received);
+            Assert.IsTrue(notifierCollisionStoppedListenerMock.Received);
+
+            Object.DestroyImmediate(trackerContainer);
+            Object.DestroyImmediate(notifierContainer);
+        }
+    }
+}

--- a/Tests/Editor/Tracking/Collision/CollisionTrackerTest.cs.meta
+++ b/Tests/Editor/Tracking/Collision/CollisionTrackerTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 583cf3818dd0d3c43951fa3d17ac1b42
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
The CollisionNotifier.EventData equality check was only checking to
see if one side of the collision matched to determine if the collision
data was equal.

This is incorrect as the following should be true:

```
A collides with B == A collides with B
A collides with B != A collides with C
A collides with B != C collides with B
```

However, previously this was actually the case

`A collides with B == C collides with B`

Because the second object of the collision was only being checked for
equality therefore if two different objects (A, C) collided with the
same target (B) then the EventData would be considered equal whereas
the collision is not equal.

The fix is to ensure if there is a forwarding source of the collision
then that should also be used in the equality check.

Additional tests have been added to test the functionality of the
CollisionNotifier and CollisionTracker and to test this EventData.