### PR TITLE
feat(Velocity): multiply velocity by vector rather than float

### DIFF
--- a/Runtime/Tracking/Velocity/VelocityMultiplier.cs
+++ b/Runtime/Tracking/Velocity/VelocityMultiplier.cs
@@ -21,13 +21,13 @@
         /// </summary>
         [Serialized]
         [field: DocumentedByXml]
-        public float VelocityMultiplierFactor { get; set; } = 1f;
+        public Vector3 VelocityMultiplierFactor { get; set; } = Vector3.one;
         /// <summary>
         /// The amount to multiply the source angular velocity by.
         /// </summary>
         [Serialized]
         [field: DocumentedByXml]
-        public float AngularVelocityMultiplierFactor { get; set; } = 1f;
+        public Vector3 AngularVelocityMultiplierFactor { get; set; } = Vector3.one;
 
         /// <inheritdoc />
         public override bool IsActive()
@@ -36,15 +36,9 @@
         }
 
         /// <inheritdoc />
-        protected override Vector3 DoGetVelocity()
-        {
-            return Source.GetVelocity() * VelocityMultiplierFactor;
-        }
+        protected override Vector3 DoGetVelocity() => Vector3.Scale(Source.GetVelocity(), VelocityMultiplierFactor);
 
         /// <inheritdoc />
-        protected override Vector3 DoGetAngularVelocity()
-        {
-            return Source.GetAngularVelocity() * AngularVelocityMultiplierFactor;
-        }
+        protected override Vector3 DoGetAngularVelocity() => Vector3.Scale(Source.GetAngularVelocity(), AngularVelocityMultiplierFactor);
     }
 }

--- a/Tests/Editor/Tracking/Velocity/VelocityMultiplierTest.cs
+++ b/Tests/Editor/Tracking/Velocity/VelocityMultiplierTest.cs
@@ -31,7 +31,7 @@ namespace Test.Zinnia.Tracking.Velocity
         {
             VelocityTrackerMock tracker = VelocityTrackerMock.Generate(true, Vector3.one, Vector3.one);
             subject.Source = tracker;
-            subject.VelocityMultiplierFactor = 2f;
+            subject.VelocityMultiplierFactor = Vector3.one * 2f;
             Assert.AreEqual(Vector3.one * 2f, subject.GetVelocity());
             Assert.AreEqual(Vector3.one, subject.GetAngularVelocity());
 
@@ -43,7 +43,7 @@ namespace Test.Zinnia.Tracking.Velocity
         {
             VelocityTrackerMock tracker = VelocityTrackerMock.Generate(true, Vector3.one, Vector3.one);
             subject.Source = tracker;
-            subject.AngularVelocityMultiplierFactor = 2f;
+            subject.AngularVelocityMultiplierFactor = Vector3.one * 2f;
             Assert.AreEqual(Vector3.one, subject.GetVelocity());
             Assert.AreEqual(Vector3.one * 2f, subject.GetAngularVelocity());
 
@@ -55,7 +55,7 @@ namespace Test.Zinnia.Tracking.Velocity
         {
             VelocityTrackerMock tracker = VelocityTrackerMock.Generate(true, Vector3.one, Vector3.one);
             subject.Source = tracker;
-            subject.AngularVelocityMultiplierFactor = 2f;
+            subject.AngularVelocityMultiplierFactor = Vector3.one * 2f;
             subject.Source.enabled = false;
             Assert.AreEqual(Vector3.zero, subject.GetVelocity());
             Assert.AreEqual(Vector3.zero, subject.GetAngularVelocity());
@@ -68,7 +68,7 @@ namespace Test.Zinnia.Tracking.Velocity
         {
             VelocityTrackerMock tracker = VelocityTrackerMock.Generate(true, Vector3.one, Vector3.one);
             subject.Source = tracker;
-            subject.AngularVelocityMultiplierFactor = 2f;
+            subject.AngularVelocityMultiplierFactor = Vector3.one * 2f;
             subject.enabled = false;
             Assert.AreEqual(Vector3.zero, subject.GetVelocity());
             Assert.AreEqual(Vector3.zero, subject.GetAngularVelocity());


### PR DESCRIPTION
*Breaking Change*

The VelocityMultiplier only allowed for a float to be multiplied
to the whole velocity vector making the multiplication very linear
and not able to affect different parts of the velocity by different
values.

This has now been changed so the multiplier is actually a Vector3,
meaning it can affect different elements with different multipliers.

This is also useful if a certain velocity axis wants to be removed
by simply multiplying that axis by 0.