### PR TITLE
fix(Tracking): calculate properties correctly if dynamic destination fix #487

### DIFF
--- a/Runtime/Tracking/Modification/TransformPropertyApplier.cs
+++ b/Runtime/Tracking/Modification/TransformPropertyApplier.cs
@@ -399,9 +399,9 @@
 
                 if (dynamicDestination)
                 {
-                    destinationScale = Source.Scale;
-                    destinationRotation = Source.Rotation;
-                    destinationPosition = Source.Position;
+                    destinationScale = CalculateScale(source, target);
+                    destinationRotation = CalculateRotation(source, target);
+                    destinationPosition = CalculatePosition(source, target, destinationScale, destinationRotation);
                 }
 
                 float lerpFrame = elapsedTime / TransitionDuration;


### PR DESCRIPTION
This fix will calculate properties correctly if IsTransitionDestinationDynamic is true.
Before the fix, it does not honor the ApplyTransformations settings.