### PR TITLE
feat(Data): add KeyNotFound event to GameObjectRelations

### DIFF
--- a/Runtime/Data/Collection/GameObjectRelations.cs
+++ b/Runtime/Data/Collection/GameObjectRelations.cs
@@ -17,7 +17,7 @@
         /// Defines the event for the output <see cref="GameObject"/>.
         /// </summary>
         [Serializable]
-        public class UnityEvent : UnityEvent<GameObject>
+        public class GameObjectUnityEvent : UnityEvent<GameObject>
         {
         }
 
@@ -29,10 +29,15 @@
         public GameObjectRelationObservableList Relations { get; set; }
 
         /// <summary>
-        /// Emitted when a value is retrieved for a given key.
+        /// Emitted when a value is retrieved for a given key or relation index.
         /// </summary>
         [DocumentedByXml]
-        public UnityEvent ValueRetrieved = new UnityEvent();
+        public GameObjectUnityEvent ValueRetrieved = new GameObjectUnityEvent();
+        /// <summary>
+        /// Emitted when a no key can be found the given key or relation index.
+        /// </summary>
+        [DocumentedByXml]
+        public UnityEvent KeyNotFound = new UnityEvent();
 
         /// <summary>
         /// Attempts to get the value in the list of relations for the given key.
@@ -50,6 +55,7 @@
                     return relation.Value;
                 }
             }
+            KeyNotFound?.Invoke();
             return null;
         }
 
@@ -70,6 +76,7 @@
                     return foundValue;
                 }
             }
+            KeyNotFound?.Invoke();
             return null;
         }
 

