### PR TITLE
feat(Data): remap a float value from a range to another

### DIFF
--- a/Runtime/Data/Type/Transformation/FloatRangeValueRemapper.cs
+++ b/Runtime/Data/Type/Transformation/FloatRangeValueRemapper.cs
@@ -1,0 +1,78 @@
+﻿namespace Zinnia.Data.Type.Transformation
+{
+    using UnityEngine;
+    using UnityEngine.Events;
+    using System;
+    using Malimbe.PropertySerializationAttribute;
+    using Malimbe.XmlDocumentationAttribute;
+
+    /// <summary>
+    /// Transforms a <see cref="float"/> by remapping from a range to a new range.
+    /// </summary>
+    /// <example>
+    /// 2f -> From(0f, 10f), To(0f, 1f), Mode(Lerp) = 0.2f
+    /// 2f -> From(0f, 10f), To(1f, 0f), Mode(Lerp) = 0.8f
+    /// 2f -> From(10f, 0f), To(0f, 1f), Mode(Lerp) = 0.8f
+    /// 2f -> From(10f, 0f), To(1f, 0f), Mode(Lerp) = 0.2f
+    /// 2f -> From(0f, 10f), To(0f, 1f), Mode(SmoothStep) = 0.104f
+    /// </example>
+    public class FloatRangeValueRemapper : Transformer<float, float, FloatRangeValueRemapper.UnityEvent>
+    {
+        /// <summary>
+        /// Defines the event with the remapped <see cref="float"/> value.
+        /// </summary>
+        [Serializable]
+        public class UnityEvent : UnityEvent<float>
+        {
+        }
+
+        /// <summary>
+        /// The range of the value from.
+        /// </summary>
+        [Serialized]
+        [field: DocumentedByXml]
+        public FloatRange From { get; set; } = new FloatRange(0f, 1f);
+
+        /// <summary>
+        /// The range of the value remaps to.
+        /// </summary>
+        [Serialized]
+        [field: DocumentedByXml]
+        public FloatRange To { get; set; } = new FloatRange(0f, 1f);
+
+        /// <summary>
+        /// The mode to use when remapping.
+        /// </summary>
+        public enum OutputMode
+        {
+            /// <summary>
+            /// Linearly interpolates.
+            /// </summary>
+            Lerp,
+            /// <summary>
+            /// Interpolates with smoothing at the limits
+            /// </summary>
+            SmoothStep
+        }
+
+        /// <summary>
+        /// The mode to use when remapping.
+        /// </summary>
+        [Serialized]
+        [field: DocumentedByXml]
+        public OutputMode Mode { get; set; } = OutputMode.Lerp;
+
+        /// <summary>
+        /// Transforms the given <see cref="float"/> by remapping to a new range.
+        /// </summary>
+        /// <param name="input">The value to remap.</param>
+        /// <returns>A new <see cref="float"/> remapped.</returns>
+        protected override float Process(float input)
+        {
+            float t = Mathf.InverseLerp(From.minimum, From.maximum, input);
+            return Mode == OutputMode.Lerp? 
+                Mathf.Lerp(To.minimum, To.maximum, t) : 
+                Mathf.SmoothStep(To.minimum, To.maximum, t);
+        }
+    }
+}

--- a/Runtime/Data/Type/Transformation/FloatRangeValueRemapper.cs.meta
+++ b/Runtime/Data/Type/Transformation/FloatRangeValueRemapper.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 255d660199fa09149924a3d5bac4dfdb
+timeCreated: 1545901103

--- a/Tests/Editor/Data/Type/Transformation/FloatRangeValueRemapperTest.cs
+++ b/Tests/Editor/Data/Type/Transformation/FloatRangeValueRemapperTest.cs
@@ -1,0 +1,71 @@
+﻿using Zinnia.Data.Type;
+using Zinnia.Data.Type.Transformation;
+
+namespace Test.Zinnia.Data.Type.Transformation
+{
+    using NUnit.Framework;
+    using Test.Zinnia.Utility.Mock;
+    using UnityEngine;
+    using Assert = UnityEngine.Assertions.Assert;
+
+    public class FloatRangeValueRemapperTest
+    {
+        private FloatRangeValueRemapper subject;
+
+        [SetUp]
+        public void SetUp()
+        {
+            subject = new GameObject().AddComponent<FloatRangeValueRemapper>();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            Object.DestroyImmediate(subject.gameObject);
+        }
+
+        [Test]
+        public void RemapByLerp()
+        {
+            UnityEventListenerMock transformedListenerMock = new UnityEventListenerMock();
+            subject.Transformed.AddListener(transformedListenerMock.Listen);
+
+            Assert.AreEqual(0f, subject.Result);
+            Assert.IsFalse(transformedListenerMock.Received);
+
+            subject.Mode = FloatRangeValueRemapper.OutputMode.Lerp;
+            subject.From = new FloatRange(0f, 10f);
+            subject.To = new FloatRange(0f, 1f);
+
+            float input = 2f;
+            float t = Mathf.InverseLerp(0, 10f, input);
+            float expected = Mathf.Lerp(0f, 1f, t);
+            float result = subject.Transform(input);
+            Assert.AreEqual(expected, result);
+            Assert.AreEqual(expected, subject.Result);
+            Assert.IsTrue(transformedListenerMock.Received);
+        }
+
+        [Test]
+        public void RemapBySmoothStep()
+        {
+            UnityEventListenerMock transformedListenerMock = new UnityEventListenerMock();
+            subject.Transformed.AddListener(transformedListenerMock.Listen);
+
+            Assert.AreEqual(0f, subject.Result);
+            Assert.IsFalse(transformedListenerMock.Received);
+
+            subject.Mode = FloatRangeValueRemapper.OutputMode.SmoothStep;
+            subject.From = new FloatRange(0f, 10f);
+            subject.To = new FloatRange(0f, 1f);
+
+            float input = 2f;
+            float t = Mathf.InverseLerp(0, 10f, input);
+            float expected = Mathf.SmoothStep(0f, 1f, t);
+            float result = subject.Transform(input);
+            Assert.AreEqual(expected, result);
+            Assert.AreEqual(expected, subject.Result);
+            Assert.IsTrue(transformedListenerMock.Received);
+        }
+    }
+}

--- a/Tests/Editor/Data/Type/Transformation/FloatRangeValueRemapperTest.cs.meta
+++ b/Tests/Editor/Data/Type/Transformation/FloatRangeValueRemapperTest.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: ebb3d17b69ec70d4da9c9f2b77e33053
+timeCreated: 1546141457


### PR DESCRIPTION
The FloatRemapper component allows a float value to be remapped from
a range to another range, with an option to map the output linearly
or smooth step.