### PR TITLE
fix(Collision): perform equality check on collider and forward source

### DIFF
--- a/Runtime/Tracking/Collision/CollisionNotifier.cs
+++ b/Runtime/Tracking/Collision/CollisionNotifier.cs
@@ -80,7 +80,7 @@
                     return true;
                 }
 
-                return Equals(ColliderData.GetContainingTransform(), other.ColliderData.GetContainingTransform()) && ((ForwardSource == null && other.ForwardSource == null) || Equals(ForwardSource, other.ForwardSource));
+                return Equals(ForwardSource, other.ForwardSource) && Equals(ColliderData, other.ColliderData);
             }
 
             /// <inheritdoc />
@@ -96,18 +96,13 @@
                     return true;
                 }
 
-                if (obj.GetType() != GetType())
-                {
-                    return false;
-                }
-
-                return Equals((EventData)obj);
+                return obj is EventData other && Equals(other);
             }
 
             /// <inheritdoc />
             public override int GetHashCode()
             {
-                return ColliderData.GetContainingTransform().GetHashCode();
+                return ((ForwardSource != null ? ForwardSource.GetHashCode() : 0) * 397) ^ (ColliderData != null ? ColliderData.GetHashCode() : 0);
             }
 
             public static bool operator ==(EventData left, EventData right) => Equals(left, right);


### PR DESCRIPTION
The CollisionNotifier.EventData was performing the equality check on
the ForwardSource of the collision and the containing Transform of
the collider being intersected. This actually can report invalid
equality data as two compound colliders being touched by the same
ForwardSource would report as being the same Collision Data which
they're actually not.

The fix is to just do the equality check directly on the Collider and
the ForwardSource.

The HashCode of the EventData should also be a combination of the
two equality checked objects to ensure its uniqueness.