### PR TITLE
feat(Extraction): add extractors for ObjectFollower.EventData

### DIFF
--- a/Runtime/Process/Moment/MomentProcessor.cs
+++ b/Runtime/Process/Moment/MomentProcessor.cs
@@ -41,7 +41,11 @@
             /// <summary>
             /// Executes the processes in the camera PreRender scene rendering part of the Unity game loop.
             /// </summary>
-            PreRender
+            PreRender,
+            /// <summary>
+            /// Executes the processes in the Application BeforeRender scene rendering part of the Unity game loop.
+            /// </summary>
+            BeforeRender
         }
 
         /// <summary>
@@ -117,6 +121,11 @@
             Process();
         }
 
+        protected virtual void OnApplicationBeforeRender()
+        {
+            Process();
+        }
+
         /// <summary>
         /// Handles unsubscribing to the chosen subscribed moment event.
         /// </summary>
@@ -138,6 +147,9 @@
                     break;
                 case Moment.PreCull:
                     Camera.onPreCull -= OnCameraPreCull;
+                    break;
+                case Moment.BeforeRender:
+                    Application.onBeforeRender -= OnApplicationBeforeRender;
                     break;
             }
         }
@@ -165,6 +177,9 @@
                     break;
                 case Moment.PreCull:
                     Camera.onPreCull += OnCameraPreCull;
+                    break;
+                case Moment.BeforeRender:
+                    Application.onBeforeRender += OnApplicationBeforeRender;
                     break;
             }
         }

--- a/Runtime/Tracking/Follow/Modifier/Property/DivergablePropertyModifier.cs
+++ b/Runtime/Tracking/Follow/Modifier/Property/DivergablePropertyModifier.cs
@@ -72,6 +72,24 @@
         }
 
         /// <summary>
+        /// Manually remove a source and target from the diverged state.
+        /// </summary>
+        /// <param name="source">The source to diverge from.</param>
+        /// <param name="target">The target that has diverged.</param>
+        public virtual void RemoveFromDiverged(GameObject source, GameObject target)
+        {
+            divergedStates.Remove(GenerateIdentifier(source, target));
+        }
+
+        /// <summary>
+        /// Clears the diverged states of all diverging source/targets.
+        /// </summary>
+        public virtual void ClearDiverged()
+        {
+            divergedStates.Clear();
+        }
+
+        /// <summary>
         /// Whether the given source and target are diverged.
         /// </summary>
         /// <param name="source">The source to check against.</param>

--- a/Runtime/Tracking/Follow/Operation/Extraction/ObjectFollowerEventDataSourceExtractor.cs
+++ b/Runtime/Tracking/Follow/Operation/Extraction/ObjectFollowerEventDataSourceExtractor.cs
@@ -1,0 +1,25 @@
+﻿namespace Zinnia.Tracking.Follow.Operation.Extraction
+{
+    using System;
+    using UnityEngine;
+    using UnityEngine.Events;
+    using Zinnia.Data.Operation.Extraction;
+
+    /// <summary>
+    /// Extracts the <see cref="GameObject"/> of the EventSource from a given <see cref="ObjectFollower.EventData"/>.
+    /// </summary>
+    public class ObjectFollowerEventDataSourceExtractor : GameObjectExtractor<ObjectFollower.EventData, ObjectFollowerEventDataSourceExtractor.UnityEvent>
+    {
+        /// <summary>
+        /// Defines the event with the specified <see cref="GameObject"/>.
+        /// </summary>
+        [Serializable]
+        public class UnityEvent : UnityEvent<GameObject> { }
+
+        /// <inheritdoc />
+        protected override GameObject ExtractValue()
+        {
+            return Source != null ? Source.EventSource : null;
+        }
+    }
+}

