### PR TITLE
fix(Collision): stop collisions when either side is disabled - fixes ExtendRealityLtd/VRTK#2005

### DIFF
--- a/Runtime/Tracking/Collision/CollisionTracker.cs
+++ b/Runtime/Tracking/Collision/CollisionTracker.cs
@@ -1,12 +1,58 @@
 ﻿namespace Zinnia.Tracking.Collision
 {
     using UnityEngine;
+    using System.Linq;
+    using System.Collections.Generic;
+    using Malimbe.MemberClearanceMethod;
+    using Malimbe.XmlDocumentationAttribute;
+    using Malimbe.PropertySerializationAttribute;
+    using Zinnia.Data.Attribute;
 
     /// <summary>
     /// Tracks collisions on the <see cref="GameObject"/> this component is on.
     /// </summary>
     public class CollisionTracker : CollisionNotifier
     {
+        /// <summary>
+        /// Causes collisions to stop if the <see cref="GameObject"/> on either side of the collision is disabled.
+        /// </summary>
+        [Serialized]
+        [field: DocumentedByXml, Restricted(RestrictedAttribute.Restrictions.ReadOnlyAtRunTime)]
+        public bool StopCollisionsOnDisable { get; protected set; } = true;
+
+        /// <summary>
+        /// A collection of current existing collisions.
+        /// </summary>
+        protected List<Collider> trackedCollisions = new List<Collider>();
+
+        /// <summary>
+        /// Stops the collision between this <see cref="CollisionTracker"/> and the given <see cref="Collider"/>. If there is still a physical intersection, then the collision will start again in the next physics frame.
+        /// </summary>
+        /// <param name="collider">The collider to stop the collision with.</param>
+        public virtual void StopCollision(Collider collider)
+        {
+            if ((StatesToProcess & CollisionStates.Exit) == 0)
+            {
+                return;
+            }
+
+            RemoveDisabledObserver(collider);
+            OnCollisionStopped(eventData.Set(this, collider.isTrigger, null, collider));
+        }
+
+        protected virtual void OnDisable()
+        {
+            if (!StopCollisionsOnDisable)
+            {
+                return;
+            }
+
+            foreach (Collider collider in trackedCollisions.ToArray())
+            {
+                StopCollision(collider);
+            }
+        }
+
         protected virtual void OnCollisionEnter(Collision collision)
         {
             if ((StatesToProcess & CollisionStates.Enter) == 0)
@@ -14,6 +60,7 @@
                 return;
             }
 
+            AddDisabledObserver(collision.collider);
             OnCollisionStarted(eventData.Set(this, false, collision, collision.collider));
         }
 
@@ -34,6 +81,7 @@
                 return;
             }
 
+            RemoveDisabledObserver(collision.collider);
             OnCollisionStopped(eventData.Set(this, false, collision, collision.collider));
         }
 
@@ -44,6 +92,7 @@
                 return;
             }
 
+            AddDisabledObserver(collider);
             OnCollisionStarted(eventData.Set(this, true, null, collider));
         }
 
@@ -64,7 +113,87 @@
                 return;
             }
 
+            RemoveDisabledObserver(collider);
             OnCollisionStopped(eventData.Set(this, true, null, collider));
