### PR TITLE
fix(Rule): allow StringInListRule to work in Unity 2018.3

### DIFF
--- a/Runtime/Rule/StringInListRule.cs
+++ b/Runtime/Rule/StringInListRule.cs
@@ -4,6 +4,7 @@
     using System.Text.RegularExpressions;
     using Malimbe.XmlDocumentationAttribute;
     using Malimbe.PropertySerializationAttribute;
+    using Zinnia.Extension;
     using Zinnia.Data.Collection.List;
 
     /// <summary>
@@ -21,7 +22,8 @@
         /// <inheritdoc/>
         protected override bool Accepts(GameObject targetGameObject)
         {
-            if (targetGameObject.TryGetComponent(out StringObservableList list))
+            StringObservableList list = targetGameObject.TryGetComponent<StringObservableList>();
+            if (list != null)
             {
                 foreach (string element in list.NonSubscribableElements)
                 {


### PR DESCRIPTION
The TryGetComponent method being used was not valid in 2018.3 and must
have been introduced in 2019.1.

The fix is to fallback to using the Zinnia.Extension version of the
TryGetComponent method.