--- a/Runtime/Tracking/Follow/Operation/Extraction/ObjectFollowerEventDataSourceExtractor.cs.meta
+++ b/Runtime/Tracking/Follow/Operation/Extraction/ObjectFollowerEventDataSourceExtractor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6b31f042fa4c9c149b1603dc2fefc2bb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Tracking/Follow/Operation/Extraction/ObjectFollowerEventDataTargetExtractor.cs
+++ b/Runtime/Tracking/Follow/Operation/Extraction/ObjectFollowerEventDataTargetExtractor.cs
@@ -1,0 +1,25 @@
+﻿namespace Zinnia.Tracking.Follow.Operation.Extraction
+{
+    using System;
+    using UnityEngine;
+    using UnityEngine.Events;
+    using Zinnia.Data.Operation.Extraction;
+
+    /// <summary>
+    /// Extracts the <see cref="GameObject"/> of the EventTarget from a given <see cref="ObjectFollower.EventData"/>.
+    /// </summary>
+    public class ObjectFollowerEventDataTargetExtractor : GameObjectExtractor<ObjectFollower.EventData, ObjectFollowerEventDataTargetExtractor.UnityEvent>
+    {
+        /// <summary>
+        /// Defines the event with the specified <see cref="GameObject"/>.
+        /// </summary>
+        [Serializable]
+        public class UnityEvent : UnityEvent<GameObject> { }
+
+        /// <inheritdoc />
+        protected override GameObject ExtractValue()
+        {
+            return Source != null ? Source.EventTarget : null;
+        }
+    }
+}

--- a/Runtime/Tracking/Follow/Operation/Extraction/ObjectFollowerEventDataTargetExtractor.cs.meta
+++ b/Runtime/Tracking/Follow/Operation/Extraction/ObjectFollowerEventDataTargetExtractor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 796cf102627c38b4bbc8567c5b814647
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Tracking/Follow/Operation/Extraction/ObjectFollowerEventDataTargetOffsetExtractor.cs
+++ b/Runtime/Tracking/Follow/Operation/Extraction/ObjectFollowerEventDataTargetOffsetExtractor.cs
@@ -1,0 +1,25 @@
+﻿namespace Zinnia.Tracking.Follow.Operation.Extraction
+{
+    using System;
+    using UnityEngine;
+    using UnityEngine.Events;
+    using Zinnia.Data.Operation.Extraction;
+
+    /// <summary>
+    /// Extracts the <see cref="GameObject"/> of the EventTargetOffset from a given <see cref="ObjectFollower.EventData"/>.
+    /// </summary>
+    public class ObjectFollowerEventDataTargetOffsetExtractor : GameObjectExtractor<ObjectFollower.EventData, ObjectFollowerEventDataTargetOffsetExtractor.UnityEvent>
+    {
+        /// <summary>
+        /// Defines the event with the specified <see cref="GameObject"/>.
+        /// </summary>
+        [Serializable]
+        public class UnityEvent : UnityEvent<GameObject> { }
+
+        /// <inheritdoc />
+        protected override GameObject ExtractValue()
+        {
+            return Source != null ? Source.EventTargetOffset : null;
+        }
+    }
+}

