### PR TITLE
feat(Collision): ability to ignore tracked collision states

### DIFF
--- a/Runtime/Tracking/Collision/CollisionNotifier.cs
+++ b/Runtime/Tracking/Collision/CollisionNotifier.cs
@@ -137,11 +137,37 @@
         }
 
         /// <summary>
+        /// The states of a tracked collision.
+        /// </summary>
+        [Flags]
+        public enum CollisionStates
+        {
+            /// <summary>
+            /// When a new collision occurs.
+            /// </summary>
+            Enter = 1 << 0,
+            /// <summary>
+            /// When an existing collision continues to exist.
+            /// </summary>
+            Stay = 1 << 1,
+            /// <summary>
+            /// When an existing collision ends.
+            /// </summary>
+            Exit = 1 << 2
+        }
+
+        /// <summary>
         /// The types of collisions that events will be emitted for.
         /// </summary>
         [Serialized]
         [field: DocumentedByXml, UnityFlags]
         public CollisionTypes EmittedTypes { get; set; } = (CollisionTypes)(-1);
+        /// <summary>
+        /// The <see cref="CollisionStates"/> to process.
+        /// </summary>
+        [Serialized]
+        [field: DocumentedByXml, UnityFlags]
+        public CollisionStates StatesToProcess { get; set; } = (CollisionStates)(-1);
         /// <summary>
         /// Allows to optionally determine which forwarded collisions to react to based on the set rules for the forwarding sender.
         /// </summary>
