### PR TITLE
fix(Attribute): provide custom grey color for restricted muted option - fixes #373

### DIFF
--- a/Editor/Data/Attribute/RestrictedAttributeDrawer.cs
+++ b/Editor/Data/Attribute/RestrictedAttributeDrawer.cs
@@ -27,7 +27,7 @@
                 GUI.enabled = false;
             }
 
-            Color controlColor = Color.grey;
+            Color controlColor = new Color(0.75f, 0.75f, 0.75f);
 
             Color originalGuiColor = GUI.color;
             FontStyle originalFontStyle = EditorStyles.label.fontStyle;


### PR DESCRIPTION
The `[Restricted]` attribute was using a standard `Color.gray` but this
became unreadable when using the Unity professional dark skin. A custom
grey color is now being used which is visible and readable in both the
professional and personal Unity skin.