### PR TITLE
fix(Extraction): simulate raycast for surface data ray

### DIFF
--- a/Tests/Editor/Data/Operation/Extraction/SurfaceDataCollisionPointExtractorTest.cs
+++ b/Tests/Editor/Data/Operation/Extraction/SurfaceDataCollisionPointExtractorTest.cs
@@ -138,7 +138,10 @@ namespace Test.Zinnia.Data.Operation.Extraction
         {
             blocker = GameObject.CreatePrimitive(PrimitiveType.Cube);
             blocker.transform.position = Vector3.forward * 2f;
+            Physics.autoSimulation = false;
+            Physics.Simulate(Time.fixedDeltaTime);
             Physics.Raycast(Vector3.zero, Vector3.forward, out RaycastHit hitData);
+            Physics.autoSimulation = true;
             return hitData;
         }
     }


### PR DESCRIPTION
The SurfaceDataCollisionPointExtractor test was failing because it used
a RayCast to fill the HitData properties to allow the process to
continue, however an Editor test won't actually do the RayCast in newer
versions of Unity unless the physics is manually simulated or
[UnityTest] is used. For the sake of what this test is actually doing,
it's easier to just manually process the physics simulation.