@@ -214,7 +240,7 @@
         /// <param name="data">The collision data.</param>
         protected virtual void OnCollisionStarted(EventData data)
         {
-            if (!CanEmit(data))
+            if ((StatesToProcess & CollisionStates.Enter) == 0 || !CanEmit(data))
             {
                 return;
             }
@@ -233,7 +259,7 @@
         /// <param name="data">The collision data.</param>
         protected virtual void OnCollisionChanged(EventData data)
         {
-            if (!CanEmit(data))
+            if ((StatesToProcess & CollisionStates.Stay) == 0 || !CanEmit(data))
             {
                 return;
             }
@@ -252,7 +278,7 @@
         /// <param name="data">The collision data.</param>
         protected virtual void OnCollisionStopped(EventData data)
         {
-            if (!CanEmit(data))
+            if ((StatesToProcess & CollisionStates.Exit) == 0 || !CanEmit(data))
             {
                 return;
             }

--- a/Runtime/Tracking/Collision/CollisionTracker.cs
+++ b/Runtime/Tracking/Collision/CollisionTracker.cs
@@ -9,31 +9,61 @@
     {
         protected virtual void OnCollisionEnter(Collision collision)
         {
+            if ((StatesToProcess & CollisionStates.Enter) == 0)
+            {
+                return;
+            }
+
             OnCollisionStarted(eventData.Set(this, false, collision, collision.collider));
         }
 
         protected virtual void OnCollisionStay(Collision collision)
         {
+            if ((StatesToProcess & CollisionStates.Stay) == 0)
+            {
+                return;
+            }
+
             OnCollisionChanged(eventData.Set(this, false, collision, collision.collider));
         }
 
         protected virtual void OnCollisionExit(Collision collision)
         {
+            if ((StatesToProcess & CollisionStates.Exit) == 0)
+            {
+                return;
+            }
+
             OnCollisionStopped(eventData.Set(this, false, collision, collision.collider));
         }
 
         protected virtual void OnTriggerEnter(Collider collider)
         {
+            if ((StatesToProcess & CollisionStates.Enter) == 0)
+            {
+                return;
+            }
+
             OnCollisionStarted(eventData.Set(this, true, null, collider));
         }
 
         protected virtual void OnTriggerStay(Collider collider)
         {
+            if ((StatesToProcess & CollisionStates.Stay) == 0)
+            {
+                return;
+            }
+
             OnCollisionChanged(eventData.Set(this, true, null, collider));
         }
 
         protected virtual void OnTriggerExit(Collider collider)
         {
+            if ((StatesToProcess & CollisionStates.Exit) == 0)
+            {
+                return;
+            }
+
             OnCollisionStopped(eventData.Set(this, true, null, collider));
         }
     }

--- a/Tests/Editor/Tracking/Collision/CollisionNotifierTest.cs
+++ b/Tests/Editor/Tracking/Collision/CollisionNotifierTest.cs
@@ -110,6 +110,96 @@ namespace Test.Zinnia.Tracking.Collision
         }
 
         [Test]
+        public void CollisionIgnoreStarted()
+        {
+            GameObject linkedContainer = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            CollisionNotifier linkedNotifier = linkedContainer.AddComponent<CollisionNotifier>();
+
+            GameObject unlinkedContainer = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            CollisionNotifier unlinkedNotifier = unlinkedContainer.AddComponent<CollisionNotifier>();
+
+            UnityEventListenerMock collisionStartedListenerMock = new UnityEventListenerMock();
+            subject.CollisionStarted.AddListener(collisionStartedListenerMock.Listen);
+
+            UnityEventListenerMock linkedCollisionStartedListenerMock = new UnityEventListenerMock();
+            linkedNotifier.CollisionStarted.AddListener(linkedCollisionStartedListenerMock.Listen);
+
+            UnityEventListenerMock unlinkedCollisionStartedListenerMock = new UnityEventListenerMock();
+            unlinkedNotifier.CollisionStarted.AddListener(unlinkedCollisionStartedListenerMock.Listen);
+
+            subject.StatesToProcess = CollisionNotifier.CollisionStates.Stay | CollisionNotifier.CollisionStates.Exit;
+
+            subject.CollisionStartedMock(linkedContainer.GetComponent<Collider>());
+
+            Assert.IsFalse(collisionStartedListenerMock.Received);
+            Assert.IsFalse(linkedCollisionStartedListenerMock.Received);
+            Assert.IsFalse(unlinkedCollisionStartedListenerMock.Received);
+
+            Object.DestroyImmediate(linkedContainer);
+            Object.DestroyImmediate(unlinkedContainer);
+        }
+
+        [Test]
+        public void CollisionIgnoreStopped()
+        {
+            GameObject linkedContainer = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            CollisionNotifier linkedNotifier = linkedContainer.AddComponent<CollisionNotifier>();
+
+            GameObject unlinkedContainer = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            CollisionNotifier unlinkedNotifier = unlinkedContainer.AddComponent<CollisionNotifier>();
+
+            UnityEventListenerMock collisionStoppedListenerMock = new UnityEventListenerMock();
+            subject.CollisionStopped.AddListener(collisionStoppedListenerMock.Listen);
+
+            UnityEventListenerMock linkedCollisionStoppedListenerMock = new UnityEventListenerMock();
+            linkedNotifier.CollisionStopped.AddListener(linkedCollisionStoppedListenerMock.Listen);
+
+            UnityEventListenerMock unlinkedCollisionStoppedListenerMock = new UnityEventListenerMock();
+            unlinkedNotifier.CollisionStopped.AddListener(unlinkedCollisionStoppedListenerMock.Listen);
+
+            subject.StatesToProcess = CollisionNotifier.CollisionStates.Enter | CollisionNotifier.CollisionStates.Stay;
+
+            subject.CollisionStoppedMock(linkedContainer.GetComponent<Collider>());
+
+            Assert.IsFalse(collisionStoppedListenerMock.Received);
+            Assert.IsFalse(linkedCollisionStoppedListenerMock.Received);
+            Assert.IsFalse(unlinkedCollisionStoppedListenerMock.Received);
+
+            Object.DestroyImmediate(linkedContainer);
+            Object.DestroyImmediate(unlinkedContainer);
+        }
+
+        [Test]
+        public void CollisionIgnoreChanged()
+        {
+            GameObject linkedContainer = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            CollisionNotifier linkedNotifier = linkedContainer.AddComponent<CollisionNotifier>();
+
+            GameObject unlinkedContainer = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            CollisionNotifier unlinkedNotifier = unlinkedContainer.AddComponent<CollisionNotifier>();
+
+            UnityEventListenerMock collisionChangedListenerMock = new UnityEventListenerMock();
+            subject.CollisionChanged.AddListener(collisionChangedListenerMock.Listen);
+
+            UnityEventListenerMock linkedCollisionChangedListenerMock = new UnityEventListenerMock();
+            linkedNotifier.CollisionChanged.AddListener(linkedCollisionChangedListenerMock.Listen);
+
+            UnityEventListenerMock unlinkedCollisionChangedListenerMock = new UnityEventListenerMock();
+            unlinkedNotifier.CollisionChanged.AddListener(unlinkedCollisionChangedListenerMock.Listen);
+
+            subject.StatesToProcess = CollisionNotifier.CollisionStates.Enter | CollisionNotifier.CollisionStates.Exit;
+
+            subject.CollisionChangedMock(linkedContainer.GetComponent<Collider>());
+
+            Assert.IsFalse(collisionChangedListenerMock.Received);
+            Assert.IsFalse(linkedCollisionChangedListenerMock.Received);
+            Assert.IsFalse(unlinkedCollisionChangedListenerMock.Received);
+
+            Object.DestroyImmediate(linkedContainer);
+            Object.DestroyImmediate(unlinkedContainer);
+        }
+
+        [Test]
         public void EventDataEquals()
         {
             GameObject forwardSourceA = GameObject.CreatePrimitive(PrimitiveType.Cube);

--- a/Tests/Editor/Tracking/Collision/CollisionTrackerTest.cs
+++ b/Tests/Editor/Tracking/Collision/CollisionTrackerTest.cs
@@ -135,5 +135,227 @@ namespace Test.Zinnia.Tracking.Collision
             Object.DestroyImmediate(trackerContainer);
             Object.DestroyImmediate(notifierContainer);
         }
+
+        [UnityTest]
+        public IEnumerator CollisionStatesIgnoreEnter()
+        {
+            WaitForFixedUpdate yieldInstruction = new WaitForFixedUpdate();
+
+            GameObject trackerContainer = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            trackerContainer.GetComponent<Collider>().isTrigger = true;
+            trackerContainer.AddComponent<Rigidbody>().isKinematic = true;
+            trackerContainer.transform.position = Vector3.forward;
+            CollisionTracker tracker = trackerContainer.AddComponent<CollisionTracker>();
+            tracker.StatesToProcess = CollisionTracker.CollisionStates.Stay | CollisionTracker.CollisionStates.Exit;
+
+            GameObject notifierContainer = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            notifierContainer.GetComponent<Collider>().isTrigger = true;
+            notifierContainer.AddComponent<Rigidbody>().isKinematic = true;
+            notifierContainer.transform.position = Vector3.back;
+            CollisionNotifier notifier = notifierContainer.AddComponent<CollisionNotifier>();
+
+            UnityEventListenerMock trackerCollisionStartedListenerMock = new UnityEventListenerMock();
+            UnityEventListenerMock trackerCollisionChangedListenerMock = new UnityEventListenerMock();
+            UnityEventListenerMock trackerCollisionStoppedListenerMock = new UnityEventListenerMock();
+            tracker.CollisionStarted.AddListener(trackerCollisionStartedListenerMock.Listen);
+            tracker.CollisionChanged.AddListener(trackerCollisionChangedListenerMock.Listen);
+            tracker.CollisionStopped.AddListener(trackerCollisionStoppedListenerMock.Listen);
+
+            UnityEventListenerMock notifierCollisionStartedListenerMock = new UnityEventListenerMock();
+            UnityEventListenerMock notifierCollisionChangedListenerMock = new UnityEventListenerMock();
+            UnityEventListenerMock notifierCollisionStoppedListenerMock = new UnityEventListenerMock();
+            notifier.CollisionStarted.AddListener(notifierCollisionStartedListenerMock.Listen);
+            notifier.CollisionChanged.AddListener(notifierCollisionChangedListenerMock.Listen);
+            notifier.CollisionStopped.AddListener(notifierCollisionStoppedListenerMock.Listen);
+
+            yield return yieldInstruction;
+
+            Assert.IsFalse(trackerCollisionStartedListenerMock.Received);
+            Assert.IsFalse(trackerCollisionChangedListenerMock.Received);
+            Assert.IsFalse(trackerCollisionStoppedListenerMock.Received);
+
+            Assert.IsFalse(notifierCollisionStartedListenerMock.Received);
+            Assert.IsFalse(notifierCollisionChangedListenerMock.Received);
+            Assert.IsFalse(notifierCollisionStoppedListenerMock.Received);
+
+            trackerCollisionStartedListenerMock.Reset();
+            trackerCollisionChangedListenerMock.Reset();
+            trackerCollisionStoppedListenerMock.Reset();
+
+            notifierCollisionStartedListenerMock.Reset();
+            notifierCollisionChangedListenerMock.Reset();
+            notifierCollisionStoppedListenerMock.Reset();
+
+            trackerContainer.transform.position = Vector3.zero;
+            notifierContainer.transform.position = Vector3.zero;
+
+            yield return yieldInstruction;
+
+            Assert.IsFalse(trackerCollisionStartedListenerMock.Received);
+            Assert.IsTrue(trackerCollisionChangedListenerMock.Received);
+            Assert.IsFalse(trackerCollisionStoppedListenerMock.Received);
+
+            Assert.IsFalse(notifierCollisionStartedListenerMock.Received);
+            Assert.IsTrue(notifierCollisionChangedListenerMock.Received);
+            Assert.IsFalse(notifierCollisionStoppedListenerMock.Received);
+
+            Object.DestroyImmediate(trackerContainer);
+            Object.DestroyImmediate(notifierContainer);
+        }
+
+        [UnityTest]
+        public IEnumerator CollisionStatesIgnoreStay()
+        {
+            WaitForFixedUpdate yieldInstruction = new WaitForFixedUpdate();
+
+            GameObject trackerContainer = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            trackerContainer.GetComponent<Collider>().isTrigger = true;
+            trackerContainer.AddComponent<Rigidbody>().isKinematic = true;
+            trackerContainer.transform.position = Vector3.forward;
+            CollisionTracker tracker = trackerContainer.AddComponent<CollisionTracker>();
+            tracker.StatesToProcess = CollisionTracker.CollisionStates.Enter | CollisionTracker.CollisionStates.Exit;
+
+            GameObject notifierContainer = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            notifierContainer.GetComponent<Collider>().isTrigger = true;
+            notifierContainer.AddComponent<Rigidbody>().isKinematic = true;
+            notifierContainer.transform.position = Vector3.back;
+            CollisionNotifier notifier = notifierContainer.AddComponent<CollisionNotifier>();
+
+            UnityEventListenerMock trackerCollisionStartedListenerMock = new UnityEventListenerMock();
+            UnityEventListenerMock trackerCollisionChangedListenerMock = new UnityEventListenerMock();
+            UnityEventListenerMock trackerCollisionStoppedListenerMock = new UnityEventListenerMock();
+            tracker.CollisionStarted.AddListener(trackerCollisionStartedListenerMock.Listen);
+            tracker.CollisionChanged.AddListener(trackerCollisionChangedListenerMock.Listen);
+            tracker.CollisionStopped.AddListener(trackerCollisionStoppedListenerMock.Listen);
+
+            UnityEventListenerMock notifierCollisionStartedListenerMock = new UnityEventListenerMock();
+            UnityEventListenerMock notifierCollisionChangedListenerMock = new UnityEventListenerMock();
+            UnityEventListenerMock notifierCollisionStoppedListenerMock = new UnityEventListenerMock();
+            notifier.CollisionStarted.AddListener(notifierCollisionStartedListenerMock.Listen);
+            notifier.CollisionChanged.AddListener(notifierCollisionChangedListenerMock.Listen);
+            notifier.CollisionStopped.AddListener(notifierCollisionStoppedListenerMock.Listen);
+
+            yield return yieldInstruction;
+
+            Assert.IsFalse(trackerCollisionStartedListenerMock.Received);
+            Assert.IsFalse(trackerCollisionChangedListenerMock.Received);
+            Assert.IsFalse(trackerCollisionStoppedListenerMock.Received);
+
+            Assert.IsFalse(notifierCollisionStartedListenerMock.Received);
+            Assert.IsFalse(notifierCollisionChangedListenerMock.Received);
+            Assert.IsFalse(notifierCollisionStoppedListenerMock.Received);
+
+            trackerCollisionStartedListenerMock.Reset();
+            trackerCollisionChangedListenerMock.Reset();
+            trackerCollisionStoppedListenerMock.Reset();
+
+            notifierCollisionStartedListenerMock.Reset();
+            notifierCollisionChangedListenerMock.Reset();
+            notifierCollisionStoppedListenerMock.Reset();
+
+            trackerContainer.transform.position = Vector3.zero;
+            notifierContainer.transform.position = Vector3.zero;
+
+            yield return yieldInstruction;
+
+            Assert.IsTrue(trackerCollisionStartedListenerMock.Received);
+            Assert.IsFalse(trackerCollisionChangedListenerMock.Received);
+            Assert.IsFalse(trackerCollisionStoppedListenerMock.Received);
+
+            Assert.IsTrue(notifierCollisionStartedListenerMock.Received);
+            Assert.IsFalse(notifierCollisionChangedListenerMock.Received);
+            Assert.IsFalse(notifierCollisionStoppedListenerMock.Received);
+
+            Object.DestroyImmediate(trackerContainer);
+            Object.DestroyImmediate(notifierContainer);
+        }
+
+        [UnityTest]
+        public IEnumerator CollisionStatesIgnoreExit()
+        {
+            WaitForFixedUpdate yieldInstruction = new WaitForFixedUpdate();
+
+            GameObject trackerContainer = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            trackerContainer.GetComponent<Collider>().isTrigger = true;
+            trackerContainer.AddComponent<Rigidbody>().isKinematic = true;
+            trackerContainer.transform.position = Vector3.forward;
+            CollisionTracker tracker = trackerContainer.AddComponent<CollisionTracker>();
+            tracker.StatesToProcess = CollisionTracker.CollisionStates.Enter | CollisionTracker.CollisionStates.Stay;
+
+            GameObject notifierContainer = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            notifierContainer.GetComponent<Collider>().isTrigger = true;
+            notifierContainer.AddComponent<Rigidbody>().isKinematic = true;
+            notifierContainer.transform.position = Vector3.back;
+            CollisionNotifier notifier = notifierContainer.AddComponent<CollisionNotifier>();
+
+            UnityEventListenerMock trackerCollisionStartedListenerMock = new UnityEventListenerMock();
+            UnityEventListenerMock trackerCollisionChangedListenerMock = new UnityEventListenerMock();
+            UnityEventListenerMock trackerCollisionStoppedListenerMock = new UnityEventListenerMock();
+            tracker.CollisionStarted.AddListener(trackerCollisionStartedListenerMock.Listen);
+            tracker.CollisionChanged.AddListener(trackerCollisionChangedListenerMock.Listen);
+            tracker.CollisionStopped.AddListener(trackerCollisionStoppedListenerMock.Listen);
+
+            UnityEventListenerMock notifierCollisionStartedListenerMock = new UnityEventListenerMock();
+            UnityEventListenerMock notifierCollisionChangedListenerMock = new UnityEventListenerMock();
+            UnityEventListenerMock notifierCollisionStoppedListenerMock = new UnityEventListenerMock();
+            notifier.CollisionStarted.AddListener(notifierCollisionStartedListenerMock.Listen);
+            notifier.CollisionChanged.AddListener(notifierCollisionChangedListenerMock.Listen);
+            notifier.CollisionStopped.AddListener(notifierCollisionStoppedListenerMock.Listen);
+
+            yield return yieldInstruction;
+
+            Assert.IsFalse(trackerCollisionStartedListenerMock.Received);
+            Assert.IsFalse(trackerCollisionChangedListenerMock.Received);
+            Assert.IsFalse(trackerCollisionStoppedListenerMock.Received);
+
+            Assert.IsFalse(notifierCollisionStartedListenerMock.Received);
+            Assert.IsFalse(notifierCollisionChangedListenerMock.Received);
+            Assert.IsFalse(notifierCollisionStoppedListenerMock.Received);
+
+            trackerCollisionStartedListenerMock.Reset();
+            trackerCollisionChangedListenerMock.Reset();
+            trackerCollisionStoppedListenerMock.Reset();
+
+            notifierCollisionStartedListenerMock.Reset();
+            notifierCollisionChangedListenerMock.Reset();
+            notifierCollisionStoppedListenerMock.Reset();
+
+            trackerContainer.transform.position = Vector3.zero;
+            notifierContainer.transform.position = Vector3.zero;
+
+            yield return yieldInstruction;
+
+            Assert.IsTrue(trackerCollisionStartedListenerMock.Received);
+            Assert.IsTrue(trackerCollisionChangedListenerMock.Received);
+            Assert.IsFalse(trackerCollisionStoppedListenerMock.Received);
+
+            Assert.IsTrue(notifierCollisionStartedListenerMock.Received);
+            Assert.IsTrue(notifierCollisionChangedListenerMock.Received);
+            Assert.IsFalse(notifierCollisionStoppedListenerMock.Received);
+
+            trackerCollisionStartedListenerMock.Reset();
+            trackerCollisionChangedListenerMock.Reset();
+            trackerCollisionStoppedListenerMock.Reset();
+
+            notifierCollisionStartedListenerMock.Reset();
+            notifierCollisionChangedListenerMock.Reset();
+            notifierCollisionStoppedListenerMock.Reset();
+
+            trackerContainer.transform.position = Vector3.forward;
+            notifierContainer.transform.position = Vector3.back;
+
+            yield return yieldInstruction;
+
+            Assert.IsFalse(trackerCollisionStartedListenerMock.Received);
+            Assert.IsFalse(trackerCollisionChangedListenerMock.Received);
+            Assert.IsFalse(trackerCollisionStoppedListenerMock.Received);
+
+            Assert.IsFalse(notifierCollisionStartedListenerMock.Received);
+            Assert.IsFalse(notifierCollisionChangedListenerMock.Received);
+            Assert.IsFalse(notifierCollisionStoppedListenerMock.Received);
+
+            Object.DestroyImmediate(trackerContainer);
+            Object.DestroyImmediate(notifierContainer);
+        }
     }
 }


### PR DESCRIPTION
The CollisionTracker now has an enum flag to determine which collision
states to process. Any ignored collision state simply will return early
in the OnCollision/Trigger method related to the state.

This gives the option of forcing any CollisionTracker to never process
a state if it's never required because at the moment it will always
at least run through the process of looking for CollisionNotifiers.