### PR TITLE
fix(Tests): use UnityEngine.Assertions.Assert in equality checking

### DIFF
--- a/Tests/Editor/Action/ActionRegistrarTest.cs
+++ b/Tests/Editor/Action/ActionRegistrarTest.cs
@@ -8,6 +8,7 @@ namespace Test.Zinnia.Action
     using System.Collections;
     using NUnit.Framework;
     using UnityEngine.TestTools;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class ActionRegistrarTest
     {

--- a/Tests/Editor/Action/AllActionTest.cs
+++ b/Tests/Editor/Action/AllActionTest.cs
@@ -8,6 +8,7 @@ namespace Test.Zinnia.Action
     using System.Collections;
     using NUnit.Framework;
     using Test.Zinnia.Utility.Mock;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class AllActionTest
     {

--- a/Tests/Editor/Action/AnyActionTest.cs
+++ b/Tests/Editor/Action/AnyActionTest.cs
@@ -8,6 +8,7 @@ namespace Test.Zinnia.Action
     using System.Collections;
     using NUnit.Framework;
     using Test.Zinnia.Utility.Mock;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class AnyActionTest
     {

--- a/Tests/Editor/Action/BooleanActionTest.cs
+++ b/Tests/Editor/Action/BooleanActionTest.cs
@@ -5,6 +5,7 @@ namespace Test.Zinnia.Action
     using UnityEngine;
     using NUnit.Framework;
     using Test.Zinnia.Utility.Mock;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class BooleanActionTest
     {

--- a/Tests/Editor/Action/Collection/ActionRegistrarSourceObservableListTest.cs
+++ b/Tests/Editor/Action/Collection/ActionRegistrarSourceObservableListTest.cs
@@ -7,6 +7,7 @@ namespace Test.Zinnia.Action.Collection
     using UnityEngine.TestTools;
     using System.Collections;
     using NUnit.Framework;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class ActionRegistrarSourceObservableListTest
     {

--- a/Tests/Editor/Action/FloatActionTest.cs
+++ b/Tests/Editor/Action/FloatActionTest.cs
@@ -5,6 +5,7 @@ namespace Test.Zinnia.Action
     using UnityEngine;
     using NUnit.Framework;
     using Test.Zinnia.Utility.Mock;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class FloatActionTest
     {

--- a/Tests/Editor/Action/StateEmitterTest.cs
+++ b/Tests/Editor/Action/StateEmitterTest.cs
@@ -5,6 +5,7 @@ namespace Test.Zinnia.Action
     using UnityEngine;
     using NUnit.Framework;
     using Test.Zinnia.Utility.Mock;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class StateEmitterTest
     {

--- a/Tests/Editor/Action/SurfaceChangeActionTest.cs
+++ b/Tests/Editor/Action/SurfaceChangeActionTest.cs
@@ -6,6 +6,7 @@ namespace Test.Zinnia.Action
     using UnityEngine;
     using NUnit.Framework;
     using Test.Zinnia.Utility.Mock;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class SurfaceChangeActionTest
     {

--- a/Tests/Editor/Action/ToggleActionTest.cs
+++ b/Tests/Editor/Action/ToggleActionTest.cs
@@ -5,6 +5,7 @@ namespace Test.Zinnia.Action
     using UnityEngine;
     using NUnit.Framework;
     using Test.Zinnia.Utility.Mock;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class ToggleActionTest
     {

--- a/Tests/Editor/Action/Vector2ActionTest.cs
+++ b/Tests/Editor/Action/Vector2ActionTest.cs
@@ -5,6 +5,7 @@ namespace Test.Zinnia.Action
     using UnityEngine;
     using NUnit.Framework;
     using Test.Zinnia.Utility.Mock;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class Vector2ActionTest
     {

--- a/Tests/Editor/Association/GameObjectsAssociationActivatorTest.cs
+++ b/Tests/Editor/Association/GameObjectsAssociationActivatorTest.cs
@@ -8,6 +8,7 @@ namespace Test.Zinnia.Association
     using UnityEngine.TestTools;
     using NUnit.Framework;
     using System.Text.RegularExpressions;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class GameObjectsAssociationActivatorTest
     {

--- a/Tests/Editor/Cast/FixedLineCastTest.cs
+++ b/Tests/Editor/Cast/FixedLineCastTest.cs
@@ -5,6 +5,7 @@ namespace Test.Zinnia.Cast
     using UnityEngine;
     using NUnit.Framework;
     using Test.Zinnia.Utility.Mock;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class FixedLineCastTest
     {

--- a/Tests/Editor/Cast/ParabolicLineCastTest.cs
+++ b/Tests/Editor/Cast/ParabolicLineCastTest.cs
@@ -10,6 +10,7 @@ namespace Test.Zinnia.Cast
     using NUnit.Framework;
     using Test.Zinnia.Utility.Mock;
     using Test.Zinnia.Utility.Stub;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class ParabolicLineCastTest
     {
@@ -97,7 +98,7 @@ namespace Test.Zinnia.Cast
                 Assert.AreEqual(expectedPoints[index].ToString(), subject.Points[index].ToString(), "Index " + index);
             }
 
-            Assert.IsNull(subject.TargetHit);
+            Assert.IsFalse(subject.TargetHit.HasValue);
             Assert.IsTrue(castResultsChangedMock.Received);
         }
 
@@ -130,7 +131,7 @@ namespace Test.Zinnia.Cast
                 Assert.AreEqual(expectedPoints[index].ToString(), subject.Points[index].ToString(), "Index " + index);
             }
 
-            Assert.IsNull(subject.TargetHit);
+            Assert.IsFalse(subject.TargetHit.HasValue);
             Assert.IsTrue(castResultsChangedMock.Received);
         }
 
@@ -201,7 +202,7 @@ namespace Test.Zinnia.Cast
             subject.Process();
 
             Assert.AreEqual(0, subject.Points.Count);
-            Assert.IsNull(subject.TargetHit);
+            Assert.IsFalse(subject.TargetHit.HasValue);
             Assert.IsFalse(castResultsChangedMock.Received);
         }
 
@@ -222,7 +223,7 @@ namespace Test.Zinnia.Cast
             subject.Process();
 
             Assert.AreEqual(0, subject.Points.Count);
-            Assert.IsNull(subject.TargetHit);
+            Assert.IsFalse(subject.TargetHit.HasValue);
             Assert.IsFalse(castResultsChangedMock.Received);
         }
     }

--- a/Tests/Editor/Cast/StraightLineCastTest.cs
+++ b/Tests/Editor/Cast/StraightLineCastTest.cs
@@ -10,6 +10,7 @@ namespace Test.Zinnia.Cast
     using NUnit.Framework;
     using Test.Zinnia.Utility.Mock;
     using Test.Zinnia.Utility.Stub;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class StraightLineCastTest
     {
@@ -76,7 +77,7 @@ namespace Test.Zinnia.Cast
 
             Assert.AreEqual(expectedStart, subject.Points[0]);
             Assert.AreEqual(expectedEnd, subject.Points[1]);
-            Assert.IsNull(subject.TargetHit);
+            Assert.IsFalse(subject.TargetHit.HasValue);
             Assert.IsTrue(castResultsChangedMock.Received);
         }
 
@@ -135,7 +136,7 @@ namespace Test.Zinnia.Cast
             subject.Process();
 
             Assert.AreEqual(0, subject.Points.Count);
-            Assert.IsNull(subject.TargetHit);
+            Assert.IsFalse(subject.TargetHit.HasValue);
             Assert.IsFalse(castResultsChangedMock.Received);
         }
 
@@ -155,7 +156,7 @@ namespace Test.Zinnia.Cast
             subject.Process();
 
             Assert.AreEqual(0, subject.Points.Count);
-            Assert.IsNull(subject.TargetHit);
+            Assert.IsFalse(subject.TargetHit.HasValue);
             Assert.IsFalse(castResultsChangedMock.Received);
         }
     }

--- a/Tests/Editor/Data/Collection/Counter/GameObjectObservableCounterTest.cs
+++ b/Tests/Editor/Data/Collection/Counter/GameObjectObservableCounterTest.cs
@@ -5,6 +5,7 @@ namespace Test.Zinnia.Data.Collection.Counter
     using UnityEngine;
     using NUnit.Framework;
     using Test.Zinnia.Utility.Mock;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class GameObjectObservableCounterTest
     {

--- a/Tests/Editor/Data/Collection/GameObjectRelationsTest.cs
+++ b/Tests/Editor/Data/Collection/GameObjectRelationsTest.cs
@@ -6,6 +6,7 @@ namespace Test.Zinnia.Data.Collection
     using UnityEngine;
     using NUnit.Framework;
     using Test.Zinnia.Utility.Mock;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class GameObjectRelationsTest
     {

--- a/Tests/Editor/Data/Collection/List/GameObjectObservableListTest.cs
+++ b/Tests/Editor/Data/Collection/List/GameObjectObservableListTest.cs
@@ -5,6 +5,7 @@ namespace Test.Zinnia.Data.Collection.List
     using UnityEngine;
     using NUnit.Framework;
     using Test.Zinnia.Utility.Mock;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class GameObjectObservableListTest
     {
@@ -127,7 +128,7 @@ namespace Test.Zinnia.Data.Collection.List
             GameObject elementOne = new GameObject();
             GameObject elementTwo = new GameObject();
 
-            Assert.IsEmpty(subject.NonSubscribableElements);
+            Assert.AreEqual(0, subject.NonSubscribableElements.Count);
 
             subject.Add(elementOne);
 
@@ -171,7 +172,7 @@ namespace Test.Zinnia.Data.Collection.List
             GameObject elementOne = new GameObject();
             GameObject elementTwo = new GameObject();
 
-            Assert.IsEmpty(subject.NonSubscribableElements);
+            Assert.AreEqual(0, subject.NonSubscribableElements.Count);
 
             subject.AddUnique(elementOne);
 
@@ -230,7 +231,7 @@ namespace Test.Zinnia.Data.Collection.List
             GameObject elementOne = new GameObject();
             GameObject elementTwo = new GameObject();
 
-            Assert.IsEmpty(subject.NonSubscribableElements);
+            Assert.AreEqual(0, subject.NonSubscribableElements.Count);
 
             subject.InsertAt(elementOne, 0);
 
@@ -356,7 +357,7 @@ namespace Test.Zinnia.Data.Collection.List
             GameObject elementOne = new GameObject();
             GameObject elementTwo = new GameObject();
 
-            Assert.IsEmpty(subject.NonSubscribableElements);
+            Assert.AreEqual(0, subject.NonSubscribableElements.Count);
 
             subject.InsertUniqueAt(elementOne, 0);
 
@@ -417,7 +418,7 @@ namespace Test.Zinnia.Data.Collection.List
             GameObject elementOne = new GameObject();
             GameObject elementTwo = new GameObject();
 
-            Assert.IsEmpty(subject.NonSubscribableElements);
+            Assert.AreEqual(0, subject.NonSubscribableElements.Count);
 
             subject.InsertAtCurrentIndex(elementOne);
 
@@ -462,7 +463,7 @@ namespace Test.Zinnia.Data.Collection.List
             GameObject elementOne = new GameObject();
             GameObject elementTwo = new GameObject();
 
-            Assert.IsEmpty(subject.NonSubscribableElements);
+            Assert.AreEqual(0, subject.NonSubscribableElements.Count);
 
             subject.AddUniqueAtCurrentIndex(elementOne);
 
@@ -553,11 +554,11 @@ namespace Test.Zinnia.Data.Collection.List
 
             GameObject elementOne = new GameObject("One");
 
-            Assert.IsEmpty(subject.NonSubscribableElements);
+            Assert.AreEqual(0, subject.NonSubscribableElements.Count);
 
             subject.SetAt(elementOne, 1);
 
-            Assert.IsEmpty(subject.NonSubscribableElements);
+            Assert.AreEqual(0, subject.NonSubscribableElements.Count);
 
             Assert.IsFalse(addedMock.Received);
             Assert.IsFalse(removedMock.Received);
@@ -575,7 +576,7 @@ namespace Test.Zinnia.Data.Collection.List
 
             GameObject elementOne = new GameObject("One");
 
-            Assert.IsEmpty(subject.NonSubscribableElements);
+            Assert.AreEqual(0, subject.NonSubscribableElements.Count);
 
             subject.SetAtOrAddIfEmpty(elementOne, 1);
 

--- a/Tests/Editor/Data/Collection/Stack/GameObjectObservableStackTest.cs
+++ b/Tests/Editor/Data/Collection/Stack/GameObjectObservableStackTest.cs
@@ -5,6 +5,7 @@ namespace Test.Zinnia.Data.Collection.Stack
     using UnityEngine;
     using NUnit.Framework;
     using Test.Zinnia.Utility.Mock;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class GameObjectEventObservableTest
     {

--- a/Tests/Editor/Data/Operation/Extraction/ComponentGameObjectExtractorTest.cs
+++ b/Tests/Editor/Data/Operation/Extraction/ComponentGameObjectExtractorTest.cs
@@ -5,6 +5,7 @@ namespace Test.Zinnia.Data.Operation.Extraction
     using UnityEngine;
     using NUnit.Framework;
     using Test.Zinnia.Utility.Mock;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class ComponentGameObjectEmitterTest
     {

--- a/Tests/Editor/Data/Operation/Extraction/GameObjectExtractorTest.cs
+++ b/Tests/Editor/Data/Operation/Extraction/GameObjectExtractorTest.cs
@@ -5,6 +5,7 @@ namespace Test.Zinnia.Data.Operation.Extraction
     using UnityEngine;
     using NUnit.Framework;
     using Test.Zinnia.Utility.Mock;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class GameObjectEmitterTest
     {

--- a/Tests/Editor/Data/Operation/Extraction/SurfaceDataCollisionPointExtractorTest.cs
+++ b/Tests/Editor/Data/Operation/Extraction/SurfaceDataCollisionPointExtractorTest.cs
@@ -6,6 +6,7 @@ namespace Test.Zinnia.Data.Operation.Extraction
     using UnityEngine;
     using NUnit.Framework;
     using Test.Zinnia.Utility.Mock;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class SurfaceDataCollisionPointExtractorTest
     {
@@ -37,7 +38,7 @@ namespace Test.Zinnia.Data.Operation.Extraction
             subject.Source = surfaceData;
 
             Assert.IsFalse(extractedMock.Received);
-            Assert.IsNull(subject.Result);
+            Assert.IsFalse(subject.Result.HasValue);
 
             RaycastHit hitData = GetRayCastData();
             hitData.point = Vector3.one;
@@ -58,12 +59,12 @@ namespace Test.Zinnia.Data.Operation.Extraction
             subject.Extracted.AddListener(extractedMock.Listen);
 
             Assert.IsFalse(extractedMock.Received);
-            Assert.IsNull(subject.Result);
+            Assert.IsFalse(subject.Result.HasValue);
 
             subject.Extract();
 
             Assert.IsFalse(extractedMock.Received);
-            Assert.IsNull(subject.Result);
+            Assert.IsFalse(subject.Result.HasValue);
         }
 
         [Test]
@@ -76,12 +77,12 @@ namespace Test.Zinnia.Data.Operation.Extraction
             subject.Source = surfaceData;
 
             Assert.IsFalse(extractedMock.Received);
-            Assert.IsNull(subject.Result);
+            Assert.IsFalse(subject.Result.HasValue);
 
             subject.Extract();
 
             Assert.IsFalse(extractedMock.Received);
-            Assert.IsNull(subject.Result);
+            Assert.IsFalse(subject.Result.HasValue);
         }
 
         [Test]
@@ -95,7 +96,7 @@ namespace Test.Zinnia.Data.Operation.Extraction
             subject.gameObject.SetActive(false);
 
             Assert.IsFalse(extractedMock.Received);
-            Assert.IsNull(subject.Result);
+            Assert.IsFalse(subject.Result.HasValue);
 
             RaycastHit hitData = GetRayCastData();
             hitData.point = Vector3.one;
@@ -104,7 +105,7 @@ namespace Test.Zinnia.Data.Operation.Extraction
             subject.Extract();
 
             Assert.IsFalse(extractedMock.Received);
-            Assert.IsNull(subject.Result);
+            Assert.IsFalse(subject.Result.HasValue);
         }
 
         [Test]
@@ -118,7 +119,7 @@ namespace Test.Zinnia.Data.Operation.Extraction
             subject.enabled = false;
 
             Assert.IsFalse(extractedMock.Received);
-            Assert.IsNull(subject.Result);
+            Assert.IsFalse(subject.Result.HasValue);
 
             RaycastHit hitData = GetRayCastData();
             hitData.point = Vector3.one;
@@ -127,7 +128,7 @@ namespace Test.Zinnia.Data.Operation.Extraction
             subject.Extract();
 
             Assert.IsFalse(extractedMock.Received);
-            Assert.IsNull(subject.Result);
+            Assert.IsFalse(subject.Result.HasValue);
         }
 
         /// <summary>

--- a/Tests/Editor/Data/Operation/Extraction/TransformDataGameObjectExtractorTest.cs
+++ b/Tests/Editor/Data/Operation/Extraction/TransformDataGameObjectExtractorTest.cs
@@ -6,6 +6,7 @@ namespace Test.Zinnia.Data.Operation.Extraction
     using UnityEngine;
     using NUnit.Framework;
     using Test.Zinnia.Utility.Mock;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class TransformDataGameObjectExtractorTest
     {

--- a/Tests/Editor/Data/Operation/Extraction/TransformDirectionExtractorTest.cs
+++ b/Tests/Editor/Data/Operation/Extraction/TransformDirectionExtractorTest.cs
@@ -5,6 +5,7 @@ namespace Test.Zinnia.Data.Operation.Extraction
     using UnityEngine;
     using NUnit.Framework;
     using Test.Zinnia.Utility.Mock;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class TransformDirectionExtractorTest
     {

--- a/Tests/Editor/Data/Operation/Extraction/TransformEulerRotationExtractorTest.cs
+++ b/Tests/Editor/Data/Operation/Extraction/TransformEulerRotationExtractorTest.cs
@@ -5,6 +5,7 @@ namespace Test.Zinnia.Data.Operation.Extraction
     using UnityEngine;
     using NUnit.Framework;
     using Test.Zinnia.Utility.Mock;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class TransformEulerRotationExtractorTest
     {

--- a/Tests/Editor/Data/Operation/Extraction/TransformPositionExtractorTest.cs
+++ b/Tests/Editor/Data/Operation/Extraction/TransformPositionExtractorTest.cs
@@ -5,6 +5,7 @@ namespace Test.Zinnia.Data.Operation.Extraction
     using UnityEngine;
     using NUnit.Framework;
     using Test.Zinnia.Utility.Mock;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class TransformPositionExtractorTest
     {

--- a/Tests/Editor/Data/Operation/Extraction/TransformScaleExtractorTest.cs
+++ b/Tests/Editor/Data/Operation/Extraction/TransformScaleExtractorTest.cs
@@ -5,6 +5,7 @@ namespace Test.Zinnia.Data.Operation.Extraction
     using UnityEngine;
     using NUnit.Framework;
     using Test.Zinnia.Utility.Mock;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class TransformScaleExtractorTest
     {

--- a/Tests/Editor/Data/Operation/Extraction/Vector2ComponentExtractorTest.cs
+++ b/Tests/Editor/Data/Operation/Extraction/Vector2ComponentExtractorTest.cs
@@ -5,6 +5,7 @@ namespace Test.Zinnia.Data.Operation.Extraction
     using UnityEngine;
     using NUnit.Framework;
     using Test.Zinnia.Utility.Mock;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class Vector2ComponentExtractorTest
     {
@@ -63,7 +64,7 @@ namespace Test.Zinnia.Data.Operation.Extraction
 
             float? result = subject.Extract();
 
-            Assert.IsNull(result);
+            Assert.IsFalse(result.HasValue);
             Assert.IsFalse(extractedListenerMock.Received);
 
             extractedListenerMock.Reset();
@@ -73,7 +74,7 @@ namespace Test.Zinnia.Data.Operation.Extraction
 
             result = subject.Extract();
 
-            Assert.IsNull(result);
+            Assert.IsFalse(result.HasValue);
             Assert.IsFalse(extractedListenerMock.Received);
         }
 
@@ -90,7 +91,7 @@ namespace Test.Zinnia.Data.Operation.Extraction
 
             float? result = subject.Extract();
 
-            Assert.IsNull(result);
+            Assert.IsFalse(result.HasValue);
             Assert.IsFalse(extractedListenerMock.Received);
 
             extractedListenerMock.Reset();
@@ -100,7 +101,7 @@ namespace Test.Zinnia.Data.Operation.Extraction
 
             result = subject.Extract();
 
-            Assert.IsNull(result);
+            Assert.IsFalse(result.HasValue);
             Assert.IsFalse(extractedListenerMock.Received);
         }
     }

--- a/Tests/Editor/Data/Operation/GameObjectClonerTest.cs
+++ b/Tests/Editor/Data/Operation/GameObjectClonerTest.cs
@@ -5,6 +5,7 @@ namespace Test.Zinnia.Data.Operation
     using UnityEngine;
     using NUnit.Framework;
     using Test.Zinnia.Utility.Mock;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class GameObjectClonerTest
     {

--- a/Tests/Editor/Data/Operation/Mutation/RigidbodyPropertyMutatorTest.cs
+++ b/Tests/Editor/Data/Operation/Mutation/RigidbodyPropertyMutatorTest.cs
@@ -4,7 +4,7 @@ namespace Test.Zinnia.Data.Operation.Mutation
 {
     using UnityEngine;
     using NUnit.Framework;
-
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class RigidbodyPropertyMutatorTest
     {

--- a/Tests/Editor/Data/Operation/Mutation/TransformEulerRotationMutatorTest.cs
+++ b/Tests/Editor/Data/Operation/Mutation/TransformEulerRotationMutatorTest.cs
@@ -5,6 +5,7 @@ namespace Test.Zinnia.Data.Operation.Mutation
 {
     using UnityEngine;
     using NUnit.Framework;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class TransformEulerRotationMutatorTest
     {
@@ -262,7 +263,7 @@ namespace Test.Zinnia.Data.Operation.Mutation
             GameObject origin = new GameObject();
             subject.Target = target;
 
-            Assert.Throws<System.ArgumentException>(() => subject.Origin = origin);
+            NUnit.Framework.Assert.Throws<System.ArgumentException>(() => subject.Origin = origin);
 
             Object.DestroyImmediate(target);
             Object.DestroyImmediate(origin);

--- a/Tests/Editor/Data/Operation/Mutation/TransformPositionMutatorTest.cs
+++ b/Tests/Editor/Data/Operation/Mutation/TransformPositionMutatorTest.cs
@@ -5,6 +5,7 @@ namespace Test.Zinnia.Data.Operation.Mutation
 {
     using UnityEngine;
     using NUnit.Framework;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class TransformPositionMutatorTest
     {

--- a/Tests/Editor/Data/Operation/Mutation/TransformScaleMutatorTest.cs
+++ b/Tests/Editor/Data/Operation/Mutation/TransformScaleMutatorTest.cs
@@ -5,6 +5,7 @@ namespace Test.Zinnia.Data.Operation.Mutation
 {
     using UnityEngine;
     using NUnit.Framework;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class TransformScaleMutatorTest
     {

--- a/Tests/Editor/Data/Type/FloatRangeTest.cs
+++ b/Tests/Editor/Data/Type/FloatRangeTest.cs
@@ -4,6 +4,7 @@ namespace Test.Zinnia.Data.Type
 {
     using UnityEngine;
     using NUnit.Framework;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class FloatRangeTest
     {

--- a/Tests/Editor/Data/Type/SerializableTypeTest.cs
+++ b/Tests/Editor/Data/Type/SerializableTypeTest.cs
@@ -5,6 +5,7 @@ namespace Test.Zinnia.Data.Type
     using UnityEngine;
     using System;
     using NUnit.Framework;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class SerializableTypeTest
     {

--- a/Tests/Editor/Data/Type/SurfaceDataTest.cs
+++ b/Tests/Editor/Data/Type/SurfaceDataTest.cs
@@ -4,6 +4,7 @@ namespace Test.Zinnia.Data.Type
 {
     using UnityEngine;
     using NUnit.Framework;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class SurfaceDataTest
     {

--- a/Tests/Editor/Data/Type/TransformDataTest.cs
+++ b/Tests/Editor/Data/Type/TransformDataTest.cs
@@ -4,6 +4,7 @@ namespace Test.Zinnia.Data.Type
 {
     using UnityEngine;
     using NUnit.Framework;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class TransformDataTest
     {

--- a/Tests/Editor/Data/Type/Transformation/Aggregation/FloatAdderTest.cs
+++ b/Tests/Editor/Data/Type/Transformation/Aggregation/FloatAdderTest.cs
@@ -6,6 +6,7 @@ namespace Test.Zinnia.Data.Type.Transformation.Aggregation
     using UnityEngine;
     using NUnit.Framework;
     using Test.Zinnia.Utility.Mock;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class FloatAdderTest
     {

--- a/Tests/Editor/Data/Type/Transformation/Aggregation/FloatMultiplierTest.cs
+++ b/Tests/Editor/Data/Type/Transformation/Aggregation/FloatMultiplierTest.cs
@@ -6,6 +6,7 @@ namespace Test.Zinnia.Data.Type.Transformation.Aggregation
     using UnityEngine;
     using NUnit.Framework;
     using Test.Zinnia.Utility.Mock;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class FloatMultiplierTest
     {

--- a/Tests/Editor/Data/Type/Transformation/Aggregation/Vector2MultiplierTest.cs
+++ b/Tests/Editor/Data/Type/Transformation/Aggregation/Vector2MultiplierTest.cs
@@ -6,6 +6,7 @@ namespace Test.Zinnia.Data.Type.Transformation.Aggregation
     using UnityEngine;
     using NUnit.Framework;
     using Test.Zinnia.Utility.Mock;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class Vector2MultiplierTest
     {

--- a/Tests/Editor/Data/Type/Transformation/Aggregation/Vector3MultiplierTest.cs
+++ b/Tests/Editor/Data/Type/Transformation/Aggregation/Vector3MultiplierTest.cs
@@ -6,6 +6,7 @@ namespace Test.Zinnia.Data.Type.Transformation.Aggregation
     using UnityEngine;
     using NUnit.Framework;
     using Test.Zinnia.Utility.Mock;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class Vector3MultiplierTest
     {

--- a/Tests/Editor/Data/Type/Transformation/Aggregation/Vector3SubtractorTest.cs
+++ b/Tests/Editor/Data/Type/Transformation/Aggregation/Vector3SubtractorTest.cs
@@ -6,6 +6,7 @@ namespace Test.Zinnia.Data.Type.Transformation.Aggregation
     using UnityEngine;
     using NUnit.Framework;
     using Test.Zinnia.Utility.Mock;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class Vector3SubtractorTest
     {

--- a/Tests/Editor/Data/Type/Transformation/Conversion/AngleToVector2DirectionTest.cs
+++ b/Tests/Editor/Data/Type/Transformation/Conversion/AngleToVector2DirectionTest.cs
@@ -5,6 +5,7 @@ namespace Test.Zinnia.Data.Type.Transformation.Conversion
     using UnityEngine;
     using NUnit.Framework;
     using Test.Zinnia.Utility.Mock;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class AngleToVector2DirectionTest
     {

--- a/Tests/Editor/Data/Type/Transformation/Conversion/BooleanToFloatTest.cs
+++ b/Tests/Editor/Data/Type/Transformation/Conversion/BooleanToFloatTest.cs
@@ -5,6 +5,7 @@ namespace Test.Zinnia.Data.Type.Transformation.Conversion
     using UnityEngine;
     using NUnit.Framework;
     using Test.Zinnia.Utility.Mock;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class BooleanToFloatTest
     {

--- a/Tests/Editor/Data/Type/Transformation/Conversion/FloatToBooleanTest.cs
+++ b/Tests/Editor/Data/Type/Transformation/Conversion/FloatToBooleanTest.cs
@@ -5,6 +5,7 @@ namespace Test.Zinnia.Data.Type.Transformation.Conversion
     using UnityEngine;
     using NUnit.Framework;
     using Test.Zinnia.Utility.Mock;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class FloatToBooleanTest
     {

--- a/Tests/Editor/Data/Type/Transformation/Conversion/FloatToVector2Test.cs
+++ b/Tests/Editor/Data/Type/Transformation/Conversion/FloatToVector2Test.cs
@@ -5,6 +5,7 @@ namespace Test.Zinnia.Data.Type.Transformation.Conversion
     using UnityEngine;
     using NUnit.Framework;
     using Test.Zinnia.Utility.Mock;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class FloatToVector2Test
     {

--- a/Tests/Editor/Data/Type/Transformation/Conversion/Vector2ToAngleTest.cs
+++ b/Tests/Editor/Data/Type/Transformation/Conversion/Vector2ToAngleTest.cs
@@ -5,6 +5,7 @@ namespace Test.Zinnia.Data.Type.Transformation.Conversion
     using UnityEngine;
     using NUnit.Framework;
     using Test.Zinnia.Utility.Mock;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class Vector2ToAngleTest
     {

--- a/Tests/Editor/Data/Type/Transformation/Conversion/Vector2ToFloatTest.cs
+++ b/Tests/Editor/Data/Type/Transformation/Conversion/Vector2ToFloatTest.cs
@@ -5,6 +5,7 @@ namespace Test.Zinnia.Data.Type.Transformation.Conversion
     using UnityEngine;
     using NUnit.Framework;
     using Test.Zinnia.Utility.Mock;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class Vector2ToFloatTest : MonoBehaviour
     {

--- a/Tests/Editor/Data/Type/Transformation/Conversion/Vector2ToVector3Test.cs
+++ b/Tests/Editor/Data/Type/Transformation/Conversion/Vector2ToVector3Test.cs
@@ -5,6 +5,7 @@ namespace Test.Zinnia.Data.Type.Transformation.Conversion
     using UnityEngine;
     using NUnit.Framework;
     using Test.Zinnia.Utility.Mock;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class Vector2ToVector3Test
     {

--- a/Tests/Editor/Data/Type/Transformation/Conversion/Vector3ToVector2Test.cs
+++ b/Tests/Editor/Data/Type/Transformation/Conversion/Vector3ToVector2Test.cs
@@ -5,6 +5,7 @@ namespace Test.Zinnia.Data.Type.Transformation.Conversion
     using UnityEngine;
     using NUnit.Framework;
     using Test.Zinnia.Utility.Mock;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class Vector3ToVector2Test
     {

--- a/Tests/Editor/Data/Type/Transformation/Vector3MagnitudeSetterTest.cs
+++ b/Tests/Editor/Data/Type/Transformation/Vector3MagnitudeSetterTest.cs
@@ -5,6 +5,7 @@ namespace Test.Zinnia.Data.Type.Transformation
     using NUnit.Framework;
     using Test.Zinnia.Utility.Mock;
     using UnityEngine;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class Vector3MagnitudeSetterTest
     {

--- a/Tests/Editor/Data/Type/Transformation/Vector3RestrictorTest.cs
+++ b/Tests/Editor/Data/Type/Transformation/Vector3RestrictorTest.cs
@@ -6,6 +6,7 @@ namespace Test.Zinnia.Data.Type.Transformation
     using UnityEngine;
     using NUnit.Framework;
     using Test.Zinnia.Utility.Mock;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class Vector3RestrictorTest
     {

--- a/Tests/Editor/Data/Type/Vector3StateTest.cs
+++ b/Tests/Editor/Data/Type/Vector3StateTest.cs
@@ -4,6 +4,7 @@ namespace Test.Zinnia.Data.Type
 {
     using UnityEngine;
     using NUnit.Framework;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class Vector3StateTest
     {

--- a/Tests/Editor/Event/BehaviourEnabledObserverTest.cs
+++ b/Tests/Editor/Event/BehaviourEnabledObserverTest.cs
@@ -8,6 +8,7 @@ namespace Test.Zinnia.Event
     using System.Collections;
     using NUnit.Framework;
     using Test.Zinnia.Utility.Mock;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class BehaviourEnabledObserverTest
     {

--- a/Tests/Editor/Event/Proxy/EmptyEventProxyEmitterTest.cs
+++ b/Tests/Editor/Event/Proxy/EmptyEventProxyEmitterTest.cs
@@ -5,6 +5,7 @@ namespace Test.Zinnia.Event.Proxy
     using UnityEngine;
     using NUnit.Framework;
     using Test.Zinnia.Utility.Mock;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class EmptyEventProxyEmitterTest
     {

--- a/Tests/Editor/Event/Proxy/FloatEventProxyEmitterTest.cs
+++ b/Tests/Editor/Event/Proxy/FloatEventProxyEmitterTest.cs
@@ -5,6 +5,7 @@ namespace Test.Zinnia.Event.Proxy
     using UnityEngine;
     using NUnit.Framework;
     using Test.Zinnia.Utility.Mock;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class FloatEventProxyEmitterTest
     {

--- a/Tests/Editor/Event/Proxy/GameObjectEventProxyEmitterTest.cs
+++ b/Tests/Editor/Event/Proxy/GameObjectEventProxyEmitterTest.cs
@@ -7,6 +7,7 @@ namespace Test.Zinnia.Event.Proxy
     using UnityEngine;
     using NUnit.Framework;
     using Test.Zinnia.Utility.Mock;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class GameObjectEventProxyEmitterTest
     {

--- a/Tests/Editor/Extension/ArraySortExtensionsTest.cs
+++ b/Tests/Editor/Extension/ArraySortExtensionsTest.cs
@@ -3,6 +3,7 @@
 namespace Test.Zinnia.Extension
 {
     using NUnit.Framework;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class ArraySortExtensionsTest
     {

--- a/Tests/Editor/Extension/BehaviourExtensionsTest.cs
+++ b/Tests/Editor/Extension/BehaviourExtensionsTest.cs
@@ -6,6 +6,7 @@ namespace Test.Zinnia.Extension
     using UnityEngine.TestTools;
     using System.Collections;
     using NUnit.Framework;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class BehaviourExtensionsTest
     {

--- a/Tests/Editor/Extension/ColliderExtensionsTest.cs
+++ b/Tests/Editor/Extension/ColliderExtensionsTest.cs
@@ -4,6 +4,7 @@ namespace Test.Zinnia.Extension
 {
     using UnityEngine;
     using NUnit.Framework;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class ColliderExtensionsTest
     {

--- a/Tests/Editor/Extension/ComponentExtensionsTest.cs
+++ b/Tests/Editor/Extension/ComponentExtensionsTest.cs
@@ -4,6 +4,7 @@ namespace Test.Zinnia.Extension
 {
     using UnityEngine;
     using NUnit.Framework;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class ComponentExtensionsTest
     {
@@ -11,7 +12,7 @@ namespace Test.Zinnia.Extension
         public void TryGetTransformValid()
         {
             Component valid = new GameObject().transform;
-            Assert.NotNull(valid.TryGetTransform());
+            Assert.IsNotNull(valid.TryGetTransform());
             Object.DestroyImmediate(valid.gameObject);
         }
 
@@ -27,7 +28,7 @@ namespace Test.Zinnia.Extension
         public void TryGetGameObjectValid()
         {
             Component valid = new GameObject().GetComponent<Component>();
-            Assert.NotNull(valid.TryGetGameObject());
+            Assert.IsNotNull(valid.TryGetGameObject());
             Object.DestroyImmediate(valid.gameObject);
         }
 

--- a/Tests/Editor/Extension/FloatExtensionsTest.cs
+++ b/Tests/Editor/Extension/FloatExtensionsTest.cs
@@ -3,6 +3,7 @@
 namespace Test.Zinnia.Extension
 {
     using NUnit.Framework;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class FloatExtensionsTest
     {

--- a/Tests/Editor/Extension/GameObjectExtensionsTest.cs
+++ b/Tests/Editor/Extension/GameObjectExtensionsTest.cs
@@ -4,6 +4,7 @@ namespace Test.Zinnia.Extension
 {
     using UnityEngine;
     using NUnit.Framework;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class GameObjectExtensionsTest
     {

--- a/Tests/Editor/Extension/ICollectionExtensionsTest.cs
+++ b/Tests/Editor/Extension/ICollectionExtensionsTest.cs
@@ -4,6 +4,7 @@ namespace Test.Zinnia.Extension
 {
     using NUnit.Framework;
     using System.Collections.Generic;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class ICollectionExtensionsTest
     {

--- a/Tests/Editor/Extension/RuleContainerExtensionsTest.cs
+++ b/Tests/Editor/Extension/RuleContainerExtensionsTest.cs
@@ -4,6 +4,7 @@ using Zinnia.Rule;
 namespace Test.Zinnia.Extension
 {
     using NUnit.Framework;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class RuleContainerExtensionsTest
     {

--- a/Tests/Editor/Extension/TransformDataExtensionsTest.cs
+++ b/Tests/Editor/Extension/TransformDataExtensionsTest.cs
@@ -5,6 +5,7 @@ namespace Test.Zinnia.Extension
 {
     using UnityEngine;
     using NUnit.Framework;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class TransformDataExtensionsTest
     {
@@ -12,7 +13,7 @@ namespace Test.Zinnia.Extension
         public void TryGetGameObjectValid()
         {
             TransformData valid = new TransformData(new GameObject());
-            Assert.NotNull(valid.TryGetGameObject());
+            Assert.IsNotNull(valid.TryGetGameObject());
             Object.DestroyImmediate(valid.Transform.gameObject);
         }
 

--- a/Tests/Editor/Extension/TransformExtensionsTest.cs
+++ b/Tests/Editor/Extension/TransformExtensionsTest.cs
@@ -4,6 +4,7 @@ namespace Test.Zinnia.Extension
 {
     using UnityEngine;
     using NUnit.Framework;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class TransformExtensionsTest
     {

--- a/Tests/Editor/Extension/Vector2ExtensionsTest.cs
+++ b/Tests/Editor/Extension/Vector2ExtensionsTest.cs
@@ -4,6 +4,7 @@ namespace Test.Zinnia.Extension
 {
     using UnityEngine;
     using NUnit.Framework;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class Vector2ExtensionsTest
     {

--- a/Tests/Editor/Extension/Vector3ExtensionsTest.cs
+++ b/Tests/Editor/Extension/Vector3ExtensionsTest.cs
@@ -4,6 +4,7 @@ namespace Test.Zinnia.Extension
 {
     using UnityEngine;
     using NUnit.Framework;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class Vector3ExtensionsTest
     {

--- a/Tests/Editor/Pointer/ObjectPointerTest.cs
+++ b/Tests/Editor/Pointer/ObjectPointerTest.cs
@@ -7,6 +7,7 @@ namespace Test.Zinnia.Pointer
     using NUnit.Framework;
     using System.Collections.Generic;
     using Test.Zinnia.Utility.Mock;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class ObjectPointerTest
     {
@@ -29,7 +30,7 @@ namespace Test.Zinnia.Pointer
         public void SetUp()
         {
             Physics.autoSimulation = false;
-            containingObject = new GameObject();
+            containingObject = new GameObject("containingObject");
             containingObject.SetActive(false);
             subject = containingObject.AddComponent<ObjectPointerMock>();
         }
@@ -49,28 +50,28 @@ namespace Test.Zinnia.Pointer
 
         protected virtual void SetUpElements()
         {
-            validOriginContainer = new GameObject();
-            validOriginMesh = new GameObject();
+            validOriginContainer = new GameObject("validOriginContainer");
+            validOriginMesh = new GameObject("validOriginMesh");
             validOriginMesh.transform.SetParent(validOriginContainer.transform);
 
-            invalidOriginContainer = new GameObject();
-            invalidOriginMesh = new GameObject();
+            invalidOriginContainer = new GameObject("invalidOriginContainer");
+            invalidOriginMesh = new GameObject("invalidOriginMesh");
             invalidOriginMesh.transform.SetParent(invalidOriginContainer.transform);
 
-            validSegmentContainer = new GameObject();
-            validSegmentMesh = new GameObject();
+            validSegmentContainer = new GameObject("validSegmentContainer");
+            validSegmentMesh = new GameObject("validSegmentMesh");
             validSegmentMesh.transform.SetParent(validSegmentContainer.transform);
 
-            invalidSegmentContainer = new GameObject();
-            invalidSegmentMesh = new GameObject();
+            invalidSegmentContainer = new GameObject("invalidSegmentContainer");
+            invalidSegmentMesh = new GameObject("invalidSegmentMesh");
             invalidSegmentMesh.transform.SetParent(invalidSegmentContainer.transform);
 
-            validDestinationContainer = new GameObject();
-            validDestinationMesh = new GameObject();
+            validDestinationContainer = new GameObject("validDestinationContainer");
+            validDestinationMesh = new GameObject("validDestinationMesh");
             validDestinationMesh.transform.SetParent(validDestinationContainer.transform);
 
-            invalidDestinationContainer = new GameObject();
-            invalidDestinationMesh = new GameObject();
+            invalidDestinationContainer = new GameObject("invalidDestinationContainer");
+            invalidDestinationMesh = new GameObject("invalidDestinationMesh");
             invalidDestinationMesh.transform.SetParent(invalidDestinationContainer.transform);
 
             PointerElement origin = containingObject.AddComponent<PointerElement>();
@@ -800,6 +801,7 @@ namespace Test.Zinnia.Pointer
 
             //Place an object in the way to make a valid target
             GameObject blocker = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            blocker.name = "blocker";
             blocker.transform.position = Vector3.forward * 5f;
 
             List<Vector3> castPoints = new List<Vector3> { Vector3.zero, blocker.transform.position };

--- a/Tests/Editor/Process/Component/GameObjectSourceTargetProcessorTest.cs
+++ b/Tests/Editor/Process/Component/GameObjectSourceTargetProcessorTest.cs
@@ -9,6 +9,7 @@ namespace Test.Zinnia.Process.Component
     using System.Collections;
     using NUnit.Framework;
     using Test.Zinnia.Utility.Stub;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class GameObjectSourceTargetProcessorTest
     {
@@ -36,7 +37,7 @@ namespace Test.Zinnia.Process.Component
             subject.Sources = containingObject.AddComponent<GameObjectObservableList>();
             yield return null;
 
-            Assert.IsEmpty(subject.Sources.NonSubscribableElements);
+            Assert.AreEqual(0, subject.Sources.NonSubscribableElements.Count);
 
             subject.Sources.Add(source);
 
@@ -60,7 +61,7 @@ namespace Test.Zinnia.Process.Component
 
             subject.Sources.Remove(source);
 
-            Assert.IsEmpty(subject.Sources.NonSubscribableElements);
+            Assert.AreEqual(0, subject.Sources.NonSubscribableElements.Count);
 
             Object.DestroyImmediate(source);
         }
@@ -108,7 +109,7 @@ namespace Test.Zinnia.Process.Component
 
             subject.Sources.Clear();
 
-            Assert.IsEmpty(subject.Sources.NonSubscribableElements);
+            Assert.AreEqual(0, subject.Sources.NonSubscribableElements.Count);
 
             Object.DestroyImmediate(source);
         }
@@ -121,7 +122,7 @@ namespace Test.Zinnia.Process.Component
             subject.Targets = containingObject.AddComponent<GameObjectObservableList>();
             yield return null;
 
-            Assert.IsEmpty(subject.Targets.NonSubscribableElements);
+            Assert.AreEqual(0, subject.Targets.NonSubscribableElements.Count);
 
             subject.Targets.Add(target);
 
@@ -145,7 +146,7 @@ namespace Test.Zinnia.Process.Component
 
             subject.Targets.Remove(target);
 
-            Assert.IsEmpty(subject.Targets.NonSubscribableElements);
+            Assert.AreEqual(0, subject.Targets.NonSubscribableElements.Count);
 
             Object.DestroyImmediate(target);
         }
@@ -191,7 +192,7 @@ namespace Test.Zinnia.Process.Component
 
             subject.Targets.Clear();
 
-            Assert.IsEmpty(subject.Targets.NonSubscribableElements);
+            Assert.AreEqual(0, subject.Targets.NonSubscribableElements.Count);
 
             Object.DestroyImmediate(target);
         }

--- a/Tests/Editor/Process/Moment/MomentProcessTest.cs
+++ b/Tests/Editor/Process/Moment/MomentProcessTest.cs
@@ -5,6 +5,7 @@ namespace Test.Zinnia.Process.Moment
 {
     using UnityEngine;
     using NUnit.Framework;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class MomentProcessTest
     {
@@ -87,8 +88,8 @@ namespace Test.Zinnia.Process.Moment
 
             subject.RandomizeNextProcessTime();
 
-            Assert.GreaterOrEqual(subject.NextProcessTime, Time.time);
-            Assert.LessOrEqual(subject.NextProcessTime, Time.time + interval);
+            Assert.IsTrue(subject.NextProcessTime >= Time.time);
+            Assert.IsTrue(subject.NextProcessTime <= Time.time + interval);
         }
 
         [Test]
@@ -97,11 +98,11 @@ namespace Test.Zinnia.Process.Moment
             const float interval = 123.456f;
             subject.Interval = interval;
 
-            Assert.Zero(subject.NextProcessTime);
+            Assert.AreEqual(0, subject.NextProcessTime);
             containingObject.SetActive(true);
 
-            Assert.GreaterOrEqual(subject.NextProcessTime, Time.time);
-            Assert.LessOrEqual(subject.NextProcessTime, Time.time + interval);
+            Assert.IsTrue(subject.NextProcessTime >= Time.time);
+            Assert.IsTrue(subject.NextProcessTime <= Time.time + interval);
         }
 
         private sealed class MockProcessable : IProcessable

--- a/Tests/Editor/Rule/ActiveInHierarchyRuleTest.cs
+++ b/Tests/Editor/Rule/ActiveInHierarchyRuleTest.cs
@@ -5,6 +5,7 @@ namespace Test.Zinnia.Rule
 {
     using UnityEngine;
     using NUnit.Framework;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class ActiveInHierarchyRuleTest
     {

--- a/Tests/Editor/Rule/AllRuleTest.cs
+++ b/Tests/Editor/Rule/AllRuleTest.cs
@@ -9,6 +9,7 @@ namespace Test.Zinnia.Rule
     using System.Collections;
     using NUnit.Framework;
     using Test.Zinnia.Utility.Stub;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class AllRuleTest
     {

--- a/Tests/Editor/Rule/AnyBehaviourEnabledRuleTest.cs
+++ b/Tests/Editor/Rule/AnyBehaviourEnabledRuleTest.cs
@@ -8,6 +8,7 @@ namespace Test.Zinnia.Rule
     using UnityEngine.TestTools;
     using System.Collections;
     using NUnit.Framework;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class AnyBehaviourEnabledRuleTest
     {

--- a/Tests/Editor/Rule/AnyComponentTypeRuleTest.cs
+++ b/Tests/Editor/Rule/AnyComponentTypeRuleTest.cs
@@ -8,6 +8,7 @@ namespace Test.Zinnia.Rule
     using UnityEngine.TestTools;
     using System.Collections;
     using NUnit.Framework;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class AnyComponentTypeRuleTest
     {

--- a/Tests/Editor/Rule/AnyLayerRuleTest.cs
+++ b/Tests/Editor/Rule/AnyLayerRuleTest.cs
@@ -5,6 +5,7 @@ namespace Test.Zinnia.Rule
 {
     using UnityEngine;
     using NUnit.Framework;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class AnyLayerRuleTest
     {

--- a/Tests/Editor/Rule/AnyRuleTest.cs
+++ b/Tests/Editor/Rule/AnyRuleTest.cs
@@ -9,6 +9,7 @@ namespace Test.Zinnia.Rule
     using System.Collections;
     using NUnit.Framework;
     using Test.Zinnia.Utility.Stub;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class AnyRuleTest
     {

--- a/Tests/Editor/Rule/AnyTagRuleTest.cs
+++ b/Tests/Editor/Rule/AnyTagRuleTest.cs
@@ -10,6 +10,7 @@ namespace Test.Zinnia.Rule
     using System.Collections;
     using System.Collections.Generic;
     using NUnit.Framework;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class AnyTagRuleTest
     {

--- a/Tests/Editor/Rule/ListContainsRuleTest.cs
+++ b/Tests/Editor/Rule/ListContainsRuleTest.cs
@@ -8,6 +8,7 @@ namespace Test.Zinnia.Rule
     using UnityEngine.TestTools;
     using System.Collections;
     using NUnit.Framework;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class ListContainsRuleTest
     {

--- a/Tests/Editor/Rule/NegationRuleTest.cs
+++ b/Tests/Editor/Rule/NegationRuleTest.cs
@@ -6,6 +6,7 @@ namespace Test.Zinnia.Rule
     using UnityEngine;
     using NUnit.Framework;
     using Test.Zinnia.Utility.Stub;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class NegationRuleTest
     {

--- a/Tests/Editor/Rule/RulesMatcherTest.cs
+++ b/Tests/Editor/Rule/RulesMatcherTest.cs
@@ -9,6 +9,7 @@ namespace Test.Zinnia.Rule
     using System.Collections;
     using NUnit.Framework;
     using Test.Zinnia.Utility.Mock;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class RulesMatcherTest
     {

--- a/Tests/Editor/Tracking/Collision/Active/ActiveCollisionConsumerTest.cs
+++ b/Tests/Editor/Tracking/Collision/Active/ActiveCollisionConsumerTest.cs
@@ -10,6 +10,7 @@ namespace Test.Zinnia.Tracking.Collision.Active
     using NUnit.Framework;
     using Test.Zinnia.Utility.Mock;
     using Test.Zinnia.Utility.Stub;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class ActiveCollisionConsumerTest
     {

--- a/Tests/Editor/Tracking/Collision/Active/ActiveCollisionPublisherTest.cs
+++ b/Tests/Editor/Tracking/Collision/Active/ActiveCollisionPublisherTest.cs
@@ -6,6 +6,7 @@ namespace Test.Zinnia.Tracking.Collision.Active
     using UnityEngine;
     using NUnit.Framework;
     using Test.Zinnia.Utility.Helper;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class ActiveCollisionPublisherTest
     {

--- a/Tests/Editor/Tracking/Collision/Active/ActiveCollisionsContainerTest.cs
+++ b/Tests/Editor/Tracking/Collision/Active/ActiveCollisionsContainerTest.cs
@@ -12,6 +12,7 @@ namespace Test.Zinnia.Tracking.Collision.Active
     using Test.Zinnia.Utility.Mock;
     using Test.Zinnia.Utility.Stub;
     using Test.Zinnia.Utility.Helper;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class ActiveCollisionsContainerTest
     {

--- a/Tests/Editor/Tracking/Collision/Active/CollisionPointContainerTest.cs
+++ b/Tests/Editor/Tracking/Collision/Active/CollisionPointContainerTest.cs
@@ -7,6 +7,7 @@ namespace Test.Zinnia.Tracking.Collision.Active
     using NUnit.Framework;
     using Test.Zinnia.Utility.Mock;
     using Test.Zinnia.Utility.Helper;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class CollisionPointContainerTest
     {

--- a/Tests/Editor/Tracking/Collision/Active/Event/Proxy/ActiveCollisionConsumerEventProxyEmitterTest.cs
+++ b/Tests/Editor/Tracking/Collision/Active/Event/Proxy/ActiveCollisionConsumerEventProxyEmitterTest.cs
@@ -6,6 +6,7 @@ namespace Test.Zinnia.Tracking.Collision.Active.Event.Proxy
     using UnityEngine;
     using NUnit.Framework;
     using Test.Zinnia.Utility.Mock;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class ActiveCollisionConsumerEventProxyEmitterTest
     {

--- a/Tests/Editor/Tracking/Collision/Active/Event/Proxy/ActiveCollisionsContainerEventProxyEmitterTest.cs
+++ b/Tests/Editor/Tracking/Collision/Active/Event/Proxy/ActiveCollisionsContainerEventProxyEmitterTest.cs
@@ -6,6 +6,7 @@ namespace Test.Zinnia.Tracking.Collision.Active.Event.Proxy
     using UnityEngine;
     using NUnit.Framework;
     using Test.Zinnia.Utility.Mock;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class ActiveCollisionsContainerEventProxyEmitterTest
     {

--- a/Tests/Editor/Tracking/Collision/Active/Operation/Extraction/NotifierContainerExtractorTest.cs
+++ b/Tests/Editor/Tracking/Collision/Active/Operation/Extraction/NotifierContainerExtractorTest.cs
@@ -6,6 +6,7 @@ namespace Test.Zinnia.Tracking.Collision.Active.Operation.Extraction
     using UnityEngine;
     using NUnit.Framework;
     using Test.Zinnia.Utility.Mock;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class NotifierContainerExtractorTest
     {

--- a/Tests/Editor/Tracking/Collision/Active/Operation/Extraction/NotifierTargetExtractorTest.cs
+++ b/Tests/Editor/Tracking/Collision/Active/Operation/Extraction/NotifierTargetExtractorTest.cs
@@ -6,6 +6,7 @@ namespace Test.Zinnia.Tracking.Collision.Active.Operation.Extraction
     using UnityEngine;
     using NUnit.Framework;
     using Test.Zinnia.Utility.Mock;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class NotifierTargetExtractorTest
     {

--- a/Tests/Editor/Tracking/Collision/Active/Operation/Extraction/PublisherContainerExtractorTest.cs
+++ b/Tests/Editor/Tracking/Collision/Active/Operation/Extraction/PublisherContainerExtractorTest.cs
@@ -6,6 +6,7 @@ namespace Test.Zinnia.Tracking.Collision.Active.Operation.Extraction
     using UnityEngine;
     using NUnit.Framework;
     using Test.Zinnia.Utility.Mock;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class PublisherContainerExtractorTest
     {

--- a/Tests/Editor/Tracking/Collision/Active/Operation/NearestSorterTest.cs
+++ b/Tests/Editor/Tracking/Collision/Active/Operation/NearestSorterTest.cs
@@ -9,6 +9,7 @@ namespace Test.Zinnia.Tracking.Collision.Active.Operation
     using System.Collections.Generic;
     using Test.Zinnia.Utility.Mock;
     using Test.Zinnia.Utility.Helper;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class NearestSorterTest
     {

--- a/Tests/Editor/Tracking/Collision/Active/Operation/OrderReverserTest.cs
+++ b/Tests/Editor/Tracking/Collision/Active/Operation/OrderReverserTest.cs
@@ -9,6 +9,7 @@ namespace Test.Zinnia.Tracking.Collision.Active.Operation
     using System.Collections.Generic;
     using Test.Zinnia.Utility.Mock;
     using Test.Zinnia.Utility.Helper;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class OrderReverserTest
     {

--- a/Tests/Editor/Tracking/Collision/Active/Operation/SlicerTest.cs
+++ b/Tests/Editor/Tracking/Collision/Active/Operation/SlicerTest.cs
@@ -9,6 +9,7 @@ namespace Test.Zinnia.Tracking.Collision.Active.Operation
     using System.Collections.Generic;
     using Test.Zinnia.Utility.Mock;
     using Test.Zinnia.Utility.Helper;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class SlicerTest
     {

--- a/Tests/Editor/Tracking/Collision/CollisionIgnorerTest.cs
+++ b/Tests/Editor/Tracking/Collision/CollisionIgnorerTest.cs
@@ -7,6 +7,7 @@ namespace Test.Zinnia.Tracking.Collision
     using UnityEngine.TestTools;
     using System.Collections;
     using NUnit.Framework;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class CollisionIgnorerTest
     {

--- a/Tests/Editor/Tracking/Collision/CollisionNotifierTest.cs
+++ b/Tests/Editor/Tracking/Collision/CollisionNotifierTest.cs
@@ -5,6 +5,7 @@ namespace Test.Zinnia.Tracking.Collision
     using UnityEngine;
     using NUnit.Framework;
     using Test.Zinnia.Utility.Mock;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class CollisionNotifierTest
     {

--- a/Tests/Editor/Tracking/Collision/CollisionTrackerTest.cs
+++ b/Tests/Editor/Tracking/Collision/CollisionTrackerTest.cs
@@ -7,6 +7,7 @@ namespace Test.Zinnia.Tracking.Collision
     using System.Collections;
     using NUnit.Framework;
     using Test.Zinnia.Utility.Mock;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class CollisionTrackerTest
     {

--- a/Tests/Editor/Tracking/Collision/Event/Proxy/CollisionNotifierEventProxyEmitterTest.cs
+++ b/Tests/Editor/Tracking/Collision/Event/Proxy/CollisionNotifierEventProxyEmitterTest.cs
@@ -8,6 +8,7 @@ namespace Test.Zinnia.Tracking.Collision.Event.Proxy
     using UnityEngine;
     using NUnit.Framework;
     using Test.Zinnia.Utility.Mock;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class CollisionNotifierEventProxyEmitterTest
     {

--- a/Tests/Editor/Tracking/Follow/Modifier/FollowModifierTest.cs
+++ b/Tests/Editor/Tracking/Follow/Modifier/FollowModifierTest.cs
@@ -6,6 +6,7 @@ namespace Test.Zinnia.Tracking.Follow.Modifier
     using UnityEngine;
     using NUnit.Framework;
     using Test.Zinnia.Utility.Mock;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class FollowModifierTest
     {

--- a/Tests/Editor/Tracking/Follow/Modifier/Property/Position/RigidbodyVelocityTest.cs
+++ b/Tests/Editor/Tracking/Follow/Modifier/Property/Position/RigidbodyVelocityTest.cs
@@ -5,6 +5,7 @@ namespace Test.Zinnia.Tracking.Follow.Modifier.Property.Position
     using UnityEngine;
     using NUnit.Framework;
     using Test.Zinnia.Utility;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class RigidbodyVelocityTest
     {

--- a/Tests/Editor/Tracking/Follow/Modifier/Property/Position/TransformPositionTest.cs
+++ b/Tests/Editor/Tracking/Follow/Modifier/Property/Position/TransformPositionTest.cs
@@ -4,6 +4,7 @@ namespace Test.Zinnia.Tracking.Follow.Modifier.Property.Position
 {
     using UnityEngine;
     using NUnit.Framework;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class TransformPositionTest
     {

--- a/Tests/Editor/Tracking/Follow/Modifier/Property/Rotation/RigidbodyAngularVelocityTest.cs
+++ b/Tests/Editor/Tracking/Follow/Modifier/Property/Rotation/RigidbodyAngularVelocityTest.cs
@@ -5,6 +5,7 @@ namespace Test.Zinnia.Tracking.Follow.Modifier.Property.Rotation
     using UnityEngine;
     using NUnit.Framework;
     using Test.Zinnia.Utility;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class RigidbodyAngularVelocityTest
     {

--- a/Tests/Editor/Tracking/Follow/Modifier/Property/Rotation/TransformPositionDifferenceRotationTest.cs
+++ b/Tests/Editor/Tracking/Follow/Modifier/Property/Rotation/TransformPositionDifferenceRotationTest.cs
@@ -4,6 +4,7 @@ namespace Test.Zinnia.Tracking.Follow.Modifier.Property.Rotation
 {
     using UnityEngine;
     using NUnit.Framework;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class TransformPositionDifferenceRotationTest
     {

--- a/Tests/Editor/Tracking/Follow/Modifier/Property/Rotation/TransformRotationTest.cs
+++ b/Tests/Editor/Tracking/Follow/Modifier/Property/Rotation/TransformRotationTest.cs
@@ -4,6 +4,7 @@ namespace Test.Zinnia.Tracking.Follow.Modifier.Property.Rotation
 {
     using UnityEngine;
     using NUnit.Framework;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class TransformRotationTest
     {

--- a/Tests/Editor/Tracking/Follow/Modifier/Property/Scale/TransformScaleTest.cs
+++ b/Tests/Editor/Tracking/Follow/Modifier/Property/Scale/TransformScaleTest.cs
@@ -4,6 +4,7 @@ namespace Test.Zinnia.Tracking.Follow.Modifier.Property.Scale
 {
     using UnityEngine;
     using NUnit.Framework;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class TransformScaleTest
     {

--- a/Tests/Editor/Tracking/Follow/ObjectDistanceComparatorTest.cs
+++ b/Tests/Editor/Tracking/Follow/ObjectDistanceComparatorTest.cs
@@ -5,7 +5,7 @@ namespace Test.Zinnia.Tracking.Follow
     using UnityEngine;
     using NUnit.Framework;
     using Test.Zinnia.Utility.Mock;
-
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class ObjectDistanceComparatorTest
     {

--- a/Tests/Editor/Tracking/Follow/ObjectFollowerTest.cs
+++ b/Tests/Editor/Tracking/Follow/ObjectFollowerTest.cs
@@ -11,6 +11,7 @@ namespace Test.Zinnia.Tracking.Follow
     using NUnit.Framework;
     using Test.Zinnia.Utility.Mock;
     using Test.Zinnia.Utility.Stub;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class ObjectFollowerTest
     {
@@ -38,7 +39,7 @@ namespace Test.Zinnia.Tracking.Follow
             subject.TargetOffsets = containingObject.AddComponent<GameObjectObservableList>();
             yield return null;
 
-            Assert.IsEmpty(subject.TargetOffsets.NonSubscribableElements);
+            Assert.AreEqual(0, subject.TargetOffsets.NonSubscribableElements.Count);
             subject.TargetOffsets.Add(offset);
             Assert.AreEqual(1, subject.TargetOffsets.NonSubscribableElements.Count);
             Assert.AreEqual(offset, subject.TargetOffsets.NonSubscribableElements[0]);
@@ -57,7 +58,7 @@ namespace Test.Zinnia.Tracking.Follow
             Assert.AreEqual(offset, subject.TargetOffsets.NonSubscribableElements[0]);
 
             subject.TargetOffsets.Remove(offset);
-            Assert.IsEmpty(subject.TargetOffsets.NonSubscribableElements);
+            Assert.AreEqual(0, subject.TargetOffsets.NonSubscribableElements.Count);
             Object.DestroyImmediate(offset);
         }
 
@@ -101,7 +102,7 @@ namespace Test.Zinnia.Tracking.Follow
             Assert.AreEqual(offset, subject.TargetOffsets.NonSubscribableElements[0]);
 
             subject.TargetOffsets.Clear();
-            Assert.IsEmpty(subject.TargetOffsets.NonSubscribableElements);
+            Assert.AreEqual(0, subject.TargetOffsets.NonSubscribableElements.Count);
             Object.DestroyImmediate(offset);
         }
 
@@ -372,7 +373,7 @@ namespace Test.Zinnia.Tracking.Follow
             FollowModifierMock followModifierMock = containingObject.AddComponent<FollowModifierMock>();
             subject.FollowModifier = followModifierMock;
 
-            Assert.Throws<System.ArgumentException>(() => subject.Process());
+            NUnit.Framework.Assert.Throws<System.ArgumentException>(() => subject.Process());
 
             Assert.IsTrue(preprocessedMock.Received);
             Assert.IsFalse(processedMock.Received);
@@ -384,7 +385,7 @@ namespace Test.Zinnia.Tracking.Follow
             Object.DestroyImmediate(targetOffset1);
             Object.DestroyImmediate(targetOffset2);
             Object.DestroyImmediate(targetOffset3);
-        }
+            }
 
         public class FollowModifierMock : FollowModifier
         {

--- a/Tests/Editor/Tracking/Follow/Operation/Extraction/ObjectDistanceComparatorEventDataExtractorTest.cs
+++ b/Tests/Editor/Tracking/Follow/Operation/Extraction/ObjectDistanceComparatorEventDataExtractorTest.cs
@@ -6,6 +6,7 @@ namespace Test.Zinnia.Tracking.Follow.Operation.Extraction
     using UnityEngine;
     using NUnit.Framework;
     using Test.Zinnia.Utility.Mock;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class ObjectDistanceComparatorEventDataExtractorTest
     {

--- a/Tests/Editor/Tracking/Modification/ComponentEnabledStateModifierTest.cs
+++ b/Tests/Editor/Tracking/Modification/ComponentEnabledStateModifierTest.cs
@@ -7,6 +7,7 @@ namespace Test.Zinnia.Tracking.Modification
     using UnityEngine.TestTools;
     using System.Collections;
     using NUnit.Framework;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class ComponentEnabledStateModifierTest
     {

--- a/Tests/Editor/Tracking/Modification/DirectionModifierTest.cs
+++ b/Tests/Editor/Tracking/Modification/DirectionModifierTest.cs
@@ -5,6 +5,7 @@ namespace Test.Zinnia.Tracking.Modification
     using UnityEngine;
     using NUnit.Framework;
     using Test.Zinnia.Utility.Mock;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class DirectionModifierTest
     {

--- a/Tests/Editor/Tracking/Modification/GameObjectStateMirrorTest.cs
+++ b/Tests/Editor/Tracking/Modification/GameObjectStateMirrorTest.cs
@@ -7,6 +7,7 @@ namespace Test.Zinnia.Tracking.Modification
     using UnityEngine.TestTools;
     using System.Collections;
     using NUnit.Framework;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class GameObjectStateMirrorTest
     {

--- a/Tests/Editor/Tracking/Modification/GameObjectStateSwitcherTest.cs
+++ b/Tests/Editor/Tracking/Modification/GameObjectStateSwitcherTest.cs
@@ -7,6 +7,7 @@ namespace Test.Zinnia.Tracking.Modification
     using UnityEngine.TestTools;
     using System.Collections;
     using NUnit.Framework;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class GameObjectStateSwitcherTest
     {

--- a/Tests/Editor/Tracking/Modification/Operation/Extraction/TransformPropertyApplierEventDataExtractorTest.cs
+++ b/Tests/Editor/Tracking/Modification/Operation/Extraction/TransformPropertyApplierEventDataExtractorTest.cs
@@ -7,6 +7,7 @@ namespace Test.Zinnia.Tracking.Modification.Operation.Extraction
     using UnityEngine;
     using NUnit.Framework;
     using Test.Zinnia.Utility.Mock;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class TransformPropertyApplierEventDataExtractorTest
     {

--- a/Tests/Editor/Tracking/Modification/PinchScalerTest.cs
+++ b/Tests/Editor/Tracking/Modification/PinchScalerTest.cs
@@ -4,6 +4,7 @@ namespace Test.Zinnia.Tracking.Modification
 {
     using UnityEngine;
     using NUnit.Framework;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class PinchScalerTest
     {

--- a/Tests/Editor/Tracking/Modification/PointNormalRotatorTest.cs
+++ b/Tests/Editor/Tracking/Modification/PointNormalRotatorTest.cs
@@ -5,6 +5,7 @@ namespace Test.Zinnia.Tracking.Modification
 {
     using UnityEngine;
     using NUnit.Framework;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class PointNormalRotatorTest
     {

--- a/Tests/Editor/Tracking/Modification/TransformPropertyApplierTest.cs
+++ b/Tests/Editor/Tracking/Modification/TransformPropertyApplierTest.cs
@@ -7,6 +7,7 @@ namespace Test.Zinnia.Tracking.Modification
     using UnityEngine;
     using NUnit.Framework;
     using Test.Zinnia.Utility.Mock;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class TransformPropertyApplierTest
     {

--- a/Tests/Editor/Tracking/Query/FacingQueryTest.cs
+++ b/Tests/Editor/Tracking/Query/FacingQueryTest.cs
@@ -7,6 +7,7 @@ namespace Test.Zinnia.Tracking.Query
     using System.Collections;
     using NUnit.Framework;
     using Test.Zinnia.Utility.Mock;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class FacingQueryTest
     {

--- a/Tests/Editor/Tracking/Query/ObscuranceQueryTest.cs
+++ b/Tests/Editor/Tracking/Query/ObscuranceQueryTest.cs
@@ -7,6 +7,7 @@ namespace Test.Zinnia.Tracking.Query
     using System.Collections;
     using NUnit.Framework;
     using Test.Zinnia.Utility.Mock;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class ObscuranceQueryTest
     {
@@ -174,7 +175,7 @@ namespace Test.Zinnia.Tracking.Query
         public void TargetWithoutCollider_ThrowsMissingColliderException()
         {
             GameObject target = new GameObject();
-            Assert.Throws<ObscuranceQuery.MissingColliderException>(() => subject.Target = target);
+            NUnit.Framework.Assert.Throws<ObscuranceQuery.MissingColliderException>(() => subject.Target = target);
             Object.DestroyImmediate(target);
         }
 
@@ -185,7 +186,7 @@ namespace Test.Zinnia.Tracking.Query
             GameObject child = GameObject.CreatePrimitive(PrimitiveType.Cube);
             child.transform.SetParent(target.transform);
 
-            Assert.Throws<ObscuranceQuery.MissingColliderException>(() => subject.Target = target);
+            NUnit.Framework.Assert.Throws<ObscuranceQuery.MissingColliderException>(() => subject.Target = target);
             Object.DestroyImmediate(target);
         }
 
@@ -197,7 +198,7 @@ namespace Test.Zinnia.Tracking.Query
             GameObject child = new GameObject();
             child.transform.SetParent(target.transform);
 
-            Assert.Throws<ObscuranceQuery.MissingColliderException>(() => subject.Target = target);
+            NUnit.Framework.Assert.Throws<ObscuranceQuery.MissingColliderException>(() => subject.Target = target);
             Object.DestroyImmediate(target);
         }
     }

--- a/Tests/Editor/Tracking/SurfaceLocatorTest.cs
+++ b/Tests/Editor/Tracking/SurfaceLocatorTest.cs
@@ -10,6 +10,7 @@ namespace Test.Zinnia.Tracking
     using NUnit.Framework;
     using Test.Zinnia.Utility.Mock;
     using Test.Zinnia.Utility.Stub;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class SurfaceLocatorTest
     {

--- a/Tests/Editor/Tracking/Velocity/AverageVelocityEstimatorTest.cs
+++ b/Tests/Editor/Tracking/Velocity/AverageVelocityEstimatorTest.cs
@@ -4,6 +4,7 @@ namespace Test.Zinnia.Tracking.Velocity
 {
     using UnityEngine;
     using NUnit.Framework;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class AverageVelocityEstimatorTest
     {

--- a/Tests/Editor/Tracking/Velocity/ComponentTrackerProxyTest.cs
+++ b/Tests/Editor/Tracking/Velocity/ComponentTrackerProxyTest.cs
@@ -5,6 +5,7 @@ namespace Test.Zinnia.Tracking.Velocity
     using UnityEngine;
     using NUnit.Framework;
     using Test.Zinnia.Utility.Mock;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class ComponentTrackerProxyTest
     {

--- a/Tests/Editor/Tracking/Velocity/VelocityApplierTest.cs
+++ b/Tests/Editor/Tracking/Velocity/VelocityApplierTest.cs
@@ -5,6 +5,7 @@ namespace Test.Zinnia.Tracking.Velocity
     using UnityEngine;
     using NUnit.Framework;
     using Test.Zinnia.Utility.Mock;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class VelocityApplierTest
     {

--- a/Tests/Editor/Tracking/Velocity/VelocityEmitterTest.cs
+++ b/Tests/Editor/Tracking/Velocity/VelocityEmitterTest.cs
@@ -5,6 +5,7 @@ namespace Test.Zinnia.Tracking.Velocity
     using UnityEngine;
     using NUnit.Framework;
     using Test.Zinnia.Utility.Mock;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class VelocityEmitterTest
     {

--- a/Tests/Editor/Tracking/Velocity/VelocityMultiplierTest.cs
+++ b/Tests/Editor/Tracking/Velocity/VelocityMultiplierTest.cs
@@ -5,6 +5,7 @@ namespace Test.Zinnia.Tracking.Velocity
     using UnityEngine;
     using NUnit.Framework;
     using Test.Zinnia.Utility.Mock;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class VelocityMultiplierTest
     {

--- a/Tests/Editor/Tracking/Velocity/VelocityTrackerProcessorTest.cs
+++ b/Tests/Editor/Tracking/Velocity/VelocityTrackerProcessorTest.cs
@@ -8,6 +8,7 @@ namespace Test.Zinnia.Tracking.Velocity
     using System.Collections;
     using NUnit.Framework;
     using Test.Zinnia.Utility.Mock;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class VelocityTrackerProcessorTest
     {

--- a/Tests/Editor/Utility/BezierCurveGeneratorTest.cs
+++ b/Tests/Editor/Utility/BezierCurveGeneratorTest.cs
@@ -5,6 +5,7 @@ namespace Test.Zinnia.Utility
 {
     using UnityEngine;
     using NUnit.Framework;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class BezierCurveGeneratorTest
     {

--- a/Tests/Editor/Utility/CountdownTimerTest.cs
+++ b/Tests/Editor/Utility/CountdownTimerTest.cs
@@ -7,6 +7,7 @@ namespace Test.Zinnia.Utility
     using System.Collections;
     using NUnit.Framework;
     using Test.Zinnia.Utility.Mock;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class CountdownTimerTest
     {

--- a/Tests/Editor/Visual/CameraColorOverlayTest.cs
+++ b/Tests/Editor/Visual/CameraColorOverlayTest.cs
@@ -5,6 +5,7 @@ namespace Test.Zinnia.Visual
     using UnityEngine;
     using NUnit.Framework;
     using Test.Zinnia.Utility.Mock;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class CameraColorOverlayTest
     {

--- a/Tests/Editor/Visual/PointsRendererTest.cs
+++ b/Tests/Editor/Visual/PointsRendererTest.cs
@@ -5,6 +5,7 @@ namespace Test.Zinnia.Visual
     using System.Collections.Generic;
     using UnityEngine;
     using NUnit.Framework;
+    using Assert = UnityEngine.Assertions.Assert;
 
     public class PointsRendererTest
     {


### PR DESCRIPTION
NUnit.Framework.Assert.AreEqual(object, object) uses the
implicit operator bool of UnityEngine.Object. So if two different
UnityEngine.Object are tested, AreEqual reports they are the same. #413 