### PR TITLE
feat(Tracking): add container for successful published consumers

### DIFF
--- a/Runtime/Tracking/Collision/Active/ActiveCollisionRegisteredConsumerContainer.cs
+++ b/Runtime/Tracking/Collision/Active/ActiveCollisionRegisteredConsumerContainer.cs
@@ -1,0 +1,171 @@
+﻿namespace Zinnia.Tracking.Collision.Active
+{
+    using Malimbe.BehaviourStateRequirementMethod;
+    using Malimbe.MemberClearanceMethod;
+    using Malimbe.PropertySerializationAttribute;
+    using Malimbe.XmlDocumentationAttribute;
+    using System;
+    using System.Collections.Generic;
+    using UnityEngine;
+    using UnityEngine.Events;
+
+    /// <summary>
+    /// Holds a <see cref="ActiveCollisionConsumer"/> collection of consumers that have successfully been published to by a <see cref="ActiveCollisionPublisher"/>.
+    /// </summary>
+    public class ActiveCollisionRegisteredConsumerContainer : MonoBehaviour
+    {
+        /// <summary>
+        /// Holds data about a <see cref="ActiveCollisionRegisteredConsumerContainer"/> payload.
+        /// </summary>
+        [Serializable]
+        public class EventData
+        {
+            /// <summary>
+            /// The registered <see cref="ActiveCollisionConsumer"/>.
+            /// </summary>
+            [Serialized, Cleared]
+            [field: DocumentedByXml]
+            public ActiveCollisionConsumer Consumer { get; set; }
+
+            /// <summary>
+            /// The payload data sent to the <see cref="ActiveCollisionConsumer"/>.
+            /// </summary>
+            [Serialized, Cleared]
+            [field: DocumentedByXml]
+            public ActiveCollisionPublisher.PayloadData Payload { get; set; }
+
+            public EventData Set(EventData source)
+            {
+                return Set(source.Consumer, source.Payload);
+            }
+
+            public EventData Set(ActiveCollisionConsumer consumer, ActiveCollisionPublisher.PayloadData payload)
+            {
+                Consumer = consumer;
+                Payload = payload;
+                return this;
+            }
+
+            public void Clear()
+            {
+                Set(default, default);
+            }
+        }
+
+        /// <summary>
+        /// Defines the event for the output <see cref="EventData"/>.
+        /// </summary>
+        [Serializable]
+        public class UnityEvent : UnityEvent<EventData> { }
+
+        /// <summary>
+        /// Emitted when each registered consumer payload data is published.
+        /// </summary>
+        [DocumentedByXml]
+        public ActiveCollisionPublisher.UnityEvent Published = new ActiveCollisionPublisher.UnityEvent();
+        /// <summary>
+        /// Emitted when a consumer is registered.
+        /// </summary>
+        [DocumentedByXml]
+        public UnityEvent Registered = new UnityEvent();
+        /// <summary>
+        /// Emitted when a consumer is unregistered.
+        /// </summary>
+        [DocumentedByXml]
+        public UnityEvent Unregistered = new UnityEvent();
+
+        /// <summary>
+        /// A collection of registered consumers to ignore when publishing.
+        /// </summary>
+        public List<ActiveCollisionConsumer> IgnoredRegisteredConsumers { get; set; } = new List<ActiveCollisionConsumer>();
+        /// <summary>
+        /// The consumers that have successfully consumed the published payload from the <see cref="ActiveCollisionPublisher"/> linked to this.
+        /// </summary>
+        public Dictionary<ActiveCollisionConsumer, ActiveCollisionPublisher.PayloadData> RegisteredConsumers { get; protected set; } = new Dictionary<ActiveCollisionConsumer, ActiveCollisionPublisher.PayloadData>();
+
+        /// <summary>
+        /// The event data emitted when collisions are consumed.
+        /// </summary>
+        protected readonly EventData eventData = new EventData();
+
+        /// <summary>
+        /// Publishes the registered <see cref="ActiveCollisionConsumer"/> components as the component is active and enabled.
+        /// Any <see cref="ActiveCollisionConsumer"/> that is in the <see cref="IgnoredRegisteredConsumers"/> will not be published to and the <see cref="IgnoredRegisteredConsumers"/> collection is cleared at the end of the <see cref="Publish"/> operation.
+        /// </summary>
+        [RequiresBehaviourState]
+        public virtual void Publish()
+        {
+            foreach (ActiveCollisionConsumer registeredConsumer in new List<ActiveCollisionConsumer>(RegisteredConsumers.Keys))
+            {
+                if (IgnoredRegisteredConsumers.Contains(registeredConsumer))
+                {
+                    continue;
+                }
+
+                if (RegisteredConsumers.TryGetValue(registeredConsumer, out ActiveCollisionPublisher.PayloadData payload))
+                {
+                    registeredConsumer.Consume(payload, registeredConsumer.ActiveCollision);
+                    Published?.Invoke(payload);
+                }
+            }
+
+            ClearIgnoredRegisteredConsumers();
+        }
+
+        /// <summary>
+        /// Registers an <see cref="ActiveCollisionConsumer"/>.
+        /// </summary>
+        /// <param name="consumer">The consumer to register.</param>
+        /// <param name="payload">The payload that the consumer successfully consumed.</param>
+        [RequiresBehaviourState]
+        public virtual void Register(ActiveCollisionConsumer consumer, ActiveCollisionPublisher.PayloadData payload)
+        {
+            if (consumer == null)
+            {
+                return;
+            }
+
+            RegisteredConsumers[consumer] = payload;
+            Registered?.Invoke(eventData.Set(consumer, payload));
+        }
+
+        /// <summary>
+        /// Unregisters an <see cref="ActiveCollisionConsumer"/>.
+        /// </summary>
+        /// <param name="consumer">The consumer to unregister.</param>
+        public virtual void Unregister(ActiveCollisionConsumer consumer)
+        {
+            if (consumer == null)
+            {
+                return;
+            }
+
+            RegisteredConsumers.Remove(consumer);
+            IgnoredRegisteredConsumers.Remove(consumer);
+            Unregistered?.Invoke(eventData.Set(consumer, null));
+        }
+
+        /// <summary>
+        /// Unregisters all <see cref="ActiveCollisionConsumer"/> components that exist on the given container.
+        /// </summary>
+        /// <param name="container">The container to unregister the consumers from.</param>
+        public virtual void UnregisterConsumersOnContainer(GameObject container)
+        {
+            foreach (ActiveCollisionConsumer registeredConsumer in new List<ActiveCollisionConsumer>(RegisteredConsumers.Keys))
+            {
+                if (registeredConsumer.ConsumerContainer == container)
+                {
+                    Unregister(registeredConsumer);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Clears the <see cref="IgnoredRegisteredConsumers"/> collection.
+        /// </summary>
+        public virtual void ClearIgnoredRegisteredConsumers()
+        {
+            IgnoredRegisteredConsumers.Clear();
+        }
+    }
+}

--- a/Runtime/Tracking/Collision/Active/ActiveCollisionRegisteredConsumerContainer.cs.meta
+++ b/Runtime/Tracking/Collision/Active/ActiveCollisionRegisteredConsumerContainer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a20ec747ef705634eb66c008baf3756a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Tracking/Collision/Active/Event/Proxy/ActiveCollisionPublisherEventProxyEmitter.cs
+++ b/Runtime/Tracking/Collision/Active/Event/Proxy/ActiveCollisionPublisherEventProxyEmitter.cs
@@ -1,0 +1,19 @@
+﻿namespace Zinnia.Tracking.Collision.Active.Event.Proxy
+{
+    using System;
+    using UnityEngine.Events;
+    using Zinnia.Event.Proxy;
+    using Zinnia.Tracking.Collision.Active;
+
+    /// <summary>
+    /// Emits a UnityEvent with a <see cref="ActiveCollisionPublisher.PayloadData"/> payload whenever the Receive method is called.
+    /// </summary>
+    public class ActiveCollisionPublisherEventProxyEmitter : SingleEventProxyEmitter<ActiveCollisionPublisher.PayloadData, ActiveCollisionPublisherEventProxyEmitter.UnityEvent>
+    {
+        /// <summary>
+        /// Defines the event with the specified state.
+        /// </summary>
+        [Serializable]
+        public class UnityEvent : UnityEvent<ActiveCollisionPublisher.PayloadData> { }
+    }
+}

--- a/Runtime/Tracking/Collision/Active/Event/Proxy/ActiveCollisionPublisherEventProxyEmitter.cs.meta
+++ b/Runtime/Tracking/Collision/Active/Event/Proxy/ActiveCollisionPublisherEventProxyEmitter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8412c34d9c8857447b7b5365b051d32b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Tracking/Collision/Active/Event/Proxy/ActiveCollisionRegisteredConsumerContainerEventProxyEmitter.cs
+++ b/Runtime/Tracking/Collision/Active/Event/Proxy/ActiveCollisionRegisteredConsumerContainerEventProxyEmitter.cs
@@ -1,0 +1,19 @@
+﻿namespace Zinnia.Tracking.Collision.Active.Event.Proxy
+{
+    using System;
+    using UnityEngine.Events;
+    using Zinnia.Event.Proxy;
+    using Zinnia.Tracking.Collision.Active;
+
+    /// <summary>
+    /// Emits a UnityEvent with a <see cref="ActiveCollisionRegisteredConsumerContainer.EventData"/> payload whenever the Receive method is called.
+    /// </summary>
+    public class ActiveCollisionRegisteredConsumerContainerEventProxyEmitter : SingleEventProxyEmitter<ActiveCollisionRegisteredConsumerContainer.EventData, ActiveCollisionRegisteredConsumerContainerEventProxyEmitter.UnityEvent>
+    {
+        /// <summary>
+        /// Defines the event with the specified state.
+        /// </summary>
+        [Serializable]
+        public class UnityEvent : UnityEvent<ActiveCollisionRegisteredConsumerContainer.EventData> { }
+    }
+}

--- a/Runtime/Tracking/Collision/Active/Event/Proxy/ActiveCollisionRegisteredConsumerContainerEventProxyEmitter.cs.meta
+++ b/Runtime/Tracking/Collision/Active/Event/Proxy/ActiveCollisionRegisteredConsumerContainerEventProxyEmitter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: af51cfa287886ef4c929d698dc7d712e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Editor/Tracking/Collision/Active/ActiveCollisionConsumerMock.cs
+++ b/Tests/Editor/Tracking/Collision/Active/ActiveCollisionConsumerMock.cs
@@ -1,0 +1,29 @@
+﻿using Zinnia.Tracking.Collision;
+using Zinnia.Tracking.Collision.Active;
+
+namespace Test.Zinnia.Tracking.Collision.Active
+{
+    using UnityEngine;
+
+    [AddComponentMenu("")]
+    public class ActiveCollisionConsumerMock : ActiveCollisionConsumer
+    {
+        public bool received;
+
+        public override bool Consume(ActiveCollisionPublisher.PayloadData publisher, CollisionNotifier.EventData currentCollision)
+        {
+            received = false;
+            if (isActiveAndEnabled)
+            {
+                received = true;
+            }
+
+            return received;
+        }
+
+        public virtual void SetConsumerContainer(GameObject container)
+        {
+            ConsumerContainer = container;
+        }
+    }
+}

--- a/Tests/Editor/Tracking/Collision/Active/ActiveCollisionConsumerMock.cs.meta
+++ b/Tests/Editor/Tracking/Collision/Active/ActiveCollisionConsumerMock.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6bac43b81db52134f98a8cb25ed3f0ac
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Editor/Tracking/Collision/Active/ActiveCollisionConsumerTest.cs
+++ b/Tests/Editor/Tracking/Collision/Active/ActiveCollisionConsumerTest.cs
@@ -49,7 +49,7 @@ namespace Test.Zinnia.Tracking.Collision.Active
 
             Assert.IsNull(subject.PublisherSource);
 
-            subject.Consume(publisher, null);
+            Assert.IsTrue(subject.Consume(publisher, null));
 
             Assert.IsTrue(consumedMock.Received);
             Assert.IsFalse(clearedMock.Received);
@@ -95,7 +95,7 @@ namespace Test.Zinnia.Tracking.Collision.Active
 
             Assert.IsNull(subject.PublisherSource);
 
-            subject.Consume(publisher, null);
+            Assert.IsFalse(subject.Consume(publisher, null));
 
             Assert.IsFalse(consumedMock.Received);
             Assert.IsFalse(clearedMock.Received);
@@ -119,7 +119,7 @@ namespace Test.Zinnia.Tracking.Collision.Active
             publisher.SourceContainer = publisherObject;
 
             subject.gameObject.SetActive(false);
-            subject.Consume(publisher, null);
+            Assert.IsFalse(subject.Consume(publisher, null));
 
             Assert.IsFalse(consumedMock.Received);
             Assert.IsFalse(clearedMock.Received);
@@ -143,7 +143,7 @@ namespace Test.Zinnia.Tracking.Collision.Active
             publisher.SourceContainer = publisherObject;
 
             subject.enabled = false;
-            subject.Consume(publisher, null);
+            Assert.IsFalse(subject.Consume(publisher, null));
 
             Assert.IsFalse(consumedMock.Received);
             Assert.IsFalse(clearedMock.Received);

--- a/Tests/Editor/Tracking/Collision/Active/ActiveCollisionRegisteredConsumerContainerTest.cs
+++ b/Tests/Editor/Tracking/Collision/Active/ActiveCollisionRegisteredConsumerContainerTest.cs
@@ -1,0 +1,335 @@
+﻿using Zinnia.Tracking.Collision;
+using Zinnia.Tracking.Collision.Active;
+
+namespace Test.Zinnia.Tracking.Collision.Active
+{
+    using NUnit.Framework;
+    using Test.Zinnia.Utility.Helper;
+    using Test.Zinnia.Utility.Mock;
+    using UnityEngine;
+    using Assert = UnityEngine.Assertions.Assert;
+
+    public class ActiveCollisionRegisteredConsumerContainerTest
+    {
+        private GameObject containingObject;
+        private ActiveCollisionRegisteredConsumerContainer subject;
+
+        [SetUp]
+        public void SetUp()
+        {
+            containingObject = new GameObject();
+            subject = containingObject.AddComponent<ActiveCollisionRegisteredConsumerContainer>();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            Object.DestroyImmediate(subject);
+            Object.DestroyImmediate(containingObject);
+        }
+
+        [Test]
+        public void RegisterAndPublish()
+        {
+            UnityEventListenerMock registeredMock = new UnityEventListenerMock();
+            UnityEventListenerMock publishedMock = new UnityEventListenerMock();
+
+            subject.Registered.AddListener(registeredMock.Listen);
+            subject.Published.AddListener(publishedMock.Listen);
+
+            ActiveCollisionConsumerMock oneConsumer = containingObject.AddComponent<ActiveCollisionConsumerMock>();
+
+            Assert.IsFalse(registeredMock.Received);
+            Assert.AreEqual(0, subject.RegisteredConsumers.Count);
+
+            subject.Register(oneConsumer, null);
+
+            Assert.IsTrue(registeredMock.Received);
+            Assert.AreEqual(1, subject.RegisteredConsumers.Count);
+
+            registeredMock.Reset();
+
+            ActiveCollisionConsumerMock twoConsumer = containingObject.AddComponent<ActiveCollisionConsumerMock>();
+
+            subject.Register(twoConsumer, null);
+
+            Assert.IsTrue(registeredMock.Received);
+            Assert.AreEqual(2, subject.RegisteredConsumers.Count);
+
+            registeredMock.Reset();
+
+            Assert.IsFalse(oneConsumer.received);
+            Assert.IsFalse(twoConsumer.received);
+            Assert.IsFalse(publishedMock.Received);
+
+            subject.Publish();
+
+            Assert.IsTrue(publishedMock.Received);
+            Assert.IsTrue(oneConsumer.received);
+            Assert.IsTrue(twoConsumer.received);
+        }
+
+        [Test]
+        public void RegisterAndPublishWithIgnored()
+        {
+            UnityEventListenerMock registeredMock = new UnityEventListenerMock();
+            UnityEventListenerMock publishedMock = new UnityEventListenerMock();
+
+            subject.Registered.AddListener(registeredMock.Listen);
+            subject.Published.AddListener(publishedMock.Listen);
+
+            ActiveCollisionConsumerMock oneConsumer = containingObject.AddComponent<ActiveCollisionConsumerMock>();
+
+            Assert.IsFalse(registeredMock.Received);
+            Assert.AreEqual(0, subject.RegisteredConsumers.Count);
+
+            subject.Register(oneConsumer, null);
+
+            Assert.IsTrue(registeredMock.Received);
+            Assert.AreEqual(1, subject.RegisteredConsumers.Count);
+
+            registeredMock.Reset();
+
+            ActiveCollisionConsumerMock twoConsumer = containingObject.AddComponent<ActiveCollisionConsumerMock>();
+
+            subject.Register(twoConsumer, null);
+
+            Assert.IsTrue(registeredMock.Received);
+            Assert.AreEqual(2, subject.RegisteredConsumers.Count);
+
+            registeredMock.Reset();
+
+            Assert.AreEqual(0, subject.IgnoredRegisteredConsumers.Count);
+
+            subject.IgnoredRegisteredConsumers.Add(twoConsumer);
+
+            Assert.AreEqual(1, subject.IgnoredRegisteredConsumers.Count);
+
+            Assert.IsFalse(oneConsumer.received);
+            Assert.IsFalse(twoConsumer.received);
+            Assert.IsFalse(publishedMock.Received);
+
+            subject.Publish();
+
+            Assert.IsTrue(publishedMock.Received);
+            Assert.IsTrue(oneConsumer.received);
+            Assert.IsFalse(twoConsumer.received);
+
+            Assert.AreEqual(0, subject.IgnoredRegisteredConsumers.Count);
+        }
+
+        [Test]
+        public void RegisterUnregister()
+        {
+            UnityEventListenerMock registeredMock = new UnityEventListenerMock();
+            UnityEventListenerMock unregisteredMock = new UnityEventListenerMock();
+
+            subject.Registered.AddListener(registeredMock.Listen);
+            subject.Unregistered.AddListener(unregisteredMock.Listen);
+
+            ActiveCollisionConsumerMock oneConsumer = containingObject.AddComponent<ActiveCollisionConsumerMock>();
+
+            Assert.IsFalse(registeredMock.Received);
+            Assert.IsFalse(unregisteredMock.Received);
+            Assert.AreEqual(0, subject.RegisteredConsumers.Count);
+
+            subject.Register(oneConsumer, null);
+
+            Assert.IsTrue(registeredMock.Received);
+            Assert.IsFalse(unregisteredMock.Received);
+            Assert.AreEqual(1, subject.RegisteredConsumers.Count);
+
+            registeredMock.Reset();
+            unregisteredMock.Reset();
+
+            ActiveCollisionConsumerMock twoConsumer = containingObject.AddComponent<ActiveCollisionConsumerMock>();
+
+            subject.Register(twoConsumer, null);
+
+            Assert.IsTrue(registeredMock.Received);
+            Assert.IsFalse(unregisteredMock.Received);
+            Assert.AreEqual(2, subject.RegisteredConsumers.Count);
+
+            registeredMock.Reset();
+            unregisteredMock.Reset();
+
+            subject.Unregister(oneConsumer);
+
+            Assert.IsFalse(registeredMock.Received);
+            Assert.IsTrue(unregisteredMock.Received);
+            Assert.AreEqual(1, subject.RegisteredConsumers.Count);
+
+            registeredMock.Reset();
+            unregisteredMock.Reset();
+
+            subject.IgnoredRegisteredConsumers.Add(twoConsumer);
+
+            Assert.AreEqual(1, subject.IgnoredRegisteredConsumers.Count);
+
+            subject.Unregister(twoConsumer);
+
+            Assert.IsFalse(registeredMock.Received);
+            Assert.IsTrue(unregisteredMock.Received);
+            Assert.AreEqual(0, subject.RegisteredConsumers.Count);
+            Assert.AreEqual(0, subject.IgnoredRegisteredConsumers.Count);
+        }
+
+        [Test]
+        public void RegisterUnregisterOnConsumerContainer()
+        {
+            UnityEventListenerMock registeredMock = new UnityEventListenerMock();
+            UnityEventListenerMock unregisteredMock = new UnityEventListenerMock();
+
+            subject.Registered.AddListener(registeredMock.Listen);
+            subject.Unregistered.AddListener(unregisteredMock.Listen);
+
+            GameObject containerOne = new GameObject();
+            GameObject containerTwo = new GameObject();
+
+            ActiveCollisionConsumerMock oneConsumerA = containerOne.AddComponent<ActiveCollisionConsumerMock>();
+            ActiveCollisionConsumerMock oneConsumerB = containerOne.AddComponent<ActiveCollisionConsumerMock>();
+            ActiveCollisionConsumerMock twoConsumer = containerTwo.AddComponent<ActiveCollisionConsumerMock>();
+
+            oneConsumerA.SetConsumerContainer(containerOne);
+            oneConsumerB.SetConsumerContainer(containerOne);
+            twoConsumer.SetConsumerContainer(containerTwo);
+
+            subject.Register(oneConsumerA, null);
+            subject.Register(oneConsumerB, null);
+            subject.Register(twoConsumer, null);
+
+            Assert.IsFalse(unregisteredMock.Received);
+            Assert.AreEqual(3, subject.RegisteredConsumers.Count);
+
+            registeredMock.Reset();
+            unregisteredMock.Reset();
+
+            subject.UnregisterConsumersOnContainer(containerOne);
+
+            Assert.IsFalse(registeredMock.Received);
+            Assert.IsTrue(unregisteredMock.Received);
+            Assert.AreEqual(1, subject.RegisteredConsumers.Count);
+
+            Object.DestroyImmediate(containerOne);
+            Object.DestroyImmediate(containerTwo);
+        }
+
+        [Test]
+        public void ClearIgnoredRegisteredConsumers()
+        {
+            Assert.AreEqual(0, subject.IgnoredRegisteredConsumers.Count);
+            subject.IgnoredRegisteredConsumers.Add(null);
+            Assert.AreEqual(1, subject.IgnoredRegisteredConsumers.Count);
+            subject.ClearIgnoredRegisteredConsumers();
+            Assert.AreEqual(0, subject.IgnoredRegisteredConsumers.Count);
+        }
+
+        [Test]
+        public void RegisterInactiveGameObject()
+        {
+            UnityEventListenerMock registeredMock = new UnityEventListenerMock();
+            UnityEventListenerMock publishedMock = new UnityEventListenerMock();
+
+            subject.Registered.AddListener(registeredMock.Listen);
+            subject.Published.AddListener(publishedMock.Listen);
+
+            subject.gameObject.SetActive(false);
+
+            ActiveCollisionConsumerMock oneConsumer = containingObject.AddComponent<ActiveCollisionConsumerMock>();
+
+            Assert.IsFalse(registeredMock.Received);
+            Assert.AreEqual(0, subject.RegisteredConsumers.Count);
+
+            subject.Register(oneConsumer, null);
+
+            Assert.IsFalse(registeredMock.Received);
+            Assert.AreEqual(0, subject.RegisteredConsumers.Count);
+        }
+
+        [Test]
+        public void RegisterInactiveComponent()
+        {
+            UnityEventListenerMock registeredMock = new UnityEventListenerMock();
+            UnityEventListenerMock publishedMock = new UnityEventListenerMock();
+
+            subject.Registered.AddListener(registeredMock.Listen);
+            subject.Published.AddListener(publishedMock.Listen);
+
+            subject.enabled = false;
+
+            ActiveCollisionConsumerMock oneConsumer = containingObject.AddComponent<ActiveCollisionConsumerMock>();
+
+            Assert.IsFalse(registeredMock.Received);
+            Assert.AreEqual(0, subject.RegisteredConsumers.Count);
+
+            subject.Register(oneConsumer, null);
+
+            Assert.IsFalse(registeredMock.Received);
+            Assert.AreEqual(0, subject.RegisteredConsumers.Count);
+        }
+
+        [Test]
+        public void PublishInactiveGameObject()
+        {
+            UnityEventListenerMock registeredMock = new UnityEventListenerMock();
+            UnityEventListenerMock publishedMock = new UnityEventListenerMock();
+
+            subject.Registered.AddListener(registeredMock.Listen);
+            subject.Published.AddListener(publishedMock.Listen);
+
+
+            ActiveCollisionConsumerMock oneConsumer = containingObject.AddComponent<ActiveCollisionConsumerMock>();
+
+            Assert.IsFalse(registeredMock.Received);
+            Assert.AreEqual(0, subject.RegisteredConsumers.Count);
+
+            subject.Register(oneConsumer, null);
+
+            Assert.IsTrue(registeredMock.Received);
+            Assert.AreEqual(1, subject.RegisteredConsumers.Count);
+
+            registeredMock.Reset();
+
+            Assert.IsFalse(oneConsumer.received);
+            Assert.IsFalse(publishedMock.Received);
+
+            subject.gameObject.SetActive(false);
+            subject.Publish();
+
+            Assert.IsFalse(publishedMock.Received);
+            Assert.IsFalse(oneConsumer.received);
+        }
+
+        [Test]
+        public void PublishInactiveComponent()
+        {
+            UnityEventListenerMock registeredMock = new UnityEventListenerMock();
+            UnityEventListenerMock publishedMock = new UnityEventListenerMock();
+
+            subject.Registered.AddListener(registeredMock.Listen);
+            subject.Published.AddListener(publishedMock.Listen);
+
+
+            ActiveCollisionConsumerMock oneConsumer = containingObject.AddComponent<ActiveCollisionConsumerMock>();
+
+            Assert.IsFalse(registeredMock.Received);
+            Assert.AreEqual(0, subject.RegisteredConsumers.Count);
+
+            subject.Register(oneConsumer, null);
+
+            Assert.IsTrue(registeredMock.Received);
+            Assert.AreEqual(1, subject.RegisteredConsumers.Count);
+
+            registeredMock.Reset();
+
+            Assert.IsFalse(oneConsumer.received);
+            Assert.IsFalse(publishedMock.Received);
+
+            subject.enabled = false;
+            subject.Publish();
+
+            Assert.IsFalse(publishedMock.Received);
+            Assert.IsFalse(oneConsumer.received);
+        }
+    }
+}

--- a/Tests/Editor/Tracking/Collision/Active/ActiveCollisionRegisteredConsumerContainerTest.cs.meta
+++ b/Tests/Editor/Tracking/Collision/Active/ActiveCollisionRegisteredConsumerContainerTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 53fbe3b8493581845b5f271523881f23
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Editor/Tracking/Collision/Active/Event/Proxy/ActiveCollisionPublisherEventProxyEmitterTest.cs
+++ b/Tests/Editor/Tracking/Collision/Active/Event/Proxy/ActiveCollisionPublisherEventProxyEmitterTest.cs
@@ -1,0 +1,79 @@
+﻿using Zinnia.Tracking.Collision.Active;
+using Zinnia.Tracking.Collision.Active.Event.Proxy;
+
+namespace Test.Zinnia.Tracking.Collision.Active.Event.Proxy
+{
+    using NUnit.Framework;
+    using Test.Zinnia.Utility.Mock;
+    using UnityEngine;
+    using Assert = UnityEngine.Assertions.Assert;
+
+    public class ActiveCollisionPublisherEventProxyEmitterTest
+    {
+        private GameObject containingObject;
+        private ActiveCollisionPublisherEventProxyEmitter subject;
+
+        [SetUp]
+        public void SetUp()
+        {
+            containingObject = new GameObject();
+            subject = containingObject.AddComponent<ActiveCollisionPublisherEventProxyEmitter>();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            Object.DestroyImmediate(subject);
+            Object.DestroyImmediate(containingObject);
+        }
+
+        [Test]
+        public void Receive()
+        {
+            UnityEventListenerMock emittedMock = new UnityEventListenerMock();
+            subject.Emitted.AddListener(emittedMock.Listen);
+            ActiveCollisionPublisher.PayloadData digest = new ActiveCollisionPublisher.PayloadData();
+
+            Assert.IsFalse(emittedMock.Received);
+            subject.Receive(digest);
+            Assert.AreEqual(digest, subject.Payload);
+            Assert.IsTrue(emittedMock.Received);
+        }
+
+        [Test]
+        public void ReceiveInactiveGameObject()
+        {
+            UnityEventListenerMock emittedMock = new UnityEventListenerMock();
+            subject.Emitted.AddListener(emittedMock.Listen);
+            ActiveCollisionPublisher.PayloadData digest = new ActiveCollisionPublisher.PayloadData();
+
+            subject.gameObject.SetActive(false);
+
+            Assert.IsNull(subject.Payload);
+            Assert.IsFalse(emittedMock.Received);
+
+            subject.Receive(digest);
+
+            Assert.IsNull(subject.Payload);
+            Assert.IsFalse(emittedMock.Received);
+        }
+
+        [Test]
+        public void ReceiveInactiveComponent()
+        {
+            UnityEventListenerMock emittedMock = new UnityEventListenerMock();
+            subject.Emitted.AddListener(emittedMock.Listen);
+            ActiveCollisionPublisher.PayloadData digest = new ActiveCollisionPublisher.PayloadData();
+
+            subject.enabled = false;
+
+            Assert.IsNull(subject.Payload);
+            Assert.IsFalse(emittedMock.Received);
+
+            subject.Receive(digest);
+
+            Assert.IsNull(subject.Payload);
+            Assert.IsFalse(emittedMock.Received);
+        }
+    }
+}

--- a/Tests/Editor/Tracking/Collision/Active/Event/Proxy/ActiveCollisionPublisherEventProxyEmitterTest.cs.meta
+++ b/Tests/Editor/Tracking/Collision/Active/Event/Proxy/ActiveCollisionPublisherEventProxyEmitterTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ca8a6d4f1cc7f074d8156b78cc06bd42
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Editor/Tracking/Collision/Active/Event/Proxy/ActiveCollisionRegisteredConsumerContainerEventProxyEmitterTest.cs
+++ b/Tests/Editor/Tracking/Collision/Active/Event/Proxy/ActiveCollisionRegisteredConsumerContainerEventProxyEmitterTest.cs
@@ -1,0 +1,79 @@
+﻿using Zinnia.Tracking.Collision.Active;
+using Zinnia.Tracking.Collision.Active.Event.Proxy;
+
+namespace Test.Zinnia.Tracking.Collision.Active.Event.Proxy
+{
+    using NUnit.Framework;
+    using Test.Zinnia.Utility.Mock;
+    using UnityEngine;
+    using Assert = UnityEngine.Assertions.Assert;
+
+    public class ActiveCollisionRegisteredConsumerContainerEventProxyEmitterTest
+    {
+        private GameObject containingObject;
+        private ActiveCollisionRegisteredConsumerContainerEventProxyEmitter subject;
+
+        [SetUp]
+        public void SetUp()
+        {
+            containingObject = new GameObject();
+            subject = containingObject.AddComponent<ActiveCollisionRegisteredConsumerContainerEventProxyEmitter>();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            Object.DestroyImmediate(subject);
+            Object.DestroyImmediate(containingObject);
+        }
+
+        [Test]
+        public void Receive()
+        {
+            UnityEventListenerMock emittedMock = new UnityEventListenerMock();
+            subject.Emitted.AddListener(emittedMock.Listen);
+            ActiveCollisionRegisteredConsumerContainer.EventData digest = new ActiveCollisionRegisteredConsumerContainer.EventData();
+
+            Assert.IsFalse(emittedMock.Received);
+            subject.Receive(digest);
+            Assert.AreEqual(digest, subject.Payload);
+            Assert.IsTrue(emittedMock.Received);
+        }
+
+        [Test]
+        public void ReceiveInactiveGameObject()
+        {
+            UnityEventListenerMock emittedMock = new UnityEventListenerMock();
+            subject.Emitted.AddListener(emittedMock.Listen);
+            ActiveCollisionRegisteredConsumerContainer.EventData digest = new ActiveCollisionRegisteredConsumerContainer.EventData();
+
+            subject.gameObject.SetActive(false);
+
+            Assert.IsNull(subject.Payload);
+            Assert.IsFalse(emittedMock.Received);
+
+            subject.Receive(digest);
+
+            Assert.IsNull(subject.Payload);
+            Assert.IsFalse(emittedMock.Received);
+        }
+
+        [Test]
+        public void ReceiveInactiveComponent()
+        {
+            UnityEventListenerMock emittedMock = new UnityEventListenerMock();
+            subject.Emitted.AddListener(emittedMock.Listen);
+            ActiveCollisionRegisteredConsumerContainer.EventData digest = new ActiveCollisionRegisteredConsumerContainer.EventData();
+
+            subject.enabled = false;
+
+            Assert.IsNull(subject.Payload);
+            Assert.IsFalse(emittedMock.Received);
+
+            subject.Receive(digest);
+
+            Assert.IsNull(subject.Payload);
+            Assert.IsFalse(emittedMock.Received);
+        }
+    }
+}

--- a/Tests/Editor/Tracking/Collision/Active/Event/Proxy/ActiveCollisionRegisteredConsumerContainerEventProxyEmitterTest.cs.meta
+++ b/Tests/Editor/Tracking/Collision/Active/Event/Proxy/ActiveCollisionRegisteredConsumerContainerEventProxyEmitterTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6b6db3ec93caa254caea95106f265d78
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
The ActiveCollisionRegisteredConsumerContainer is linked to a
ActiveCollisionPublisher and its job is to store a collection
of consumers that the publisher has successfully published to.

This means the publisher still doesn't know directly who it is
publishing to, but holds an audit log of which consumers have
successfully received the payload in the past.

The ActiveCollisionConsumer now also holds a reference to the
top level container (i.e. the colliding rigidbody/collider GameObject)
that the component is residing under.