+        }
+
+        /// <summary>
+        /// Adds a <see cref="CollisionTrackerDisabledObserver"/> to the <see cref="GameObject"/> that contains the <see cref="Collider"/> causing the collision.
+        /// </summary>
+        /// <param name="target">The target to add the <see cref="CollisionTrackerDisabledObserver"/> component to.</param>
+        protected virtual void AddDisabledObserver(Collider target)
+        {
+            if (target == null || !StopCollisionsOnDisable)
+            {
+                return;
+            }
+
+            trackedCollisions.Add(target);
+            CollisionTrackerDisabledObserver observer = target.gameObject.AddComponent<CollisionTrackerDisabledObserver>();
+            observer.Source = this;
+            observer.Target = target;
+        }
+
+        /// <summary>
+        /// Removes the <see cref="CollisionTrackerDisabledObserver"/> from the <see cref="GameObject"/> that contains the <see cref="Collider"/> ceasing the collision.
+        /// </summary>
+        /// <param name="target">The target to remove the <see cref="CollisionTrackerDisabledObserver"/> component from.</param>
+        protected virtual void RemoveDisabledObserver(Collider target)
+        {
+            if (target == null || !StopCollisionsOnDisable)
+            {
+                return;
+            }
+
+            foreach (CollisionTrackerDisabledObserver observer in target.gameObject.GetComponents<CollisionTrackerDisabledObserver>())
+            {
+                if (observer.Source == this && observer.Target == target)
+                {
+                    observer.Destroy();
+                    trackedCollisions.Remove(target);
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Observes the disabled state of any <see cref="GameObject"/> that the <see cref="CollisionTracker"/> is currently colliding with.
+    /// </summary>
+    public class CollisionTrackerDisabledObserver : MonoBehaviour
+    {
+        /// <summary>
+        /// The <see cref="CollisionTracker"/> that is causing the collision.
+        /// </summary>
+        [Serialized, Cleared]
+        [field: DocumentedByXml]
+        public CollisionTracker Source { get; set; }
+        /// <summary>
+        /// The <see cref="Collider"/> that is being collided with.
+        /// </summary>
+        [Serialized, Cleared]
+        [field: DocumentedByXml]
+        public Collider Target { get; set; }
+
+        /// <summary>
+        /// Whether <see cref="this"/> is being destroyed.
+        /// </summary>
+        protected bool isDestroyed;
+
+        /// <summary>
+        /// Destroys <see cref="this"/> from the scene.
+        /// </summary>
+        public virtual void Destroy()
+        {
+            isDestroyed = true;
+            Destroy(this);
+        }
+
+        protected virtual void OnDisable()
+        {
+            if (!isDestroyed)
+            {
+                Source.StopCollision(Target);
+            }
         }
     }
 }

--- a/Tests/Editor/Tracking/Collision/CollisionTrackerTest.cs
+++ b/Tests/Editor/Tracking/Collision/CollisionTrackerTest.cs
@@ -357,5 +357,359 @@ namespace Test.Zinnia.Tracking.Collision
             Object.DestroyImmediate(trackerContainer);
             Object.DestroyImmediate(notifierContainer);
         }
+
+        [UnityTest]
+        public IEnumerator CollisionEndsOnNotifierGameObjectDisable()
+        {
+            WaitForFixedUpdate yieldInstruction = new WaitForFixedUpdate();
+
+            GameObject trackerContainer = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            trackerContainer.GetComponent<Collider>().isTrigger = true;
+            trackerContainer.AddComponent<Rigidbody>().isKinematic = true;
+            trackerContainer.transform.position = Vector3.forward;
+            CollisionTracker tracker = trackerContainer.AddComponent<CollisionTracker>();
+
+            GameObject notifierContainer = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            notifierContainer.GetComponent<Collider>().isTrigger = true;
+            notifierContainer.AddComponent<Rigidbody>().isKinematic = true;
+            notifierContainer.transform.position = Vector3.back;
+            CollisionNotifier notifier = notifierContainer.AddComponent<CollisionNotifier>();
+
+            UnityEventListenerMock trackerCollisionStartedListenerMock = new UnityEventListenerMock();
+            UnityEventListenerMock trackerCollisionChangedListenerMock = new UnityEventListenerMock();
+            UnityEventListenerMock trackerCollisionStoppedListenerMock = new UnityEventListenerMock();
+            tracker.CollisionStarted.AddListener(trackerCollisionStartedListenerMock.Listen);
+            tracker.CollisionChanged.AddListener(trackerCollisionChangedListenerMock.Listen);
+            tracker.CollisionStopped.AddListener(trackerCollisionStoppedListenerMock.Listen);
+
+            UnityEventListenerMock notifierCollisionStartedListenerMock = new UnityEventListenerMock();
+            UnityEventListenerMock notifierCollisionChangedListenerMock = new UnityEventListenerMock();
+            UnityEventListenerMock notifierCollisionStoppedListenerMock = new UnityEventListenerMock();
+            notifier.CollisionStarted.AddListener(notifierCollisionStartedListenerMock.Listen);
+            notifier.CollisionChanged.AddListener(notifierCollisionChangedListenerMock.Listen);
+            notifier.CollisionStopped.AddListener(notifierCollisionStoppedListenerMock.Listen);
+
+            yield return yieldInstruction;
+
+            Assert.IsFalse(trackerCollisionStartedListenerMock.Received);
+            Assert.IsFalse(trackerCollisionChangedListenerMock.Received);
+            Assert.IsFalse(trackerCollisionStoppedListenerMock.Received);
+
+            Assert.IsFalse(notifierCollisionStartedListenerMock.Received);
+            Assert.IsFalse(notifierCollisionChangedListenerMock.Received);
+            Assert.IsFalse(notifierCollisionStoppedListenerMock.Received);
+
+            trackerCollisionStartedListenerMock.Reset();
+            trackerCollisionChangedListenerMock.Reset();
+            trackerCollisionStoppedListenerMock.Reset();
+
+            notifierCollisionStartedListenerMock.Reset();
+            notifierCollisionChangedListenerMock.Reset();
+            notifierCollisionStoppedListenerMock.Reset();
+
+            trackerContainer.transform.position = Vector3.zero;
+            notifierContainer.transform.position = Vector3.zero;
+
+            yield return yieldInstruction;
+
+            Assert.IsTrue(trackerCollisionStartedListenerMock.Received);
+            Assert.IsTrue(trackerCollisionChangedListenerMock.Received);
+            Assert.IsFalse(trackerCollisionStoppedListenerMock.Received);
+
+            Assert.IsTrue(notifierCollisionStartedListenerMock.Received);
+            Assert.IsTrue(notifierCollisionChangedListenerMock.Received);
+            Assert.IsFalse(notifierCollisionStoppedListenerMock.Received);
+
+            trackerCollisionStartedListenerMock.Reset();
+            trackerCollisionChangedListenerMock.Reset();
+            trackerCollisionStoppedListenerMock.Reset();
+
+            notifierCollisionStartedListenerMock.Reset();
+            notifierCollisionChangedListenerMock.Reset();
+            notifierCollisionStoppedListenerMock.Reset();
+
+            notifierContainer.SetActive(false);
+
+            yield return yieldInstruction;
+
+            Assert.IsFalse(trackerCollisionStartedListenerMock.Received);
+            Assert.IsFalse(trackerCollisionChangedListenerMock.Received);
+            Assert.IsTrue(trackerCollisionStoppedListenerMock.Received);
+
+            Assert.IsFalse(notifierCollisionStartedListenerMock.Received);
+            Assert.IsFalse(notifierCollisionChangedListenerMock.Received);
+            Assert.IsTrue(notifierCollisionStoppedListenerMock.Received);
+
+            Object.DestroyImmediate(trackerContainer);
+            Object.DestroyImmediate(notifierContainer);
+        }
+
+        [UnityTest]
+        public IEnumerator CollisionEndsOnTrackerGameObjectDisable()
+        {
+            WaitForFixedUpdate yieldInstruction = new WaitForFixedUpdate();
+
+            GameObject trackerContainer = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            trackerContainer.GetComponent<Collider>().isTrigger = true;
+            trackerContainer.AddComponent<Rigidbody>().isKinematic = true;
+            trackerContainer.transform.position = Vector3.forward;
+            CollisionTracker tracker = trackerContainer.AddComponent<CollisionTracker>();
+
+            GameObject notifierContainer = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            notifierContainer.GetComponent<Collider>().isTrigger = true;
+            notifierContainer.AddComponent<Rigidbody>().isKinematic = true;
+            notifierContainer.transform.position = Vector3.back;
+            CollisionNotifier notifier = notifierContainer.AddComponent<CollisionNotifier>();
+
+            UnityEventListenerMock trackerCollisionStartedListenerMock = new UnityEventListenerMock();
+            UnityEventListenerMock trackerCollisionChangedListenerMock = new UnityEventListenerMock();
+            UnityEventListenerMock trackerCollisionStoppedListenerMock = new UnityEventListenerMock();
+            tracker.CollisionStarted.AddListener(trackerCollisionStartedListenerMock.Listen);
+            tracker.CollisionChanged.AddListener(trackerCollisionChangedListenerMock.Listen);
+            tracker.CollisionStopped.AddListener(trackerCollisionStoppedListenerMock.Listen);
+
+            UnityEventListenerMock notifierCollisionStartedListenerMock = new UnityEventListenerMock();
+            UnityEventListenerMock notifierCollisionChangedListenerMock = new UnityEventListenerMock();
+            UnityEventListenerMock notifierCollisionStoppedListenerMock = new UnityEventListenerMock();
+            notifier.CollisionStarted.AddListener(notifierCollisionStartedListenerMock.Listen);
+            notifier.CollisionChanged.AddListener(notifierCollisionChangedListenerMock.Listen);
+            notifier.CollisionStopped.AddListener(notifierCollisionStoppedListenerMock.Listen);
+
+            yield return yieldInstruction;
+
+            Assert.IsFalse(trackerCollisionStartedListenerMock.Received);
+            Assert.IsFalse(trackerCollisionChangedListenerMock.Received);
+            Assert.IsFalse(trackerCollisionStoppedListenerMock.Received);
+
+            Assert.IsFalse(notifierCollisionStartedListenerMock.Received);
+            Assert.IsFalse(notifierCollisionChangedListenerMock.Received);
+            Assert.IsFalse(notifierCollisionStoppedListenerMock.Received);
+
+            trackerCollisionStartedListenerMock.Reset();
+            trackerCollisionChangedListenerMock.Reset();
+            trackerCollisionStoppedListenerMock.Reset();
+
+            notifierCollisionStartedListenerMock.Reset();
+            notifierCollisionChangedListenerMock.Reset();
+            notifierCollisionStoppedListenerMock.Reset();
+
+            trackerContainer.transform.position = Vector3.zero;
+            notifierContainer.transform.position = Vector3.zero;
+
+            yield return yieldInstruction;
+
+            Assert.IsTrue(trackerCollisionStartedListenerMock.Received);
+            Assert.IsTrue(trackerCollisionChangedListenerMock.Received);
+            Assert.IsFalse(trackerCollisionStoppedListenerMock.Received);
+
+            Assert.IsTrue(notifierCollisionStartedListenerMock.Received);
+            Assert.IsTrue(notifierCollisionChangedListenerMock.Received);
+            Assert.IsFalse(notifierCollisionStoppedListenerMock.Received);
+
+            trackerCollisionStartedListenerMock.Reset();
+            trackerCollisionChangedListenerMock.Reset();
+            trackerCollisionStoppedListenerMock.Reset();
+
+            notifierCollisionStartedListenerMock.Reset();
+            notifierCollisionChangedListenerMock.Reset();
+            notifierCollisionStoppedListenerMock.Reset();
+
+            trackerContainer.SetActive(false);
+
+            yield return yieldInstruction;
+
+            Assert.IsFalse(trackerCollisionStartedListenerMock.Received);
+            Assert.IsFalse(trackerCollisionChangedListenerMock.Received);
+            Assert.IsTrue(trackerCollisionStoppedListenerMock.Received);
+
+            Assert.IsFalse(notifierCollisionStartedListenerMock.Received);
+            Assert.IsFalse(notifierCollisionChangedListenerMock.Received);
+            Assert.IsTrue(notifierCollisionStoppedListenerMock.Received);
+
+            Object.DestroyImmediate(trackerContainer);
+            Object.DestroyImmediate(notifierContainer);
+        }
+
+        [UnityTest]
+        public IEnumerator CollisionDoesNotEndOnNotifierGameObjectDisable()
+        {
+            WaitForFixedUpdate yieldInstruction = new WaitForFixedUpdate();
+
+            GameObject trackerContainer = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            trackerContainer.GetComponent<Collider>().isTrigger = true;
+            trackerContainer.AddComponent<Rigidbody>().isKinematic = true;
+            trackerContainer.transform.position = Vector3.forward;
+            CollisionTrackerMock tracker = trackerContainer.AddComponent<CollisionTrackerMock>();
+            tracker.SetStopCollisionsOnDisable(false);
+
+            GameObject notifierContainer = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            notifierContainer.GetComponent<Collider>().isTrigger = true;
+            notifierContainer.AddComponent<Rigidbody>().isKinematic = true;
+            notifierContainer.transform.position = Vector3.back;
+            CollisionNotifier notifier = notifierContainer.AddComponent<CollisionNotifier>();
+
+            UnityEventListenerMock trackerCollisionStartedListenerMock = new UnityEventListenerMock();
+            UnityEventListenerMock trackerCollisionChangedListenerMock = new UnityEventListenerMock();
+            UnityEventListenerMock trackerCollisionStoppedListenerMock = new UnityEventListenerMock();
+            tracker.CollisionStarted.AddListener(trackerCollisionStartedListenerMock.Listen);
+            tracker.CollisionChanged.AddListener(trackerCollisionChangedListenerMock.Listen);
+            tracker.CollisionStopped.AddListener(trackerCollisionStoppedListenerMock.Listen);
+
+            UnityEventListenerMock notifierCollisionStartedListenerMock = new UnityEventListenerMock();
+            UnityEventListenerMock notifierCollisionChangedListenerMock = new UnityEventListenerMock();
+            UnityEventListenerMock notifierCollisionStoppedListenerMock = new UnityEventListenerMock();
+            notifier.CollisionStarted.AddListener(notifierCollisionStartedListenerMock.Listen);
+            notifier.CollisionChanged.AddListener(notifierCollisionChangedListenerMock.Listen);
+            notifier.CollisionStopped.AddListener(notifierCollisionStoppedListenerMock.Listen);
+
+            yield return yieldInstruction;
+
+            Assert.IsFalse(trackerCollisionStartedListenerMock.Received);
+            Assert.IsFalse(trackerCollisionChangedListenerMock.Received);
+            Assert.IsFalse(trackerCollisionStoppedListenerMock.Received);
+
+            Assert.IsFalse(notifierCollisionStartedListenerMock.Received);
+            Assert.IsFalse(notifierCollisionChangedListenerMock.Received);
+            Assert.IsFalse(notifierCollisionStoppedListenerMock.Received);
+
+            trackerCollisionStartedListenerMock.Reset();
+            trackerCollisionChangedListenerMock.Reset();
+            trackerCollisionStoppedListenerMock.Reset();
+
+            notifierCollisionStartedListenerMock.Reset();
+            notifierCollisionChangedListenerMock.Reset();
+            notifierCollisionStoppedListenerMock.Reset();
+
+            trackerContainer.transform.position = Vector3.zero;
+            notifierContainer.transform.position = Vector3.zero;
+
+            yield return yieldInstruction;
+
+            Assert.IsTrue(trackerCollisionStartedListenerMock.Received);
+            Assert.IsTrue(trackerCollisionChangedListenerMock.Received);
+            Assert.IsFalse(trackerCollisionStoppedListenerMock.Received);
+
+            Assert.IsTrue(notifierCollisionStartedListenerMock.Received);
+            Assert.IsTrue(notifierCollisionChangedListenerMock.Received);
+            Assert.IsFalse(notifierCollisionStoppedListenerMock.Received);
+
+            trackerCollisionStartedListenerMock.Reset();
+            trackerCollisionChangedListenerMock.Reset();
+            trackerCollisionStoppedListenerMock.Reset();
+
+            notifierCollisionStartedListenerMock.Reset();
+            notifierCollisionChangedListenerMock.Reset();
+            notifierCollisionStoppedListenerMock.Reset();
+
+            notifierContainer.SetActive(false);
+
+            yield return yieldInstruction;
+
+            Assert.IsFalse(trackerCollisionStartedListenerMock.Received);
+            Assert.IsFalse(trackerCollisionChangedListenerMock.Received);
+            Assert.IsFalse(trackerCollisionStoppedListenerMock.Received);
+
+            Assert.IsFalse(notifierCollisionStartedListenerMock.Received);
+            Assert.IsFalse(notifierCollisionChangedListenerMock.Received);
+            Assert.IsFalse(notifierCollisionStoppedListenerMock.Received);
+
+            Object.DestroyImmediate(trackerContainer);
+            Object.DestroyImmediate(notifierContainer);
+        }
+
+        [UnityTest]
+        public IEnumerator CollisionDoesNotEndOnTrackerGameObjectDisable()
+        {
+            WaitForFixedUpdate yieldInstruction = new WaitForFixedUpdate();
+
+            GameObject trackerContainer = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            trackerContainer.GetComponent<Collider>().isTrigger = true;
+            trackerContainer.AddComponent<Rigidbody>().isKinematic = true;
+            trackerContainer.transform.position = Vector3.forward;
+            CollisionTrackerMock tracker = trackerContainer.AddComponent<CollisionTrackerMock>();
+            tracker.SetStopCollisionsOnDisable(false);
+
+            GameObject notifierContainer = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            notifierContainer.GetComponent<Collider>().isTrigger = true;
+            notifierContainer.AddComponent<Rigidbody>().isKinematic = true;
+            notifierContainer.transform.position = Vector3.back;
+            CollisionNotifier notifier = notifierContainer.AddComponent<CollisionNotifier>();
+
+            UnityEventListenerMock trackerCollisionStartedListenerMock = new UnityEventListenerMock();
+            UnityEventListenerMock trackerCollisionChangedListenerMock = new UnityEventListenerMock();
+            UnityEventListenerMock trackerCollisionStoppedListenerMock = new UnityEventListenerMock();
+            tracker.CollisionStarted.AddListener(trackerCollisionStartedListenerMock.Listen);
+            tracker.CollisionChanged.AddListener(trackerCollisionChangedListenerMock.Listen);
+            tracker.CollisionStopped.AddListener(trackerCollisionStoppedListenerMock.Listen);
+
+            UnityEventListenerMock notifierCollisionStartedListenerMock = new UnityEventListenerMock();
+            UnityEventListenerMock notifierCollisionChangedListenerMock = new UnityEventListenerMock();
+            UnityEventListenerMock notifierCollisionStoppedListenerMock = new UnityEventListenerMock();
+            notifier.CollisionStarted.AddListener(notifierCollisionStartedListenerMock.Listen);
+            notifier.CollisionChanged.AddListener(notifierCollisionChangedListenerMock.Listen);
+            notifier.CollisionStopped.AddListener(notifierCollisionStoppedListenerMock.Listen);
+
+            yield return yieldInstruction;
+
+            Assert.IsFalse(trackerCollisionStartedListenerMock.Received);
+            Assert.IsFalse(trackerCollisionChangedListenerMock.Received);
+            Assert.IsFalse(trackerCollisionStoppedListenerMock.Received);
+
+            Assert.IsFalse(notifierCollisionStartedListenerMock.Received);
+            Assert.IsFalse(notifierCollisionChangedListenerMock.Received);
+            Assert.IsFalse(notifierCollisionStoppedListenerMock.Received);
+
+            trackerCollisionStartedListenerMock.Reset();
+            trackerCollisionChangedListenerMock.Reset();
+            trackerCollisionStoppedListenerMock.Reset();
+
+            notifierCollisionStartedListenerMock.Reset();
+            notifierCollisionChangedListenerMock.Reset();
+            notifierCollisionStoppedListenerMock.Reset();
+
+            trackerContainer.transform.position = Vector3.zero;
+            notifierContainer.transform.position = Vector3.zero;
+
+            yield return yieldInstruction;
+
+            Assert.IsTrue(trackerCollisionStartedListenerMock.Received);
+            Assert.IsTrue(trackerCollisionChangedListenerMock.Received);
+            Assert.IsFalse(trackerCollisionStoppedListenerMock.Received);
+
+            Assert.IsTrue(notifierCollisionStartedListenerMock.Received);
+            Assert.IsTrue(notifierCollisionChangedListenerMock.Received);
+            Assert.IsFalse(notifierCollisionStoppedListenerMock.Received);
+
+            trackerCollisionStartedListenerMock.Reset();
+            trackerCollisionChangedListenerMock.Reset();
+            trackerCollisionStoppedListenerMock.Reset();
+
+            notifierCollisionStartedListenerMock.Reset();
+            notifierCollisionChangedListenerMock.Reset();
+            notifierCollisionStoppedListenerMock.Reset();
+
+            trackerContainer.SetActive(false);
+
+            yield return yieldInstruction;
+
+            Assert.IsFalse(trackerCollisionStartedListenerMock.Received);
+            Assert.IsFalse(trackerCollisionChangedListenerMock.Received);
+            Assert.IsFalse(trackerCollisionStoppedListenerMock.Received);
+
+            Assert.IsFalse(notifierCollisionStartedListenerMock.Received);
+            Assert.IsFalse(notifierCollisionChangedListenerMock.Received);
+            Assert.IsFalse(notifierCollisionStoppedListenerMock.Received);
+
+            Object.DestroyImmediate(trackerContainer);
+            Object.DestroyImmediate(notifierContainer);
+        }
+
+        public class CollisionTrackerMock : CollisionTracker
+        {
+            public virtual void SetStopCollisionsOnDisable(bool state)
+            {
+                StopCollisionsOnDisable = state;
+            }
+        }
     }
 }


