### PR TITLE
feat(Attribute): provide custom inspector text for inspector properties - resolves #431

### DIFF
--- a/Editor/Data/Attribute/CustomInspectorTextAttributeDrawer.cs
+++ b/Editor/Data/Attribute/CustomInspectorTextAttributeDrawer.cs
@@ -1,0 +1,14 @@
+﻿namespace Zinnia.Data.Attribute
+{
+    using UnityEngine;
+    using UnityEditor;
+
+    [CustomPropertyDrawer(typeof(CustomInspectorTextAttribute))]
+    public class CustomInspectorTextAttributeDrawer : PropertyDrawer
+    {
+        public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+        {
+            EditorGUI.PropertyField(position, property, new GUIContent(((CustomInspectorTextAttribute)attribute).customText));
+        }
+    }
+}

--- a/Editor/Data/Attribute/CustomInspectorTextAttributeDrawer.cs.meta
+++ b/Editor/Data/Attribute/CustomInspectorTextAttributeDrawer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8a545cfdb29b5ea488476023d5c55673
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Data/Attribute/CustomInspectorTextAttribute.cs
+++ b/Runtime/Data/Attribute/CustomInspectorTextAttribute.cs
@@ -1,0 +1,17 @@
+﻿namespace Zinnia.Data.Attribute
+{
+    using UnityEngine;
+
+    /// <summary>
+    /// Defines the <c>[CustomInspectorText]</c> attribute.
+    /// </summary>
+    public class CustomInspectorTextAttribute : PropertyAttribute
+    {
+        public readonly string customText;
+
+        public CustomInspectorTextAttribute(string customText)
+        {
+            this.customText = customText;
+        }
+    }
+}

--- a/Runtime/Data/Attribute/CustomInspectorTextAttribute.cs.meta
+++ b/Runtime/Data/Attribute/CustomInspectorTextAttribute.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 87428320b8afe6a4aab7f741e29a0974
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
The new CustomInspectorText attribute allows an inspector field to have
custom text instead of Unity using the field/property name for the
inspector text.

This only works with simple fields at the moment and does not work with
nested fields such as the ObservableList Drawer.