--- a/Runtime/Tracking/Follow/Operation/Extraction/ObjectFollowerEventDataTargetOffsetExtractor.cs.meta
+++ b/Runtime/Tracking/Follow/Operation/Extraction/ObjectFollowerEventDataTargetOffsetExtractor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 076299891aaf54f47a23955e6a37bf31
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Tracking/Velocity/XRNodeVelocityEstimator.cs
+++ b/Runtime/Tracking/Velocity/XRNodeVelocityEstimator.cs
@@ -1,5 +1,6 @@
 ﻿namespace Zinnia.Tracking.Velocity
 {
+    using Malimbe.MemberClearanceMethod;
     using Malimbe.PropertySerializationAttribute;
     using Malimbe.XmlDocumentationAttribute;
     using System.Collections.Generic;
@@ -19,6 +20,13 @@
         public XRNode Node { get; set; } = XRNode.LeftHand;
 
         /// <summary>
+        /// An optional object to consider the source relative to when estimating the velocities.
+        /// </summary>
+        [Serialized, Cleared]
+        [field: DocumentedByXml]
+        public GameObject RelativeTo { get; set; }
+
+        /// <summary>
         /// A collection of node states.
         /// </summary>
         protected readonly List<XRNodeState> nodesStates = new List<XRNodeState>();
@@ -27,6 +35,7 @@
         protected override Vector3 DoGetVelocity()
         {
             GetNodeState().TryGetVelocity(out Vector3 result);
+            result = (RelativeTo != null ? RelativeTo.transform.rotation : Quaternion.identity) * result;
             return result;
         }
 
@@ -34,6 +43,8 @@
         protected override Vector3 DoGetAngularVelocity()
         {
             GetNodeState().TryGetAngularVelocity(out Vector3 result);
+            GetNodeState().TryGetRotation(out Quaternion rotation);
+            result = (RelativeTo != null ? RelativeTo.transform.rotation : Quaternion.identity) * rotation * result;
             return result;
         }
 

--- a/Tests/Editor/Tracking/Follow/Operation/Extraction/ObjectFollowerEventDataSourceExtractorTest.cs
+++ b/Tests/Editor/Tracking/Follow/Operation/Extraction/ObjectFollowerEventDataSourceExtractorTest.cs
@@ -1,0 +1,53 @@
+﻿using Zinnia.Tracking.Follow;
+using Zinnia.Tracking.Follow.Operation.Extraction;
+
+namespace Test.Zinnia.Tracking.Follow.Operation.Extraction
+{
+    using NUnit.Framework;
+    using Test.Zinnia.Utility.Mock;
+    using UnityEngine;
+    using Assert = UnityEngine.Assertions.Assert;
+
+    public class ObjectFollowerEventDataSourceExtractorTest
+    {
+        private GameObject containingObject;
+        private ObjectFollowerEventDataSourceExtractor subject;
+
+        [SetUp]
+        public void SetUp()
+        {
+            containingObject = new GameObject();
+            subject = containingObject.AddComponent<ObjectFollowerEventDataSourceExtractor>();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            Object.DestroyImmediate(containingObject);
+        }
+
+        [Test]
+        public void Extract()
+        {
+            GameObject source = new GameObject();
+
+            UnityEventListenerMock extractedMock = new UnityEventListenerMock();
+            subject.Extracted.AddListener(extractedMock.Listen);
+
+            ObjectFollower.EventData eventData = new ObjectFollower.EventData
+            {
+                EventSource = source
+            };
+
+            Assert.IsFalse(extractedMock.Received);
+            Assert.IsNull(subject.Result);
+
+            subject.Extract(eventData);
+
+            Assert.IsTrue(extractedMock.Received);
+            Assert.AreEqual(subject.Result, source);
+
+            Object.DestroyImmediate(source);
+        }
+    }
+}

--- a/Tests/Editor/Tracking/Follow/Operation/Extraction/ObjectFollowerEventDataSourceExtractorTest.cs.meta
+++ b/Tests/Editor/Tracking/Follow/Operation/Extraction/ObjectFollowerEventDataSourceExtractorTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: abe57126e4ba2fe4f885883338e33997
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Editor/Tracking/Follow/Operation/Extraction/ObjectFollowerEventDataTargetExtractorTest.cs
+++ b/Tests/Editor/Tracking/Follow/Operation/Extraction/ObjectFollowerEventDataTargetExtractorTest.cs
@@ -1,0 +1,53 @@
+﻿using Zinnia.Tracking.Follow;
+using Zinnia.Tracking.Follow.Operation.Extraction;
+
+namespace Test.Zinnia.Tracking.Follow.Operation.Extraction
+{
+    using NUnit.Framework;
+    using Test.Zinnia.Utility.Mock;
+    using UnityEngine;
+    using Assert = UnityEngine.Assertions.Assert;
+
+    public class ObjectFollowerEventDataTargetExtractorTest
+    {
+        private GameObject containingObject;
+        private ObjectFollowerEventDataTargetExtractor subject;
+
+        [SetUp]
+        public void SetUp()
+        {
+            containingObject = new GameObject();
+            subject = containingObject.AddComponent<ObjectFollowerEventDataTargetExtractor>();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            Object.DestroyImmediate(containingObject);
+        }
+
+        [Test]
+        public void Extract()
+        {
+            GameObject source = new GameObject();
+
+            UnityEventListenerMock extractedMock = new UnityEventListenerMock();
+            subject.Extracted.AddListener(extractedMock.Listen);
+
+            ObjectFollower.EventData eventData = new ObjectFollower.EventData
+            {
+                EventTarget = source
+            };
+
+            Assert.IsFalse(extractedMock.Received);
+            Assert.IsNull(subject.Result);
+
+            subject.Extract(eventData);
+
+            Assert.IsTrue(extractedMock.Received);
+            Assert.AreEqual(subject.Result, source);
+
+            Object.DestroyImmediate(source);
+        }
+    }
+}

--- a/Tests/Editor/Tracking/Follow/Operation/Extraction/ObjectFollowerEventDataTargetExtractorTest.cs.meta
+++ b/Tests/Editor/Tracking/Follow/Operation/Extraction/ObjectFollowerEventDataTargetExtractorTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e134007c49366aa4eaaec34cc3ddbfa6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Editor/Tracking/Follow/Operation/Extraction/ObjectFollowerEventDataTargetOffsetExtractorTest.cs
+++ b/Tests/Editor/Tracking/Follow/Operation/Extraction/ObjectFollowerEventDataTargetOffsetExtractorTest.cs
@@ -1,0 +1,53 @@
+﻿using Zinnia.Tracking.Follow;
+using Zinnia.Tracking.Follow.Operation.Extraction;
+
+namespace Test.Zinnia.Tracking.Follow.Operation.Extraction
+{
+    using NUnit.Framework;
+    using Test.Zinnia.Utility.Mock;
+    using UnityEngine;
+    using Assert = UnityEngine.Assertions.Assert;
+
+    public class ObjectFollowerEventDataTargetOffsetExtractorTest
+    {
+        private GameObject containingObject;
+        private ObjectFollowerEventDataTargetOffsetExtractor subject;
+
+        [SetUp]
+        public void SetUp()
+        {
+            containingObject = new GameObject();
+            subject = containingObject.AddComponent<ObjectFollowerEventDataTargetOffsetExtractor>();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            Object.DestroyImmediate(containingObject);
+        }
+
+        [Test]
+        public void Extract()
+        {
+            GameObject source = new GameObject();
+
+            UnityEventListenerMock extractedMock = new UnityEventListenerMock();
+            subject.Extracted.AddListener(extractedMock.Listen);
+
+            ObjectFollower.EventData eventData = new ObjectFollower.EventData
+            {
+                EventTargetOffset = source
+            };
+
+            Assert.IsFalse(extractedMock.Received);
+            Assert.IsNull(subject.Result);
+
+            subject.Extract(eventData);
+
+            Assert.IsTrue(extractedMock.Received);
+            Assert.AreEqual(subject.Result, source);
+
+            Object.DestroyImmediate(source);
+        }
+    }
+}

--- a/Tests/Editor/Tracking/Follow/Operation/Extraction/ObjectFollowerEventDataTargetOffsetExtractorTest.cs.meta
+++ b/Tests/Editor/Tracking/Follow/Operation/Extraction/ObjectFollowerEventDataTargetOffsetExtractorTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e5bab2670a8a8bd4aac35953ddbbce32
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
A collection of extractors that can extract specific data from
the ObjectFollower.EventData.

For example, an Interactable is using Follow Rigidbody.
When it is diverged, the event data can be feed into the
FollowerSourceExtractor to get the grabbing interactor.