### PR TITLE
fix(Tracking): calculate angular velocity angle in radians

### DIFF
--- a/Runtime/Tracking/Follow/Modifier/Property/Rotation/RigidbodyAngularVelocity.cs
+++ b/Runtime/Tracking/Follow/Modifier/Property/Rotation/RigidbodyAngularVelocity.cs
@@ -48,7 +48,7 @@
             Quaternion rotationDelta = source.transform.rotation * Quaternion.Inverse(offset != null ? offset.transform.rotation : target.transform.rotation);
 
             rotationDelta.ToAngleAxis(out float angle, out Vector3 axis);
-            angle = angle.GetSignedDegree();
+            angle = angle * Mathf.Deg2Rad / Time.deltaTime;
 
             if (!angle.ApproxEquals(0))
             {


### PR DESCRIPTION
The RigidbodyAngularVelocity component was calculating the angle of
angular velocity in degrees but angular velocity is set in radians
so this was causing artifacts when rotating.

The fix is to ensure the angle is calculated in radians.

Co-authored-by: JGroxz