### PR TITLE
fix(Extraction): remove Cleared attribute from ValueExtractor.Source - fixes #498

### DIFF
--- a/Runtime/Data/Operation/Extraction/ValueExtractor.cs
+++ b/Runtime/Data/Operation/Extraction/ValueExtractor.cs
@@ -20,7 +20,7 @@
         /// <summary>
         /// The source to extract from.
         /// </summary>
-        [Serialized, Cleared]
+        [Serialized]
         [field: DocumentedByXml]
         public TSourceElement Source { get; set; }
 


### PR DESCRIPTION
The Source property from the ValueExtractor is of a generic type and
if the Cleared attribute is used then Malimbe will always weave an
auto generated Clear method that attempts to set the property to null
and this will cause issues in IL2CPP when attempting to clear non
nullable types such as RaycastHit.

As there is a manual ClearSource method already that sets Source to
`default` then this `Cleared` attribute can simply be removed.