### PR TITLE
fix(Action): all/anyAction references destroyed actions

### DIFF
--- a/Runtime/Action/AllAction.cs
+++ b/Runtime/Action/AllAction.cs
@@ -63,7 +63,10 @@
 
             foreach (Action action in Actions.SubscribableElements)
             {
-                action.ActivationStateChanged.RemoveListener(OnActionActivationStateChanged);
+                if (action != null)
+                {
+                    action.ActivationStateChanged.RemoveListener(OnActionActivationStateChanged);
+                }
             }
         }
 

--- a/Runtime/Action/AnyAction.cs
+++ b/Runtime/Action/AnyAction.cs
@@ -63,7 +63,10 @@
 
             foreach (Action action in Actions.SubscribableElements)
             {
-                action.ActivationStateChanged.RemoveListener(OnActionActivationStateChanged);
+                if (action != null)
+                {
+                    action.ActivationStateChanged.RemoveListener(OnActionActivationStateChanged);
+                }
             }
         }
 

--- a/Tests/Editor/Action/AllActionTest.cs
+++ b/Tests/Editor/Action/AllActionTest.cs
@@ -245,6 +245,28 @@ namespace Test.Zinnia.Action
             Assert.IsFalse(deactivatedListenerMock.Received);
             Assert.IsFalse(changedListenerMock.Received);
         }
+
+        [Test]
+        public void RemoveActionListenersCorrectly()
+        {
+            subject.enabled = false;
+
+            GameObject otherObject = new GameObject();
+            MockAction actionA = otherObject.AddComponent<MockAction>();
+            MockAction actionB = otherObject.AddComponent<MockAction>();
+
+            actionA.SetIsActivated(false);
+            actionB.SetIsActivated(false);
+
+            subject.Actions.Add(actionA);
+            subject.Actions.Add(actionB);
+
+            subject.enabled = true;
+
+            Object.DestroyImmediate(otherObject);
+
+            subject.enabled = false;
+        }
     }
 
     public class AllActionMock : ZinniaAction.AllAction

--- a/Tests/Editor/Action/AnyActionTest.cs
+++ b/Tests/Editor/Action/AnyActionTest.cs
@@ -245,6 +245,28 @@ namespace Test.Zinnia.Action
             Assert.IsFalse(deactivatedListenerMock.Received);
             Assert.IsFalse(changedListenerMock.Received);
         }
+
+        [Test]
+        public void RemoveActionListenersCorrectly()
+        {
+            subject.enabled = false;
+
+            GameObject otherObject = new GameObject();
+            MockAction actionA = otherObject.AddComponent<MockAction>();
+            MockAction actionB = otherObject.AddComponent<MockAction>();
+
+            actionA.SetIsActivated(false);
+            actionB.SetIsActivated(false);
+
+            subject.Actions.Add(actionA);
+            subject.Actions.Add(actionB);
+
+            subject.enabled = true;
+
+            Object.DestroyImmediate(otherObject);
+
+            subject.enabled = false;
+        }
     }
 
     public class AnyActionMock : AnyAction


### PR DESCRIPTION
If All/AnyAction references other actions that are destroyed,
it will generate null reference exception when all/any attempts to
remove listeners (when they are disabled or destroyed).