### PR TITLE
feat(Tracking): publicize collision notifier collision methods

### DIFF
--- a/Runtime/Tracking/Collision/CollisionNotifier.cs
+++ b/Runtime/Tracking/Collision/CollisionNotifier.cs
@@ -249,6 +249,84 @@
         protected bool isProcessingStopNotifierCollection;
 
         /// <summary>
+        /// Processes any collision start events on the given data and propagates it to any linked <see cref="CollisionNotifier"/>.
+        /// </summary>
+        /// <param name="data">The collision data.</param>
+        public virtual void OnCollisionStarted(EventData data)
+        {
+            if (!CanProcess() || (StatesToProcess & CollisionStates.Enter) == 0 || !CanEmit(data))
+            {
+                return;
+            }
+
+            CollisionStarted?.Invoke(data);
+
+            if (isProcessingStartNotifierCollection)
+            {
+                return;
+            }
+
+            isProcessingStartNotifierCollection = true;
+            foreach (CollisionNotifier notifier in GetNotifiers(data, startCollisionNotifiers))
+            {
+                notifier.OnCollisionStarted(data);
+            }
+            isProcessingStartNotifierCollection = false;
+        }
+
+        /// <summary>
+        /// Processes any collision change events on the given data and propagates it to any linked <see cref="CollisionNotifier"/>.
+        /// </summary>
+        /// <param name="data">The collision data.</param>
+        public virtual void OnCollisionChanged(EventData data)
+        {
+            if (!CanProcess() || (StatesToProcess & CollisionStates.Stay) == 0 || !CanEmit(data))
+            {
+                return;
+            }
+
+            CollisionChanged?.Invoke(data);
+
+            if (isProcessingChangeNotifierCollection)
+            {
+                return;
+            }
+
+            isProcessingChangeNotifierCollection = true;
+            foreach (CollisionNotifier notifier in GetNotifiers(data, changeCollisionNotifiers))
+            {
+                notifier.OnCollisionChanged(data);
+            }
+            isProcessingChangeNotifierCollection = false;
+        }
+
+        /// <summary>
+        /// Processes any collision stop events on the given data and propagates it to any linked <see cref="CollisionNotifier"/>.
+        /// </summary>
+        /// <param name="data">The collision data.</param>
+        public virtual void OnCollisionStopped(EventData data)
+        {
+            if (!CanProcess() || (StatesToProcess & CollisionStates.Exit) == 0 || !CanEmit(data))
+            {
+                return;
+            }
+
+            CollisionStopped?.Invoke(data);
+
+            if (isProcessingStopNotifierCollection)
+            {
+                return;
+            }
+
+            isProcessingStopNotifierCollection = true;
+            foreach (CollisionNotifier notifier in GetNotifiers(data, stopCollisionNotifiers))
+            {
+                notifier.OnCollisionStopped(data);
+            }
+            isProcessingStopNotifierCollection = false;
+        }
+
+        /// <summary>
         /// Whether to process the collision check.
         /// </summary>
         /// <returns><see langword="true"/> if the collision should be processed.</returns>
@@ -294,84 +372,6 @@
             }
 
             return collisionNotifiers;
