### PR TITLE
fix(Tracking): ensure right trigger exit happens on kinematic change

### DIFF
--- a/Tests/Editor/Tracking/Collision/CollisionTrackerTest.cs
+++ b/Tests/Editor/Tracking/Collision/CollisionTrackerTest.cs
@@ -704,11 +704,341 @@ namespace Test.Zinnia.Tracking.Collision
             Object.DestroyImmediate(notifierContainer);
         }
 
+        [UnityTest]
+        public IEnumerator CollisionCheckExitEnterOnKinematicChange()
+        {
+            WaitForFixedUpdate yieldInstruction = new WaitForFixedUpdate();
+
+            GameObject trackerContainer = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            trackerContainer.name = "TrackerContainer";
+            trackerContainer.GetComponent<Collider>().isTrigger = true;
+            trackerContainer.AddComponent<Rigidbody>().isKinematic = true;
+            trackerContainer.transform.position = Vector3.forward;
+            trackerContainer.transform.localScale = Vector3.one * 0.1f;
+            CollisionTrackerMock tracker = trackerContainer.AddComponent<CollisionTrackerMock>();
+
+            UnityEventListenerMock trackerCollisionStartedListenerMock = new UnityEventListenerMock();
+            UnityEventListenerMock trackerCollisionStoppedListenerMock = new UnityEventListenerMock();
+            tracker.CollisionStarted.AddListener(trackerCollisionStartedListenerMock.Listen);
+            tracker.CollisionStopped.AddListener(trackerCollisionStoppedListenerMock.Listen);
+
+            GameObject targetContainer = new GameObject("TargetContainer");
+            targetContainer.transform.localPosition = Vector3.zero;
+            targetContainer.transform.localScale = Vector3.one;
+
+            GameObject childOne = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            childOne.name = "childOne";
+            childOne.transform.SetParent(targetContainer.transform);
+            childOne.transform.localPosition = Vector3.zero;
+            childOne.transform.localScale = Vector3.one * 0.2f;
+
+            GameObject childTwo = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            childTwo.name = "childTwo";
+            childTwo.transform.SetParent(targetContainer.transform);
+            childTwo.transform.localPosition = Vector3.left * 0.2f;
+            childTwo.transform.localScale = Vector3.one * 0.2f;
+
+            Rigidbody targetRigidbody = targetContainer.AddComponent<Rigidbody>();
+            targetRigidbody.useGravity = false;
+
+            yield return yieldInstruction;
+
+            Assert.IsFalse(trackerCollisionStartedListenerMock.Received);
+            Assert.IsFalse(trackerCollisionStoppedListenerMock.Received);
+            trackerCollisionStartedListenerMock.Reset();
+            trackerCollisionStoppedListenerMock.Reset();
+
+            tracker.LatestStartedEventData.Clear();
+            tracker.LatestStoppedEventData.Clear();
+
+            /// 1. First do a simple touch childOne to check started is called.
+
+            trackerContainer.transform.position = childOne.transform.position;
+
+            yield return yieldInstruction;
+
+            Assert.IsTrue(trackerCollisionStartedListenerMock.Received);
+            Assert.IsFalse(trackerCollisionStoppedListenerMock.Received);
+            trackerCollisionStartedListenerMock.Reset();
+            trackerCollisionStoppedListenerMock.Reset();
+
+            Assert.AreEqual(childOne.transform, tracker.LatestStartedEventData.ColliderData.transform);
+            Assert.AreEqual(targetRigidbody, tracker.LatestStartedEventData.ColliderData.attachedRigidbody);
+            Assert.IsTrue(tracker.IsEventDataEmpty(tracker.LatestStoppedEventData));
+
+            tracker.LatestStartedEventData.Clear();
+            tracker.LatestStoppedEventData.Clear();
+
+            /// 1. Then untouch childOne to check stopped is called
+
+            trackerContainer.transform.position = Vector3.forward;
+
+            yield return yieldInstruction;
+
+            Assert.IsFalse(trackerCollisionStartedListenerMock.Received);
+            Assert.IsTrue(trackerCollisionStoppedListenerMock.Received);
+            trackerCollisionStartedListenerMock.Reset();
+            trackerCollisionStoppedListenerMock.Reset();
+
+            Assert.AreEqual(childOne.transform, tracker.LatestStoppedEventData.ColliderData.transform);
+            Assert.AreEqual(targetRigidbody, tracker.LatestStoppedEventData.ColliderData.attachedRigidbody);
+
+            Assert.IsTrue(tracker.IsEventDataEmpty(tracker.LatestStartedEventData));
+
+            tracker.LatestStartedEventData.Clear();
+            tracker.LatestStoppedEventData.Clear();
+
+            yield return yieldInstruction;
+
+            /// 1. Now touch childOne, check start is called, then switch target to kinematic
+
+            trackerContainer.transform.position = childOne.transform.position;
+
+            yield return yieldInstruction;
+
+            Assert.IsTrue(trackerCollisionStartedListenerMock.Received);
+            Assert.IsFalse(trackerCollisionStoppedListenerMock.Received);
+            trackerCollisionStartedListenerMock.Reset();
+            trackerCollisionStoppedListenerMock.Reset();
+
+            tracker.PrepareKinematicStateChange(targetRigidbody);
+            targetRigidbody.isKinematic = true;
+
+            yield return yieldInstruction;
+
+            Assert.IsFalse(trackerCollisionStartedListenerMock.Received);
+            Assert.IsFalse(trackerCollisionStoppedListenerMock.Received);
+            trackerCollisionStartedListenerMock.Reset();
+            trackerCollisionStoppedListenerMock.Reset();
+
+            Assert.AreEqual(childOne.transform, tracker.LatestStartedEventData.ColliderData.transform);
+            Assert.AreEqual(targetRigidbody, tracker.LatestStartedEventData.ColliderData.attachedRigidbody);
+
+            Assert.IsTrue(tracker.IsEventDataEmpty(tracker.LatestStoppedEventData));
+
+            tracker.LatestStartedEventData.Clear();
+            tracker.LatestStoppedEventData.Clear();
+
+            /// 1. Then untouch childOne but remove kinematic state first
+
+            tracker.PrepareKinematicStateChange(targetRigidbody);
+            targetRigidbody.isKinematic = false;
+
+            yield return yieldInstruction;
+
+            Assert.IsFalse(trackerCollisionStartedListenerMock.Received);
+            Assert.IsFalse(trackerCollisionStoppedListenerMock.Received);
+            trackerCollisionStartedListenerMock.Reset();
+            trackerCollisionStoppedListenerMock.Reset();
+
+            trackerContainer.transform.position = Vector3.forward;
+
+            yield return yieldInstruction;
+
+            Assert.IsFalse(trackerCollisionStartedListenerMock.Received);
+            Assert.IsTrue(trackerCollisionStoppedListenerMock.Received);
+            trackerCollisionStartedListenerMock.Reset();
+            trackerCollisionStoppedListenerMock.Reset();
+
+            Assert.AreEqual(childOne.transform, tracker.LatestStoppedEventData.ColliderData.transform);
+            Assert.AreEqual(targetRigidbody, tracker.LatestStoppedEventData.ColliderData.attachedRigidbody);
+
+            Assert.IsTrue(tracker.IsEventDataEmpty(tracker.LatestStartedEventData));
+
+            tracker.LatestStartedEventData.Clear();
+            tracker.LatestStoppedEventData.Clear();
+
+            /// 2. Now do a simple touch childTwo to check started is called.
+
+            trackerContainer.transform.position = childTwo.transform.position;
+
+            yield return yieldInstruction;
+
+            Assert.IsTrue(trackerCollisionStartedListenerMock.Received);
+            Assert.IsFalse(trackerCollisionStoppedListenerMock.Received);
+            trackerCollisionStartedListenerMock.Reset();
+            trackerCollisionStoppedListenerMock.Reset();
+
+            Assert.AreEqual(childTwo.transform, tracker.LatestStartedEventData.ColliderData.transform);
+            Assert.AreEqual(targetRigidbody, tracker.LatestStartedEventData.ColliderData.attachedRigidbody);
+
+            Assert.IsTrue(tracker.IsEventDataEmpty(tracker.LatestStoppedEventData));
+
+            tracker.LatestStartedEventData.Clear();
+            tracker.LatestStoppedEventData.Clear();
+
+            /// 2. Then untouch childTwo to check stopped is called
+
+            trackerContainer.transform.position = Vector3.forward;
+
+            yield return yieldInstruction;
+
+            Assert.IsFalse(trackerCollisionStartedListenerMock.Received);
+            Assert.IsTrue(trackerCollisionStoppedListenerMock.Received);
+            trackerCollisionStartedListenerMock.Reset();
+            trackerCollisionStoppedListenerMock.Reset();
+
+            Assert.AreEqual(childTwo.transform, tracker.LatestStoppedEventData.ColliderData.transform);
+            Assert.AreEqual(targetRigidbody, tracker.LatestStoppedEventData.ColliderData.attachedRigidbody);
+
+            Assert.IsTrue(tracker.IsEventDataEmpty(tracker.LatestStartedEventData));
+
+            tracker.LatestStartedEventData.Clear();
+            tracker.LatestStoppedEventData.Clear();
+
+            /// 2. Now touch childTwo, check start is called, then switch target to kinematic
+
+            trackerContainer.transform.position = childTwo.transform.position;
+
+            yield return yieldInstruction;
+
+            Assert.IsTrue(trackerCollisionStartedListenerMock.Received);
+            Assert.IsFalse(trackerCollisionStoppedListenerMock.Received);
+            trackerCollisionStartedListenerMock.Reset();
+            trackerCollisionStoppedListenerMock.Reset();
+
+            tracker.PrepareKinematicStateChange(targetRigidbody);
+            targetRigidbody.isKinematic = true;
+
+            yield return yieldInstruction;
+
+            Assert.IsFalse(trackerCollisionStartedListenerMock.Received);
+            Assert.IsFalse(trackerCollisionStoppedListenerMock.Received);
+            trackerCollisionStartedListenerMock.Reset();
+            trackerCollisionStoppedListenerMock.Reset();
+
+            Assert.AreEqual(childTwo.transform, tracker.LatestStartedEventData.ColliderData.transform);
+            Assert.AreEqual(targetRigidbody, tracker.LatestStartedEventData.ColliderData.attachedRigidbody);
+
+            Assert.IsTrue(tracker.IsEventDataEmpty(tracker.LatestStoppedEventData));
+
+            tracker.LatestStartedEventData.Clear();
+            tracker.LatestStoppedEventData.Clear();
+
+            /// 2. Then untouch childTwo but remove kinematic state first
+
+            tracker.PrepareKinematicStateChange(targetRigidbody);
+            targetRigidbody.isKinematic = false;
+
+            yield return yieldInstruction;
+
+            Assert.IsFalse(trackerCollisionStartedListenerMock.Received);
+            Assert.IsFalse(trackerCollisionStoppedListenerMock.Received);
+            trackerCollisionStartedListenerMock.Reset();
+            trackerCollisionStoppedListenerMock.Reset();
+
+            trackerContainer.transform.position = Vector3.forward;
+
+            yield return yieldInstruction;
+
+            Assert.IsFalse(trackerCollisionStartedListenerMock.Received);
+            Assert.IsTrue(trackerCollisionStoppedListenerMock.Received);
+            trackerCollisionStartedListenerMock.Reset();
+            trackerCollisionStoppedListenerMock.Reset();
+
+            Assert.AreEqual(childTwo.transform, tracker.LatestStoppedEventData.ColliderData.transform);
+            Assert.AreEqual(targetRigidbody, tracker.LatestStoppedEventData.ColliderData.attachedRigidbody);
+
+            Assert.IsTrue(tracker.IsEventDataEmpty(tracker.LatestStartedEventData));
+
+            tracker.LatestStartedEventData.Clear();
+            tracker.LatestStoppedEventData.Clear();
+
+            /// 3. Now touch childTwo, but when kinematic is changed, in the same frame move the touch to childOne
+
+            trackerContainer.transform.position = childTwo.transform.position;
+
+            yield return yieldInstruction;
+
+            Assert.IsTrue(trackerCollisionStartedListenerMock.Received);
+            Assert.IsFalse(trackerCollisionStoppedListenerMock.Received);
+            trackerCollisionStartedListenerMock.Reset();
+            trackerCollisionStoppedListenerMock.Reset();
+
+            Assert.AreEqual(childTwo.transform, tracker.LatestStartedEventData.ColliderData.transform);
+            Assert.AreEqual(targetRigidbody, tracker.LatestStartedEventData.ColliderData.attachedRigidbody);
+
+            Assert.IsTrue(tracker.IsEventDataEmpty(tracker.LatestStoppedEventData));
+
+            tracker.LatestStartedEventData.Clear();
+            tracker.LatestStoppedEventData.Clear();
+
+            tracker.PrepareKinematicStateChange(targetRigidbody);
+            targetRigidbody.isKinematic = true;
+            trackerContainer.transform.position = childOne.transform.position;
+
+            yield return yieldInstruction;
+
+            Assert.IsTrue(trackerCollisionStartedListenerMock.Received);
+            /// Wait a frame for the trigger exit fix in 2019
+            yield return yieldInstruction;
+            Assert.IsTrue(trackerCollisionStoppedListenerMock.Received);
+            trackerCollisionStartedListenerMock.Reset();
+            trackerCollisionStoppedListenerMock.Reset();
+
+            Assert.AreEqual(childOne.transform, tracker.LatestStartedEventData.ColliderData.transform);
+            Assert.AreEqual(targetRigidbody, tracker.LatestStartedEventData.ColliderData.attachedRigidbody);
+            Assert.AreEqual(childTwo.transform, tracker.LatestStoppedEventData.ColliderData.transform);
+
+            tracker.LatestStartedEventData.Clear();
+            tracker.LatestStoppedEventData.Clear();
+
+            /// 3. Then untouch childOne but remove kinematic state first
+
+            tracker.PrepareKinematicStateChange(targetRigidbody);
+            targetRigidbody.isKinematic = false;
+            trackerContainer.transform.position = Vector3.forward;
+
+            yield return yieldInstruction;
+
+            Assert.IsFalse(trackerCollisionStartedListenerMock.Received);
+            /// Wait a frame for the trigger exit fix in 2019
+            yield return yieldInstruction;
+            Assert.IsTrue(trackerCollisionStoppedListenerMock.Received);
+            trackerCollisionStartedListenerMock.Reset();
+            trackerCollisionStoppedListenerMock.Reset();
+
+            Assert.AreEqual(childOne.transform, tracker.LatestStoppedEventData.ColliderData.transform);
+            Assert.AreEqual(targetRigidbody, tracker.LatestStoppedEventData.ColliderData.attachedRigidbody);
+
+            Assert.IsTrue(tracker.IsEventDataEmpty(tracker.LatestStartedEventData));
+
+            tracker.LatestStartedEventData.Clear();
+            tracker.LatestStoppedEventData.Clear();
+
+            /// Clean up
+
+            Object.DestroyImmediate(trackerContainer);
+            Object.DestroyImmediate(targetContainer);
+        }
+
         public class CollisionTrackerMock : CollisionTracker
         {
+            public EventData LatestStartedEventData { get; set; } = new EventData();
+            public EventData LatestStoppedEventData { get; set; } = new EventData();
+
             public virtual void SetStopCollisionsOnDisable(bool state)
             {
                 StopCollisionsOnDisable = state;
+            }
+
+            public override void OnCollisionStarted(EventData data)
+            {
+                base.OnCollisionStarted(data);
+                LatestStartedEventData = new EventData();
+                LatestStartedEventData.Set(data);
+            }
+
+            public override void OnCollisionStopped(EventData data)
+            {
+                base.OnCollisionStopped(data);
+                LatestStoppedEventData = new EventData();
+                LatestStoppedEventData.Set(data);
+            }
+
+            public virtual bool IsEventDataEmpty(EventData data)
+            {
+                return (data.ForwardSource == default && data.IsTrigger == default && data.CollisionData == default && data.ColliderData == default);
             }
         }
     }


### PR DESCRIPTION
There was an issue with the 2019 kinematic fix where if a GameObject
with multiple child colliders was touched on one collider and then
when the kinematic state changed the collider would no longer be
touched but another collider in the GameObject was touched then the
exit event would not happen for the original collider and the new
start event for the new collider would not happen.

This would mean the collision with the original collider would have
ended in the CollisionTracker but the CollisionTracker would not
have reported it, and the new collider collision would not have a
started event reported. Then when the actual new collider collision
ended it would not report it had ended correctly.

The fix is to hold a dictionary for each collider and their frame
interaction timestamp and then this is checked in the fix logic
for the Exit/Enter that happens when the kinematic state is changed.

If the collider has changed then it won't cancel the deferred
trigger exit so the exit will happen as expected, but if the collider
hasn't changed then the deferred exit will be cancelled in the enter
to prevent the enter/exit issue.

A new test has been added to prove all this logic works.