### PR TITLE
feat(Utility): add extra abstracted XRDevice properties

### DIFF
--- a/Runtime/Pattern/XRDevicePatternMatcher.cs
+++ b/Runtime/Pattern/XRDevicePatternMatcher.cs
@@ -25,6 +25,18 @@
             /// </summary>
             BatteryLevel,
             /// <summary>
+            /// The number of devices found at a given node.
+            /// </summary>
+            DeviceCount,
+            /// <summary>
+            /// The device positional tracking state.
+            /// </summary>
+            HasPositionalTracking,
+            /// <summary>
+            /// The device rotational tracking state.
+            /// </summary>
+            HasRotationalTracking,
+            /// <summary>
             /// The device presence state.
             /// </summary>
             IsPresent,
@@ -32,6 +44,10 @@
             /// The device tracked state.
             /// </summary>
             IsTracked,
+            /// <summary>
+            /// The device validity.
+            /// </summary>
+            IsValid,
             /// <summary>
             /// The device manufacturer.
             /// </summary>
@@ -76,6 +92,19 @@
             PropertySource = EnumExtensions.GetByIndex<Source>(index);
         }
 
+        /// <summary>
+        /// Sets the <see cref="DeviceSource"/>.
+        /// </summary>
+        /// <param name="index">The index of the <see cref="XRNode"/>.</param>
+        public virtual void SetDeviceSource(int index)
+        {
+#if UNITY_2019_3_OR_NEWER
+            DeviceSource = EnumExtensions.GetByIndex<XRNode>(index);
+#else
+            DeviceSource = XRNode.Head;
+#endif
+        }
+
         /// <inheritdoc/>
         protected override string DefineSourceString()
         {
@@ -83,10 +112,18 @@
             {
                 case Source.BatteryLevel:
                     return XRDeviceProperties.BatteryLevel(DeviceSource).ToString();
+                case Source.DeviceCount:
+                    return XRDeviceProperties.DeviceCount(DeviceSource).ToString();
+                case Source.HasPositionalTracking:
+                    return XRDeviceProperties.HasPositionalTracking().ToString();
+                case Source.HasRotationalTracking:
+                    return XRDeviceProperties.HasRotationalTracking().ToString();
                 case Source.IsPresent:
                     return XRDeviceProperties.IsPresent().ToString();
                 case Source.IsTracked:
                     return XRDeviceProperties.IsTracked(DeviceSource).ToString();
+                case Source.IsValid:
+                    return XRDeviceProperties.IsValid(DeviceSource).ToString();
                 case Source.Manufacturer:
                     return XRDeviceProperties.Manufacturer(DeviceSource);
                 case Source.Model:

--- a/Runtime/Utility/XRDeviceProperties.cs
+++ b/Runtime/Utility/XRDeviceProperties.cs
@@ -1,9 +1,7 @@
 ﻿namespace Zinnia.Utility
 {
-#if UNITY_2019_3_OR_NEWER
     using System.Collections.Generic;
     using UnityEngine;
-#endif
     using UnityEngine.XR;
 
     /// <summary>
@@ -11,6 +9,32 @@
     /// </summary>
     public static class XRDeviceProperties
     {
+        /// <summary>
+        /// The number of devices found with the same node identifier.
+        /// </summary>
+        /// <param name="node">The node to check for.</param>
+        /// <returns>The number of devices found.</returns>
+        public static int DeviceCount(XRNode node = XRNode.Head)
+        {
+            int deviceCount = 0;
+#if UNITY_2019_3_OR_NEWER
+            List<InputDevice> devices = new List<InputDevice>();
+            InputDevices.GetDevicesAtXRNode(node, devices);
+            deviceCount = devices.Count;
+#else
+            List<XRNodeState> nodeStates = new List<XRNodeState>();
+            InputTracking.GetNodeStates(nodeStates);
+            foreach (XRNodeState nodeState in nodeStates)
+            {
+                if (nodeState.nodeType == node)
+                {
+                    deviceCount++;
+                }
+            }
+#endif
+            return deviceCount;
+        }
+
         /// <summary>
         /// Determines whether the device is present.
         /// </summary>
@@ -32,6 +56,66 @@
             isPresent = XRDevice.isPresent;
 #endif
             return isPresent;
+        }
+
+        /// <summary>
+        /// Determines whether the device has positional tracking.
+        /// </summary>
+        /// <param name="node">The node to check for.</param>
+        /// <returns>Whether the device has positional tracking.</returns>
+        public static bool HasPositionalTracking(XRNode node = XRNode.Head)
+        {
+            bool hasPositionalTracking = false;
+#if UNITY_2019_3_OR_NEWER
+            InputDevice positionalTrackingDevice = InputDevices.GetDeviceAtXRNode(node);
+            if (positionalTrackingDevice != null)
+            {
+                positionalTrackingDevice.TryGetFeatureValue(CommonUsages.trackingState, out InputTrackingState trackingState);
+                hasPositionalTracking = (trackingState & InputTrackingState.Position) != 0;
+            }
+#else
+            List<XRNodeState> nodeStates = new List<XRNodeState>();
+            InputTracking.GetNodeStates(nodeStates);
+            foreach (XRNodeState nodeState in nodeStates)
+            {
+                if (nodeState.nodeType == node)
+                {
+                    hasPositionalTracking = nodeState.TryGetPosition(out _);
+                    break;
+                }
+            }
+#endif
+            return hasPositionalTracking;
+        }
+
+        /// <summary>
+        /// Determines whether the device has rotational tracking.
+        /// </summary>
+        /// <param name="node">The node to check for.</param>
+        /// <returns>Whether the device has rotational tracking.</returns>
+        public static bool HasRotationalTracking(XRNode node = XRNode.Head)
+        {
+            bool hasRotationalTracking = false;
+#if UNITY_2019_3_OR_NEWER
+            InputDevice rotationalTrackingDevice = InputDevices.GetDeviceAtXRNode(node);
+            if (rotationalTrackingDevice != null)
+            {
+                rotationalTrackingDevice.TryGetFeatureValue(CommonUsages.trackingState, out InputTrackingState trackingState);
+                hasRotationalTracking = (trackingState & InputTrackingState.Rotation) != 0;
+            }
+#else
+            List<XRNodeState> nodeStates = new List<XRNodeState>();
+            InputTracking.GetNodeStates(nodeStates);
+            foreach (XRNodeState nodeState in nodeStates)
+            {
+                if (nodeState.nodeType == node)
+                {
+                    hasRotationalTracking = nodeState.TryGetRotation(out _);
+                    break;
+                }
+            }
+#endif
+            return hasRotationalTracking;
         }
 
         /// <summary>
@@ -80,8 +164,36 @@
             {
                 trackedDevice.TryGetFeatureValue(CommonUsages.isTracked, out isTracked);
             }
+#else
+            List<XRNodeState> nodeStates = new List<XRNodeState>();
+            InputTracking.GetNodeStates(nodeStates);
+            foreach (XRNodeState nodeState in nodeStates)
+            {
+                if (nodeState.nodeType == node)
+                {
+                    isTracked = nodeState.tracked;
+                    break;
+                }
+            }
 #endif
             return isTracked;
+        }
+
+        /// <summary>
+        /// Determines whether the device is valid.
+        /// </summary>
+        /// <param name="node">The node to check for.</param>
+        /// <returns>Whether the device is valid.</returns>
+        public static bool IsValid(XRNode node = XRNode.Head)
+        {
+            bool isValid = false;
+#if UNITY_2019_3_OR_NEWER
+            InputDevice validDevice = InputDevices.GetDeviceAtXRNode(node);
+            isValid = validDevice != null && validDevice.isValid;
+#else
+            Debug.Log("This method is only supported in Unity 2019.3 and above, it will always return `false` in any prior version.");
+#endif
+            return isValid;
         }
 
         /// <summary>
@@ -118,15 +230,52 @@
         /// <returns>The current battery level.</returns>
         public static float BatteryLevel(XRNode node = XRNode.Head)
         {
-            float batteryLevel = -1;
+            float batteryLevel = -1f;
 #if UNITY_2019_3_OR_NEWER
             InputDevice batteryLevelDevice = InputDevices.GetDeviceAtXRNode(node);
             if (batteryLevelDevice != null)
             {
                 batteryLevelDevice.TryGetFeatureValue(CommonUsages.batteryLevel, out batteryLevel);
             }
+#else
+            Debug.Log("This method is only supported in Unity 2019.3 and above, it will always return `-1f` in any prior version.");
 #endif
             return batteryLevel;
         }
+
+#if UNITY_2019_3_OR_NEWER
+        /// <summary>
+        /// Returns the first device found at the given node.
+        /// </summary>
+        /// <param name="node">The node to check for.</param>
+        /// <returns>The first found device.</returns>
+        public static InputDevice DeviceInstance(XRNode node = XRNode.Head)
+        {
+            List<InputDevice> devices = new List<InputDevice>();
+            InputDevices.GetDevicesAtXRNode(node, devices);
+
+            if (devices.Count == 0)
+            {
+                return default;
+            }
+
+            if (devices.Count > 1)
+            {
+                Debug.Log("Multiple devices found at node: " + node);
+            }
+
+            return devices[0];
+        }
+
+        /// <summary>
+        /// Determines whether the given device is the same as a default unset device.
+        /// </summary>
+        /// <param name="device">The device to check for.</param>
+        /// <returns>Whether the device is the same as a default unset device.</returns>
+        public static bool IsDeviceDefault(InputDevice device)
+        {
+            return device == default;
+        }
+#endif
     }
 }


### PR DESCRIPTION
The XRDeviceProperties class now returns data for:

* DeviceCount
* HasPositionalTracking
* HasRotationalTracking
* IsValid (but only for 2019.3 and above)

It also has a couple of new methods that are only available in 2019.3
and above:

* DeviceInstance
* IsDeviceDefault

The XRDevicePatternMatcher has been updated to match against these new
properties and it can also set the XRNode device source now via a
method.