### PR TITLE
fix(Pointers): check hover target collision data in select test

### DIFF
--- a/Tests/Editor/Pointer/ObjectPointerTest.cs
+++ b/Tests/Editor/Pointer/ObjectPointerTest.cs
@@ -814,7 +814,7 @@ namespace Test.Zinnia.Pointer
             Assert.IsTrue(enterListenerMock.Received);
             Assert.IsFalse(exitListenerMock.Received);
             Assert.IsTrue(hoverListenerMock.Received);
-            Assert.AreEqual(blocker.transform, subject.HoverTarget.Transform);
+            Assert.AreEqual(blocker, subject.HoverTarget.CollisionData.transform.gameObject);
 
             enterListenerMock.Reset();
             hoverListenerMock.Reset();


### PR DESCRIPTION
The hover target should be the transform in collision data
Not the hover target transform (which is the object pointer)
#415 