### PR TITLE
feat(Action): add method for action to receive its own default value

### DIFF
--- a/Runtime/Action/Action.cs
+++ b/Runtime/Action/Action.cs
@@ -64,6 +64,10 @@
         /// Emits the appropriate event for when the activation state changes from Activated or Deactivated.
         /// </summary>
         public abstract void EmitActivationState();
+        /// <summary>
+        /// Makes the action receive its own default value.
+        /// </summary>
+        public abstract void ReceiveDefaultValue();
 
         /// <summary>
         /// Whether the event should be emitted.
@@ -169,6 +173,13 @@
                 ValueChanged?.Invoke(Value);
                 Deactivated?.Invoke(Value);
             }
+        }
+
+        /// <inheritdoc />
+        [RequiresBehaviourState]
+        public override void ReceiveDefaultValue()
+        {
+            Receive(DefaultValue);
         }
 
         /// <summary>

--- a/Tests/Editor/Action/AllActionTest.cs
+++ b/Tests/Editor/Action/AllActionTest.cs
@@ -292,6 +292,8 @@ namespace Test.Zinnia.Action
 
         public override void EmitActivationState() { }
 
+        public override void ReceiveDefaultValue() { }
+
         public virtual void SetIsActivated(bool value)
         {
             IsActivated = value;

--- a/Tests/Editor/Action/BooleanActionTest.cs
+++ b/Tests/Editor/Action/BooleanActionTest.cs
@@ -73,6 +73,31 @@ namespace Test.Zinnia.Action
         }
 
         [Test]
+        public void DeactivatedEmittedFromReceivingDefaultValue()
+        {
+            subject.SetIsActivated(true);
+            subject.SetValue(true);
+
+            UnityEventListenerMock activatedListenerMock = new UnityEventListenerMock();
+            UnityEventListenerMock deactivatedListenerMock = new UnityEventListenerMock();
+            UnityEventListenerMock changedListenerMock = new UnityEventListenerMock();
+
+            subject.Activated.AddListener(activatedListenerMock.Listen);
+            subject.Deactivated.AddListener(deactivatedListenerMock.Listen);
+            subject.ValueChanged.AddListener(changedListenerMock.Listen);
+
+            Assert.IsFalse(activatedListenerMock.Received);
+            Assert.IsFalse(deactivatedListenerMock.Received);
+            Assert.IsFalse(changedListenerMock.Received);
+
+            subject.ReceiveDefaultValue();
+
+            Assert.IsFalse(activatedListenerMock.Received);
+            Assert.IsTrue(deactivatedListenerMock.Received);
+            Assert.IsTrue(changedListenerMock.Received);
+        }
+
+        [Test]
         public void ChangedEmitted()
         {
             UnityEventListenerMock changedListenerMock = new UnityEventListenerMock();


### PR DESCRIPTION
The new `ReceiveDefaultValue` method is a shortcut for the `Receive`
method but it simply makes the Action receive its own default value.

This can be used to programmatically get an Action to call its own
deactivation event if the Action is already activated without needing
to know the type of the concrete action. This is useful when dealing
with Actions in their generic abstract form but wanting them to
emit their deactivated state for whatever reason, such as a linked
GameObject becoming disabled.