### PR TITLE
fix(Tracking): prevent duplicate active collisions in collection

### DIFF
--- a/Runtime/Tracking/Collision/Active/ActiveCollisionsContainer.cs
+++ b/Runtime/Tracking/Collision/Active/ActiveCollisionsContainer.cs
@@ -117,7 +117,7 @@
         [RequiresBehaviourState]
         public virtual void Add(CollisionNotifier.EventData collisionData)
         {
-            if (!IsValidCollision(collisionData))
+            if (Elements.Contains(collisionData) || !IsValidCollision(collisionData))
             {
                 return;
             }

--- a/Tests/Editor/Tracking/Collision/Active/ActiveCollisionsContainerTest.cs
+++ b/Tests/Editor/Tracking/Collision/Active/ActiveCollisionsContainerTest.cs
@@ -79,6 +79,20 @@ namespace Test.Zinnia.Tracking.Collision.Active
             Assert.IsTrue(contentsChangedMock.Received);
             Assert.IsFalse(allStoppedMock.Received);
 
+            firstStartedMock.Reset();
+            countChangedMock.Reset();
+            contentsChangedMock.Reset();
+            allStoppedMock.Reset();
+
+            subject.Add(twoData);
+
+            Assert.AreEqual(2, subject.Elements.Count);
+
+            Assert.IsFalse(firstStartedMock.Received);
+            Assert.IsFalse(countChangedMock.Received);
+            Assert.IsFalse(contentsChangedMock.Received);
+            Assert.IsFalse(allStoppedMock.Received);
+
             Object.DestroyImmediate(oneContainer);
             Object.DestroyImmediate(twoContainer);
         }


### PR DESCRIPTION
The ActiveCollisionsContainer could have duplicate collisions added
to the container which is incorrect because only 1 collision is really
valid and required. It would also create a leak if the collision was
never removed but due to a Unity bug if the colliding object was
disabled then the collision would not be removed but would be readded
again if the colliding object was enabled again.