### PR TITLE
Make CompositeProcess derive from MomentProcess directly

### DIFF
--- a/Runtime/Process/Moment/CompositeProcess.cs
+++ b/Runtime/Process/Moment/CompositeProcess.cs
@@ -8,7 +8,7 @@
     /// <summary>
     /// Processes a list of <see cref="MomentProcess"/> as if it's a single <see cref="IProcessable"/> process.
     /// </summary>
-    public class CompositeProcess : MonoBehaviour, IProcessable
+    public class CompositeProcess : MomentProcess
     {
         /// <summary>
         /// A collection of <see cref="MomentProcess"/> to process.


### PR DESCRIPTION
Currently `CompositeProcess` instances cannot be assigned to `MomentProcessObservableList` instances. This change makes `CompositeProcess` derive from `MomentProcess` directly, which allows interoperability with `MomentProcessObservableList` and seems to conveniently work as expected without any breakage from what I could tell.