-        }
-
-        /// <summary>
-        /// Processes any collision start events on the given data and propagates it to any linked <see cref="CollisionNotifier"/>.
-        /// </summary>
-        /// <param name="data">The collision data.</param>
-        protected virtual void OnCollisionStarted(EventData data)
-        {
-            if (!CanProcess() || (StatesToProcess & CollisionStates.Enter) == 0 || !CanEmit(data))
-            {
-                return;
-            }
-
-            CollisionStarted?.Invoke(data);
-
-            if (isProcessingStartNotifierCollection)
-            {
-                return;
-            }
-
-            isProcessingStartNotifierCollection = true;
-            foreach (CollisionNotifier notifier in GetNotifiers(data, startCollisionNotifiers))
-            {
-                notifier.OnCollisionStarted(data);
-            }
-            isProcessingStartNotifierCollection = false;
-        }
-
-        /// <summary>
-        /// Processes any collision change events on the given data and propagates it to any linked <see cref="CollisionNotifier"/>.
-        /// </summary>
-        /// <param name="data">The collision data.</param>
-        protected virtual void OnCollisionChanged(EventData data)
-        {
-            if (!CanProcess() || (StatesToProcess & CollisionStates.Stay) == 0 || !CanEmit(data))
-            {
-                return;
-            }
-
-            CollisionChanged?.Invoke(data);
-
-            if (isProcessingChangeNotifierCollection)
-            {
-                return;
-            }
-
-            isProcessingChangeNotifierCollection = true;
-            foreach (CollisionNotifier notifier in GetNotifiers(data, changeCollisionNotifiers))
-            {
-                notifier.OnCollisionChanged(data);
-            }
-            isProcessingChangeNotifierCollection = false;
-        }
-
-        /// <summary>
-        /// Processes any collision stop events on the given data and propagates it to any linked <see cref="CollisionNotifier"/>.
-        /// </summary>
-        /// <param name="data">The collision data.</param>
-        protected virtual void OnCollisionStopped(EventData data)
-        {
-            if (!CanProcess() || (StatesToProcess & CollisionStates.Exit) == 0 || !CanEmit(data))
-            {
-                return;
-            }
-
-            CollisionStopped?.Invoke(data);
-
-            if (isProcessingStopNotifierCollection)
-            {
-                return;
-            }
-
-            isProcessingStopNotifierCollection = true;
-            foreach (CollisionNotifier notifier in GetNotifiers(data, stopCollisionNotifiers))
-            {
-                notifier.OnCollisionStopped(data);
-            }
-            isProcessingStopNotifierCollection = false;
         }
     }
 }

--- a/Runtime/Visual/CameraColorOverlay.cs
+++ b/Runtime/Visual/CameraColorOverlay.cs
@@ -465,7 +465,13 @@
         protected virtual void UrpPreRender(ScriptableRenderContext context, Camera sceneCamera)
         {
             ProcessColorTransition();
-            if (urpFadeOverlay != null && fadeRenderer != null && ShouldTransition())
+
+            if (urpFadeOverlay == null || fadeRenderer == null)
+            {
+                return;
+            }
+
+            if (ShouldTransition())
             {
                 if (lastUsedCamera != sceneCamera)
                 {

--- a/Runtime/Visual/CameraColorOverlay.cs
+++ b/Runtime/Visual/CameraColorOverlay.cs
@@ -228,6 +228,20 @@
             blinkRoutine = StartCoroutine(ResetBlink());
         }
 
+        /// <summary>
+        /// Destroys the fade mesh used in the Universal Render Pipeline. To recreate it, the component must be disabled then re-enabled.
+        /// </summary>
+        public virtual void DestroyFadeMesh()
+        {
+            if (urpFadeOverlay == null)
+            {
+                return;
+            }
+
+            urpFadeOverlay.transform.SetParent(null);
+            Destroy(urpFadeOverlay);
+        }
+
         protected virtual void OnEnable()
         {
             lastUsedCamera = null;
@@ -251,10 +265,13 @@
             CancelBlinkRoutine();
             if (GraphicsSettings.renderPipelineAsset != null)
             {
+                if (fadeRenderer != null)
+                {
+                    fadeRenderer.enabled = false;
+                }
 #if UNITY_2019_1_OR_NEWER
                 RenderPipelineManager.beginCameraRendering -= UrpPreRender;
 #endif
-                DestroyFadeMesh();
             }
             else
             {
@@ -307,21 +324,6 @@
             uv[3] = new Vector2(1, 1);
 
             mesh.uv = uv;
-        }
-
-        /// <summary>
-        /// Destroys the fade mesh used in the Universal Render Pipeline.
-        /// </summary>
-        protected virtual void DestroyFadeMesh()
-        {
-            if (urpFadeOverlay == null)
-            {
-                return;
-            }
-
-            urpFadeOverlay.transform.SetParent(null);
-            Destroy(urpFadeOverlay);
-
         }
 
         /// <summary>


### PR DESCRIPTION
The methods responsible for handling collision events in the
CollisionNotifier have been made public so they can be called manually
if need be.

This is useful if a manual collision is needed to be raised without an
actual physics collision taking place to simulate collisions.