### PR TITLE
fix(Tracking): calculate angular velocity angle optionally in degrees

### DIFF
--- a/Runtime/Tracking/Follow/Modifier/Property/Position/RigidbodyVelocity.cs
+++ b/Runtime/Tracking/Follow/Modifier/Property/Position/RigidbodyVelocity.cs
@@ -46,8 +46,9 @@
             cachedTarget = target;
 
             Vector3 positionDelta = source.transform.position - (offset != null ? offset.transform.position : target.transform.position);
-            Vector3 velocityTarget = positionDelta / Time.deltaTime;
-            Vector3 calculatedVelocity = Vector3.MoveTowards(cachedTargetRigidbody.velocity, velocityTarget, MaxDistanceDelta);
+            float deltaTime = Time.inFixedTimeStep ? Time.fixedDeltaTime : Time.deltaTime;
+            Vector3 velocityTarget = positionDelta / deltaTime;
+            Vector3 calculatedVelocity = Vector3.MoveTowards(cachedTargetRigidbody.velocity, velocityTarget, MaxDistanceDelta / deltaTime);
 
             if (calculatedVelocity.sqrMagnitude < VelocityLimit)
             {
@@ -65,13 +66,15 @@
         /// <param name="offset">Any offset applied to the target.</param>
         /// <param name="a">The source position.</param>
         /// <param name="b">The target position.</param>
+
         protected override void GetCheckPoints(GameObject source, GameObject target, GameObject offset, out Vector3 a, out Vector3 b)
         {
             a = source.transform.position;
             b = target.transform.position;
+
             if (offset != null)
             {
-                b += offset.transform.localPosition;
+                a = source.transform.position - (offset.transform.position - target.transform.position);
             }
         }
     }

--- a/Tests/Editor/Tracking/Follow/Modifier/Property/Position/RigidbodyVelocityTest.cs
+++ b/Tests/Editor/Tracking/Follow/Modifier/Property/Position/RigidbodyVelocityTest.cs
@@ -44,7 +44,7 @@ namespace Test.Zinnia.Tracking.Follow.Modifier.Property.Position
             source.transform.position = Vector3.one;
             target.transform.position = Vector3.zero;
 
-            Vector3 expectedVelocity = Vector3.one * 5.8f;
+            Vector3 expectedVelocity = Vector3.one / (Time.inFixedTimeStep ? Time.fixedDeltaTime : Time.deltaTime);
             Vector3 expectedAngularVelocity = Vector3.zero;
 
             Assert.AreEqual(Vector3.zero, subjectRigidbody.velocity);
@@ -119,7 +119,7 @@ namespace Test.Zinnia.Tracking.Follow.Modifier.Property.Position
             target.transform.position = Vector3.zero;
             offset.transform.position = Vector3.one * 2f;
 
-            Vector3 expectedVelocity = Vector3.one * -5.8f;
+            Vector3 expectedVelocity = -(Vector3.one / (Time.inFixedTimeStep ? Time.fixedDeltaTime : Time.deltaTime));
             Vector3 expectedAngularVelocity = Vector3.zero;
 
             Assert.AreEqual(Vector3.zero, subjectRigidbody.velocity);
@@ -197,7 +197,7 @@ namespace Test.Zinnia.Tracking.Follow.Modifier.Property.Position
             target.transform.position = Vector3.zero;
             offset.transform.position = Vector3.one * 2f;
 
-            Vector3 expectedVelocity = Vector3.one * 5.8f;
+            Vector3 expectedVelocity = Vector3.one / (Time.inFixedTimeStep ? Time.fixedDeltaTime : Time.deltaTime);
             Vector3 expectedAngularVelocity = Vector3.zero;
 
             Assert.AreEqual(Vector3.zero, subjectRigidbody.velocity);


### PR DESCRIPTION
The RigidbodyAngularVelocity component was updated to calculate in
radians only. Whilst, this makes sense for the most part, it does not
create a good outcome in all situations. The component has been updated
so it can optionally use radians or degrees and it can also take in
to consideration the offset to determine the new centre of mass to
calculate around.

The divergence checking code was also faulty, so this has been fixed
as part of this commit.