### PR TITLE
fix(Visual): possible null pointer exception on camera blink

### DIFF
--- a/Runtime/Visual/CameraColorOverlay.cs
+++ b/Runtime/Visual/CameraColorOverlay.cs
@@ -465,7 +465,11 @@
         protected virtual void UrpPreRender(ScriptableRenderContext context, Camera sceneCamera)
         {
             ProcessColorTransition();
-            if (urpFadeOverlay != null && fadeRenderer != null && ShouldTransition())
+            if (fadeRenderer == default)
+            {
+                return;
+            }
+            if (urpFadeOverlay != null && ShouldTransition())
             {
                 if (lastUsedCamera != sceneCamera)
                 {


### PR DESCRIPTION
I've tried to add the teleporter functionality to my scene (VRTK+SteamVR+HDRP) according to the current documentation on github. I can use the curved pointer to trigger the teleport, but the application stops with a MissingReferenceException. It seams that CameraColorOverlay:UrpPreRender does not handle nulled (or destroyed) fadeRenderer very well. I know, that this is a URP specific method, but after fixing/workarounding it the teleport is functioning.

Environment
* Unity 2021.1.12f (latest)
* SteamVR 2.7.3 (latest)
* com.unity.render-pipelines.high-definition 11.0.0 (latest)
* io.extendreality.tilia.indicators.objectpointers.unity 1.7.10
* io.extendreality.tilia.locomotors.teleporter.unity 1.6.6
* io.extendreality.tilia.locomotors.teleporttargets.unity 1.1.10
* io.extendreality.tilia.sdk.steamvr.unity 1.1.17
* io.extendreality.zinnia.unity 1.36.2

Error message:
MissingReferenceException: The object of type 'MeshRenderer' has been destroyed but you are still trying to access it.
Your script should either check if it is null or you should not destroy the object.
Zinnia.Visual.CameraColorOverlay.UrpPreRender (UnityEngine.Rendering.ScriptableRenderContext context, UnityEngine.Camera sceneCamera) (at Library/PackageCache/io.extendreality.zinnia.unity@1.36.2/Runtime/Visual/CameraColorOverlay.cs:483)
UnityEngine.Rendering.RenderPipelineManager.BeginCameraRendering (UnityEngine.Rendering.ScriptableRenderContext context, UnityEngine.Camera camera) (at <adfa4b62400849189388df71c9e26e89>:0)
UnityEngine.Rendering.RenderPipeline.BeginCameraRendering (UnityEngine.Rendering.ScriptableRenderContext context, UnityEngine.Camera camera) (at <adfa4b62400849189388df71c9e26e89>:0)
UnityEngine.Rendering.HighDefinition.HDRenderPipeline.TryCull (UnityEngine.Camera camera, UnityEngine.Rendering.HighDefinition.HDCamera hdCamera, UnityEngine.Rendering.ScriptableRenderContext renderContext, UnityEngine.Rendering.HighDefinition.SkyManager skyManager, UnityEngine.Rendering.ScriptableCullingParameters cullingParams, UnityEngine.Rendering.HighDefinition.HDRenderPipelineAsset hdrp, UnityEngine.Rendering.HighDefinition.HDRenderPipeline+HDCullingResults& cullingResults) (at Library/PackageCache/com.unity.render-pipelines.high-definition@11.0.0/Runtime/RenderPipeline/HDRenderPipeline.cs:2490)
UnityEngine.Rendering.HighDefinition.HDRenderPipeline.Render (UnityEngine.Rendering.ScriptableRenderContext renderContext, System.Collections.Generic.List`1[T] cameras) (at Library/PackageCache/com.unity.render-pipelines.high-definition@11.0.0/Runtime/RenderPipeline/HDRenderPipeline.cs:1396)
UnityEngine.Rendering.RenderPipeline.InternalRender (UnityEngine.Rendering.ScriptableRenderContext context, System.Collections.Generic.List`1[T] cameras) (at <adfa4b62400849189388df71c9e26e89>:0)
UnityEngine.Rendering.RenderPipelineManager.DoRenderLoop_Internal (UnityEngine.Rendering.RenderPipelineAsset pipe, System.IntPtr loopPtr, System.Collections.Generic.List`1[T] renderRequests, Unity.Collections.LowLevel.Unsafe.AtomicSafetyHandle safety) (at <adfa4b62400849189388df71c9e26e89>:0)
UnityEngine.GUIUtility:ProcessEvent(Int32, IntPtr, Boolean&)