### PR TITLE
fix(Process): restrict SRP support to 2019.1 and above - fixes #424

### DIFF
--- a/Runtime/Process/Moment/MomentProcessor.cs
+++ b/Runtime/Process/Moment/MomentProcessor.cs
@@ -90,10 +90,12 @@
             }
         }
 
+#if UNITY_2019_1_OR_NEWER
         protected virtual void OnSrpCameraPreRender(ScriptableRenderContext context, Camera givenCamera)
         {
             Process();
         }
+#endif
 
         protected virtual void OnCameraPreRender(Camera givenCamera)
         {
@@ -115,7 +117,9 @@
                 case Moment.PreRender:
                     if (GraphicsSettings.renderPipelineAsset != null)
                     {
+#if UNITY_2019_1_OR_NEWER
                         RenderPipelineManager.beginCameraRendering -= OnSrpCameraPreRender;
+#endif
                     }
                     else
                     {
@@ -138,7 +142,11 @@
                 case Moment.PreRender:
                     if (GraphicsSettings.renderPipelineAsset != null)
                     {
+#if UNITY_2019_1_OR_NEWER
                         RenderPipelineManager.beginCameraRendering += OnSrpCameraPreRender;
+#else
+                        Debug.LogWarning("SRP is only supported on Unity 2019.1 or above");
+#endif
                     }
                     else
                     {


### PR DESCRIPTION
A compile error was occurring because Unity 2018 did not support the
SRP related calls outside of an experimental namespace. It's not a good
idea to support experimental Unity solutions so the fix for this
compile error is to just only support SRP on Unity 2019.1 and above as
the required functionality is standard in 2019.1 and above.

A warning will be logged if SRP is used on 2018.