### PR TITLE
fix(Tracking): remove ancestor position when calculating rotation - fixes #429

### DIFF
--- a/Runtime/Tracking/Follow/Modifier/Property/Rotation/TransformPositionDifferenceRotation.cs
+++ b/Runtime/Tracking/Follow/Modifier/Property/Rotation/TransformPositionDifferenceRotation.cs
@@ -1,6 +1,7 @@
 ﻿namespace Zinnia.Tracking.Follow.Modifier.Property.Rotation
 {
     using UnityEngine;
+    using Malimbe.MemberClearanceMethod;
     using Malimbe.XmlDocumentationAttribute;
     using Malimbe.PropertySerializationAttribute;
     using Zinnia.Extension;
@@ -24,6 +25,13 @@
         [Serialized]
         [field: DocumentedByXml]
         public Vector3State FollowOnAxis { get; set; } = Vector3State.True;
+
+        /// <summary>
+        /// An optional <see cref="GameObject"/> that is negated from the calculation if both the source and target are descendants of it.
+        /// </summary>
+        [Serialized, Cleared]
+        [field: DocumentedByXml]
+        public GameObject Ancestor { get; set; }
 
         /// <summary>
         /// The current angular velocity the rotation is applying to the target.
@@ -68,8 +76,9 @@
         /// <returns>The angular velocity to project onto the target.</returns>
         protected virtual Vector3 CalculateAngularVelocity(GameObject source, GameObject target)
         {
-            Vector3 sourcePosition = source.transform.position;
-            Vector3 targetPosition = target.transform.position;
+            Vector3 negatePosition = Ancestor != null ? Ancestor.transform.position : Vector3.zero;
+            Vector3 sourcePosition = source.transform.position - negatePosition;
+            Vector3 targetPosition = target.transform.position - negatePosition;
 
             if (previousSourcePosition == null)
             {

--- a/Tests/Editor/Tracking/Follow/Modifier/Property/Rotation/TransformPositionDifferenceRotationTest.cs
+++ b/Tests/Editor/Tracking/Follow/Modifier/Property/Rotation/TransformPositionDifferenceRotationTest.cs
@@ -48,6 +48,37 @@ namespace Test.Zinnia.Tracking.Follow.Modifier.Property.Rotation
         }
 
         [Test]
+        public void ModifyWithAncestor()
+        {
+            GameObject ancestor = new GameObject();
+            GameObject source = new GameObject();
+            GameObject target = new GameObject();
+
+            ancestor.transform.position = new Vector3(0f, 0f, 0f);
+            source.transform.SetParent(ancestor.transform);
+            target.transform.SetParent(ancestor.transform);
+            subject.Ancestor = ancestor;
+
+            target.transform.position = new Vector3(0f, 0f, 0f);
+            target.transform.localRotation = Quaternion.identity;
+
+            source.transform.position = new Vector3(0.5f, 0f, -0.5f);
+            subject.Modify(source, target);
+            ancestor.transform.position += Vector3.left;
+            source.transform.position = new Vector3(0.5f, 0.5f, -0.5f);
+            subject.Modify(source, target);
+            ancestor.transform.position += Vector3.left;
+            source.transform.position = new Vector3(0.5f, 1f, -0.5f);
+            subject.Modify(source, target);
+
+            Assert.AreEqual(new Quaternion(0.1f, -0.3f, 0.2f, 0.9f).ToString(), target.transform.localRotation.ToString());
+
+            Object.DestroyImmediate(source);
+            Object.DestroyImmediate(target);
+            Object.DestroyImmediate(ancestor);
+        }
+
+        [Test]
         public void ModifyInactiveGameObject()
         {
             GameObject source = new GameObject();


### PR DESCRIPTION
The TransformPositionDifferenceRotation had an issue where if the
source and target GameObjects were descendants of another GameObject
that was also moving, then the source position and previous position
would be further away due to the move in their ancestor GameObject
causing the rotation calculation to be incorrect. This fix provides
the ability to inject the ancestor GameObject to ensure the calculation
is still correct.