### PR TITLE
feat(Action): allow access to surface locator destination offset

### DIFF
--- a/Runtime/Action/SurfaceChangeAction.cs
+++ b/Runtime/Action/SurfaceChangeAction.cs
@@ -67,8 +67,8 @@
                 return;
             }
 
-            Vector3 generatedOrigin = GetCollisionPoint(surfaceData.PreviousCollisionData);
-            Vector3 generatedTarget = GeneratePoint(surfaceData.Position);
+            Vector3 generatedOrigin = GetCollisionPoint(surfaceData.PreviousCollisionData, surfaceData.PositionalOffset);
+            Vector3 generatedTarget = GeneratePoint(surfaceData.Position, Vector3.zero);
 
             bool result = !generatedOrigin.ApproxEquals(generatedTarget, ChangeDistance);
             Receive(result);
@@ -89,22 +89,24 @@
         /// Attempts to get the collision point for the given <see cref="RaycastHit"/> data.
         /// </summary>
         /// <param name="collisionData">The <see cref="RaycastHit"/> data to get the collision point from.</param>
+        /// <param name="offset">The positional offset to apply.</param>
         /// <returns>The collision point.</returns>
-        protected virtual Vector3 GetCollisionPoint(RaycastHit collisionData)
+        protected virtual Vector3 GetCollisionPoint(RaycastHit collisionData, Vector3 offset)
         {
-            return collisionData.transform != null ? GeneratePoint(collisionData.point) : Vector3.zero;
+            return collisionData.transform != null ? GeneratePoint(collisionData.point, offset) : Vector3.zero;
         }
 
         /// <summary>
         /// Creates a <see cref="Vector3"/> based on the given point for the valid axes.
         /// </summary>
         /// <param name="point">The Point to generate the <see cref="Vector3"/> from.</param>
+        /// <param name="offset">The positional offset to apply.</param>
         /// <returns>The point only within the valid axes.</returns>
-        protected virtual Vector3 GeneratePoint(Vector3 point)
+        protected virtual Vector3 GeneratePoint(Vector3 point, Vector3 offset)
         {
-            float resultX = CheckAxis.xState ? point.x : 0f;
-            float resultY = CheckAxis.yState ? point.y : 0f;
-            float resultZ = CheckAxis.zState ? point.z : 0f;
+            float resultX = CheckAxis.xState ? point.x + offset.x : 0f;
+            float resultY = CheckAxis.yState ? point.y + offset.y : 0f;
+            float resultZ = CheckAxis.zState ? point.z + offset.z : 0f;
             return new Vector3(resultX, resultY, resultZ);
         }
 

--- a/Runtime/Data/Type/SurfaceData.cs
+++ b/Runtime/Data/Type/SurfaceData.cs
@@ -27,6 +27,11 @@
         public Vector3 Direction { get; set; }
 
         /// <summary>
+        /// Positional offset data that has been applied to the collision point.
+        /// </summary>
+        public Vector3 PositionalOffset { get; set; }
+
+        /// <summary>
         /// <see cref="RaycastHit"/> data about the current collision.
         /// </summary>
         public RaycastHit CollisionData { get; set; }
@@ -61,8 +66,9 @@
         public override void Clear()
         {
             base.Clear();
-            Origin = new Vector3();
-            Direction = new Vector3();
+            Origin = Vector3.zero;
+            Direction = Vector3.zero;
+            PositionalOffset = Vector3.zero;
             CollisionData = new RaycastHit();
             PreviousCollisionData = new RaycastHit();
         }

--- a/Runtime/Tracking/SurfaceLocator.cs
+++ b/Runtime/Tracking/SurfaceLocator.cs
@@ -288,6 +288,7 @@
             surfaceData.CollisionData = collision;
             surfaceData.Transform = surfaceData.CollisionData.transform;
             surfaceData.PositionOverride = surfaceData.CollisionData.point + DestinationOffset;
+            surfaceData.PositionalOffset = DestinationOffset;
         }
 
         /// <summary>

--- a/Tests/Editor/Action/SurfaceChangeActionTest.cs
+++ b/Tests/Editor/Action/SurfaceChangeActionTest.cs
@@ -95,9 +95,9 @@ namespace Test.Zinnia.Action
             return true;
         }
 
-        protected override Vector3 GetCollisionPoint(RaycastHit collisionData)
+        protected override Vector3 GetCollisionPoint(RaycastHit collisionData, Vector3 offset)
         {
-            return GeneratePoint(collisionData.point);
+            return GeneratePoint(collisionData.point, offset);
         }
     }
 }


### PR DESCRIPTION
The Surface Change Action actually needs to access the offset that the
SurfaceLocator has on it, but there is no way of directly getting this
so the SurfaceData has now been updated to contain a Positional Offset
property that can be set by the Surface Locator and then accessed by
the Surface Change Action.