### PR DESCRIPTION
There is an issue in Unity where when two objects are colliding will
create a collision started event, but whilst the objects are
intersecting, if one of the objects is disabled then Unity does not
consider this to stop the collision between the two objects so no
OnCollisionExit or OnTriggerExit occurs. However, if the disabled
object is re-enabled and is still in the same intersecting position
then Unity will consider this a new Enter event.

This causes a problem for the CollisionTracker as it means the state
of the tracker can become out of sync. If a collision starts twice
but no stop was called between, then the tracked collision state is
not valid. This would then have knock on effects in usages such as
the ActiveCollisionsContainer where a started collision is treated
as an active collision, but then if the object is disabled then
no stopped collision occurs and therefore that would still be
considered as an active collision.

To fix this issue and work around the shortcomings of Unity, a new
component is added at runtime to the GameObject that contains the
collider that is colliding with the CollisionTracker. This new
component then monitors the disabled state of the GameObject and upon
that GameObject becoming disabled will stop the collision manually
on the linked CollisionTracker. It will also then remove any traces
of the magically created component.

The CollisionTracker now also tracks any colliders it may be
intersecting with and therefore if the CollisionTracker is disabled
then any collider it may be linked to also has the Collision Stopped
event emitted for to ensure both sides of the collision adhere to the
disabled state.

This new functionality is optional and can be turned off by the `Stop
Collisions On Disable` property, which can only be set at edit time to
prevent fundamental state getting out of sync if it was changed at
runtime.

The `AddComponent` and `Destroy` are used over a pooling method because
these only occur on the `Enter/Exit` events so are not firing all the
time and therefore performance hits should be reduced. But also,
pooling would create a large set of GameObjects for each
CollisionTracker and they would all have to independently manage these
pools themselves resulting in a potential large number of pooled
GameObjects being created on scene start, which would have a potential
much larger impact on initial performance.

The tests have been updated to showcase the issue of disabling a
GameObject on either side of the collision now can successfully result
in the Stopped event being emitted.