### PR TITLE
fix(Data): prevent collapsible event drawer from setting scene as dirty - fixes #440

### DIFF
--- a/Editor/Data/Type/CollapsibleUnityEventDrawer.cs
+++ b/Editor/Data/Type/CollapsibleUnityEventDrawer.cs
@@ -63,7 +63,6 @@
             {
                 base.OnGUI(position, property, label);
                 wasBaseOnGuiCalled = true;
-                EditorUtility.SetDirty(property.serializedObject.targetObject);
                 return;
             }
 


### PR DESCRIPTION
The CollapsibleUnityEvent drawer Editor drawer was setting the scene
as dirty on first draw of the component which was then causing an error
in Unity 2019.1 and above when a prefab utilizing the custom drawer
was drawn in the inspector. This is because the prefab cannot be
saved if it is coming from a 3rd party Unity package and attempting
to set the scene as dirty was causing an attempt to save.

There is no reason for this SetDirty to occur as it provides no
required functionality so the line has been removed which should
fix the error it was causing.