### PR TITLE
fix(Data): stop Vector2ToFloatTest extending MonoBehaviour

### DIFF
--- a/Tests/Editor/Data/Type/Transformation/Conversion/Vector2ToFloatTest.cs
+++ b/Tests/Editor/Data/Type/Transformation/Conversion/Vector2ToFloatTest.cs
@@ -7,7 +7,7 @@ namespace Test.Zinnia.Data.Type.Transformation.Conversion
     using Test.Zinnia.Utility.Mock;
     using Assert = UnityEngine.Assertions.Assert;
 
-    public class Vector2ToFloatTest : MonoBehaviour
+    public class Vector2ToFloatTest
     {
         private GameObject containingObject;
         private Vector2ToFloat subject;
@@ -22,8 +22,8 @@ namespace Test.Zinnia.Data.Type.Transformation.Conversion
         [TearDown]
         public void TearDown()
         {
-            DestroyImmediate(subject);
-            DestroyImmediate(containingObject);
+            Object.DestroyImmediate(subject);
+            Object.DestroyImmediate(containingObject);
         }
 
         [Test]


### PR DESCRIPTION
Tests should not need to extend MonoBehaviour and this was causing a
warning to be displayed due to this test extending it. The fix is to
simply prevent the test class from extending MonoBehaviour.