### PR TITLE
fix(Utility): move prefab creator menu location

### DIFF
--- a/Editor/Utility/BasePrefabCreator.cs
+++ b/Editor/Utility/BasePrefabCreator.cs
@@ -5,9 +5,10 @@ namespace Zinnia.Utility
 
     public abstract class BasePrefabCreator : ScriptableObject
     {
-        protected const string topLevelMenuLocation = "Window/";
+        protected const string topLevelMenuLocation = "GameObject/";
         protected const string subLevelMenuLocation = "Prefabs/";
         protected const string packageRoot = "Packages";
+        protected const int priority = 49;
 
         protected static void CreatePrefab(string assetPath)
         {


### PR DESCRIPTION
The Prefab Creator has now been moved to the `GameObject` main menu
so it can also show up in the right click context menu for adding
new items to the hierarchy.