### PR TITLE
feat(Tracking): add haptic profiles to LinkedAliasAssociationCollection

### DIFF
--- a/Runtime/Haptics/TimedHapticProcess.cs
+++ b/Runtime/Haptics/TimedHapticProcess.cs
@@ -17,14 +17,12 @@
         [Serialized]
         [field: DocumentedByXml]
         public HapticProcess HapticProcess { get; set; }
-
         /// <summary>
         /// The amount of time to keep repeating the process for.
         /// </summary>
         [Serialized]
         [field: DocumentedByXml]
         public float Duration { get; set; } = 1f;
-
         /// <summary>
         /// The amount of time to pause after each process iteration.
         /// </summary>

--- a/Runtime/Haptics/XRNodeHapticPulser.cs
+++ b/Runtime/Haptics/XRNodeHapticPulser.cs
@@ -18,6 +18,9 @@
         /// <summary>
         /// The duration to pulse <see cref="Node"/> for.
         /// </summary>
+        /// <remarks>
+        /// Not supported by all devices.
+        /// </remarks>
         [Serialized]
         [field: DocumentedByXml]
         public float Duration { get; set; } = 0.005f;

--- a/Runtime/Tracking/CameraRig/LinkedAliasAssociationCollection.cs
+++ b/Runtime/Tracking/CameraRig/LinkedAliasAssociationCollection.cs
@@ -6,6 +6,7 @@
     using UnityEngine;
     using Zinnia.Data.Collection.List;
     using Zinnia.Haptics;
+    using Zinnia.Haptics.Collection;
     using Zinnia.Tracking.Velocity;
 
     /// <summary>
@@ -63,11 +64,17 @@
         [field: DocumentedByXml]
         public VelocityTracker LeftControllerVelocityTracker { get; set; }
         /// <summary>
-        /// The associated Left Controller Haptic Process.
+        /// The main Left Controller Haptic Process profile.
         /// </summary>
         [Serialized, Cleared]
         [field: DocumentedByXml]
         public HapticProcess LeftControllerHapticProcess { get; set; }
+        /// <summary>
+        /// A <see cref="HapticProcess"/> collection of haptic profiles that can be used with the Left Controller.
+        /// </summary>
+        [Serialized, Cleared]
+        [field: DocumentedByXml]
+        public HapticProcessObservableList LeftControllerHapticProfiles { get; set; }
         #endregion
 
         #region Right Controller Settings
@@ -84,11 +91,17 @@
         [field: DocumentedByXml]
         public VelocityTracker RightControllerVelocityTracker { get; set; }
         /// <summary>
-        /// The associated Right Controller Haptic Process.
+        /// The main Right Controller Haptic Process profile.
         /// </summary>
         [Serialized, Cleared]
         [field: DocumentedByXml]
         public HapticProcess RightControllerHapticProcess { get; set; }
+        /// <summary>
+        /// A <see cref="HapticProcess"/> collection of supplement haptic settings that can be used with the Right Controller.
+        /// </summary>
+        [Serialized, Cleared]
+        [field: DocumentedByXml]
+        public HapticProcessObservableList RightControllerHapticProfiles { get; set; }
         #endregion
     }
 }


### PR DESCRIPTION
The LinkedAliasAssociationCollection now has the concept of haptic
profiles for the left and right controller.

The haptic profile is a list of haptice processes for each controller
that describe different haptic output scenarios.