### PR TITLE
enable non xr use for zinnia

### DIFF
--- a/Runtime/Association/LoadedXrDeviceAssociation.cs
+++ b/Runtime/Association/LoadedXrDeviceAssociation.cs
@@ -5,7 +5,9 @@
     using System;
     using System.Text.RegularExpressions;
     using UnityEngine;
+#if UNITY_XR || UNITY_VR
     using UnityEngine.XR;
+#endif
 
     /// <summary>
     /// Holds <see cref="GameObject"/>s to (de)activate based on the loaded XR device's name.
@@ -23,7 +25,11 @@
         /// <inheritdoc/>
         public override bool ShouldBeActive()
         {
+#if UNITY_VR
             return Regex.IsMatch(XRSettings.loadedDeviceName, XrDeviceNamePattern);
+#else
+            return false;
+#endif
         }
     }
 }

--- a/Runtime/Association/PlatformDeviceAssociation.cs
+++ b/Runtime/Association/PlatformDeviceAssociation.cs
@@ -4,7 +4,9 @@
     using Malimbe.XmlDocumentationAttribute;
     using System.Text.RegularExpressions;
     using UnityEngine;
+#if UNITY_XR || UNITY_VR
     using UnityEngine.XR;
+#endif
 
     /// <summary>
     /// Holds <see cref="GameObject"/>s to (de)activate based on the current platform and loaded XR device type.
@@ -36,13 +38,19 @@
         {
             string modelName = "";
 #if UNITY_2020_2_OR_NEWER
+#if UNITY_XR
             InputDevice currentDevice = InputDevices.GetDeviceAtXRNode(XRNode.Head);
             modelName = currentDevice != null && currentDevice.name != null ? currentDevice.name : "";
+#endif
 #else
+#if UNITY_VR
             modelName = XRDevice.model;
 #endif
+#endif
             return Regex.IsMatch(Application.platform.ToString(), PlatformPattern) &&
+#if UNITY_VR
                 Regex.IsMatch(XRSettings.loadedDeviceName, XrSdkPattern) &&
+#endif
                 Regex.IsMatch(modelName, XrModelPattern);
 
         }

--- a/Runtime/Haptics/XRNodeHapticPulser.cs
+++ b/Runtime/Haptics/XRNodeHapticPulser.cs
@@ -1,4 +1,5 @@
-﻿namespace Zinnia.Haptics
+﻿#if UNITY_XR
+namespace Zinnia.Haptics
 {
     using Malimbe.PropertySerializationAttribute;
     using Malimbe.XmlDocumentationAttribute;
@@ -84,3 +85,4 @@
         }
     }
 }
+#endif

--- a/Runtime/Tracking/Velocity/XRNodeVelocityEstimator.cs
+++ b/Runtime/Tracking/Velocity/XRNodeVelocityEstimator.cs
@@ -1,4 +1,5 @@
-﻿namespace Zinnia.Tracking.Velocity
+﻿#if UNITY_XR
+namespace Zinnia.Tracking.Velocity
 {
     using Malimbe.MemberClearanceMethod;
     using Malimbe.PropertySerializationAttribute;
@@ -66,4 +67,5 @@
             return new XRNodeState();
         }
     }
-}
+} 
+#endif

--- a/Runtime/Zinnia.Runtime.asmdef
+++ b/Runtime/Zinnia.Runtime.asmdef
@@ -14,5 +14,18 @@
         "Malimbe.XmlDocumentationAttribute.dll"
     ],
     "autoReferenced": true,
-    "defineConstraints": []
+    "defineConstraints": [],
+    "versionDefines": [
+        {
+            "name": "com.unity.modules.xr",
+            "expression": "",
+            "define": "UNITY_XR"
+        },
+        {
+            "name": "com.unity.modules.vr",
+            "expression": "",
+            "define": "UNITY_VR"
+        }
+    ],
+    "noEngineReferences": false
 }


### PR DESCRIPTION
not to be merged directly
--------------
both XRNodeHapticPulser and XRNodeVelocityEstimator uses XRNode for serialized property,
cannot be modified readily to ignore those properties without losing the serialized data.
I chose to complete #if out the components.

PlatformDeviceAssociation (and deprecated LoadedXrDeviceAssociation) uses XRNode, XRDevice, XRSettings
but some of the logic can be ignored, so I chose to #if just those parts.
-------------------------------------
Zinnia.Runtime.asmdef added versionDefines
XRNode and InputDevices are within com.unity.modules.xr
XRDevice and XRSettings are within com.unity.modules.vr
com.unity.modules.vr depends on com.unity.modules.xr

although technically we would expect them both to be enabled in a vr project,
I chose to make separate define symbols for each of them.
--------------------------------
The following Tilia have reference to XR/VR:
"io.extendreality.tilia.camerarigs.spatialsimulator.unity": "1.4.21",
"io.extendreality.tilia.camerarigs.unityxr": "1.5.9",
"io.extendreality.tilia.camerarigs.xrpluginframework.unity": "1.1.10",
"io.extendreality.tilia.output.interactorhaptics.unity": "1.1.34",
"io.extendreality.tilia.sdk.oculusintegration.unity": "1.3.19",
"io.extendreality.tilia.sdk.steamvr.unity": "1.1.22",