--- a/Tests/Editor/Data/Collection/GameObjectRelationsTest.cs
+++ b/Tests/Editor/Data/Collection/GameObjectRelationsTest.cs
@@ -30,7 +30,9 @@ namespace Test.Zinnia.Data.Collection
         public void GetValueByKey()
         {
             UnityEventListenerMock valueRetrievedListenerMock = new UnityEventListenerMock();
+            UnityEventListenerMock valueNotFoundListenerMock = new UnityEventListenerMock();
             subject.ValueRetrieved.AddListener(valueRetrievedListenerMock.Listen);
+            subject.KeyNotFound.AddListener(valueNotFoundListenerMock.Listen);
 
             GameObject keyOne = new GameObject();
             GameObject valueOne = new GameObject();
@@ -52,10 +54,12 @@ namespace Test.Zinnia.Data.Collection
             subject.Relations.Add(relationThree);
 
             Assert.IsFalse(valueRetrievedListenerMock.Received);
+            Assert.IsFalse(valueNotFoundListenerMock.Received);
 
             Assert.AreEqual(valueTwo, subject.GetValue(keyTwo));
 
             Assert.IsTrue(valueRetrievedListenerMock.Received);
+            Assert.IsFalse(valueNotFoundListenerMock.Received);
 
             Object.DestroyImmediate(keyOne);
             Object.DestroyImmediate(valueOne);
@@ -69,7 +73,9 @@ namespace Test.Zinnia.Data.Collection
         public void GetValueByKeyNotFound()
         {
             UnityEventListenerMock valueRetrievedListenerMock = new UnityEventListenerMock();
+            UnityEventListenerMock valueNotFoundListenerMock = new UnityEventListenerMock();
             subject.ValueRetrieved.AddListener(valueRetrievedListenerMock.Listen);
+            subject.KeyNotFound.AddListener(valueNotFoundListenerMock.Listen);
 
             GameObject keyOne = new GameObject();
             GameObject valueOne = new GameObject();
@@ -88,10 +94,12 @@ namespace Test.Zinnia.Data.Collection
             subject.Relations.Add(relationThree);
 
             Assert.IsFalse(valueRetrievedListenerMock.Received);
+            Assert.IsFalse(valueNotFoundListenerMock.Received);
 
             Assert.IsNull(subject.GetValue(keyTwo));
 
             Assert.IsFalse(valueRetrievedListenerMock.Received);
+            Assert.IsTrue(valueNotFoundListenerMock.Received);
 
             Object.DestroyImmediate(keyOne);
             Object.DestroyImmediate(valueOne);
@@ -105,7 +113,9 @@ namespace Test.Zinnia.Data.Collection
         public void GetValueByIndex()
         {
             UnityEventListenerMock valueRetrievedListenerMock = new UnityEventListenerMock();
+            UnityEventListenerMock valueNotFoundListenerMock = new UnityEventListenerMock();
             subject.ValueRetrieved.AddListener(valueRetrievedListenerMock.Listen);
+            subject.KeyNotFound.AddListener(valueNotFoundListenerMock.Listen);
 
             GameObject keyOne = new GameObject();
             GameObject valueOne = new GameObject();
@@ -126,10 +136,12 @@ namespace Test.Zinnia.Data.Collection
             subject.Relations.Add(relationThree);
 
             Assert.IsFalse(valueRetrievedListenerMock.Received);
+            Assert.IsFalse(valueNotFoundListenerMock.Received);
 
             Assert.AreEqual(valueTwo, subject.GetValue(1));
 
             Assert.IsTrue(valueRetrievedListenerMock.Received);
+            Assert.IsFalse(valueNotFoundListenerMock.Received);
 
             Object.DestroyImmediate(keyOne);
             Object.DestroyImmediate(valueOne);
@@ -143,7 +155,9 @@ namespace Test.Zinnia.Data.Collection
         public void GetValueByIndexNotFound()
         {
             UnityEventListenerMock valueRetrievedListenerMock = new UnityEventListenerMock();
+            UnityEventListenerMock valueNotFoundListenerMock = new UnityEventListenerMock();
             subject.ValueRetrieved.AddListener(valueRetrievedListenerMock.Listen);
+            subject.KeyNotFound.AddListener(valueNotFoundListenerMock.Listen);
 
             GameObject keyOne = new GameObject();
             GameObject valueOne = new GameObject();
@@ -162,10 +176,72 @@ namespace Test.Zinnia.Data.Collection
             subject.Relations.Add(relationThree);
 
             Assert.IsFalse(valueRetrievedListenerMock.Received);
+            Assert.IsFalse(valueNotFoundListenerMock.Received);
 
             Assert.IsNull(subject.GetValue(2));
 
             Assert.IsFalse(valueRetrievedListenerMock.Received);
+            Assert.IsTrue(valueNotFoundListenerMock.Received);
+
+            Object.DestroyImmediate(keyOne);
+            Object.DestroyImmediate(valueOne);
+            Object.DestroyImmediate(keyTwo);
+            Object.DestroyImmediate(valueTwo);
+            Object.DestroyImmediate(keyThree);
+            Object.DestroyImmediate(valueThree);
+        }
+
+        [Test]
+        public void GetValueByIndexNotFoundEmpty()
+        {
+            UnityEventListenerMock valueRetrievedListenerMock = new UnityEventListenerMock();
+            UnityEventListenerMock valueNotFoundListenerMock = new UnityEventListenerMock();
+            subject.ValueRetrieved.AddListener(valueRetrievedListenerMock.Listen);
+            subject.KeyNotFound.AddListener(valueNotFoundListenerMock.Listen);
+
+            GameObjectRelationObservableList relations = containingObject.AddComponent<GameObjectRelationObservableList>();
+            subject.Relations = relations;
+
+            Assert.IsFalse(valueRetrievedListenerMock.Received);
+            Assert.IsFalse(valueNotFoundListenerMock.Received);
+
+            Assert.IsNull(subject.GetValue(0));
+
+            Assert.IsFalse(valueRetrievedListenerMock.Received);
+            Assert.IsTrue(valueNotFoundListenerMock.Received);
+        }
+
+        [Test]
+        public void GetValueByIndexNotFoundOutOfBoundsIndex()
+        {
+            UnityEventListenerMock valueRetrievedListenerMock = new UnityEventListenerMock();
+            UnityEventListenerMock valueNotFoundListenerMock = new UnityEventListenerMock();
+            subject.ValueRetrieved.AddListener(valueRetrievedListenerMock.Listen);
+            subject.KeyNotFound.AddListener(valueNotFoundListenerMock.Listen);
+
+            GameObject keyOne = new GameObject();
+            GameObject valueOne = new GameObject();
+            GameObject keyTwo = new GameObject();
+            GameObject valueTwo = new GameObject();
+            GameObject keyThree = new GameObject();
+            GameObject valueThree = new GameObject();
+
+            GameObjectRelationObservableList relations = containingObject.AddComponent<GameObjectRelationObservableList>();
+            subject.Relations = relations;
+
+            GameObjectRelationObservableList.Relation relationOne = new GameObjectRelationObservableList.Relation() { Key = keyOne, Value = valueOne };
+            GameObjectRelationObservableList.Relation relationThree = new GameObjectRelationObservableList.Relation() { Key = keyThree, Value = valueThree };
+
+            subject.Relations.Add(relationOne);
+            subject.Relations.Add(relationThree);
+
+            Assert.IsFalse(valueRetrievedListenerMock.Received);
+            Assert.IsFalse(valueNotFoundListenerMock.Received);
+
+            Assert.IsNull(subject.GetValue(5));
+
+            Assert.IsFalse(valueRetrievedListenerMock.Received);
+            Assert.IsTrue(valueNotFoundListenerMock.Received);
 
             Object.DestroyImmediate(keyOne);
             Object.DestroyImmediate(valueOne);


### PR DESCRIPTION
The KeyNotFound event is raised whenever the GetValue method on the
GameObjectRelations component is called but no key can be matched
because either the key is not in the dictionary or the index given
is out of bounds of the collection.