### PR TITLE
fix(Data): allow list drawer to save changes

### DIFF
--- a/Editor/Data/Type/DefaultObservableListDrawer.cs
+++ b/Editor/Data/Type/DefaultObservableListDrawer.cs
@@ -18,6 +18,14 @@
         /// The label style.
         /// </summary>
         protected readonly GUIContent propertyReferenceLabel = new GUIContent("Elements");
+        /// <summary>
+        /// Whether to set the serialized list data.
+        /// </summary>
+        protected bool setSerializedList;
+        /// <summary>
+        /// The serialized list object.
+        /// </summary>
+        protected SerializedObject referenceObject;
 
         /// <inheritdoc/>
         public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
@@ -33,10 +41,18 @@
             using (new EditorGUI.IndentLevelScope())
             using (new EditorGUI.DisabledScope(Application.isPlaying))
             {
-                SerializedObject referenceObject = new SerializedObject(propertyObject);
+                if (!setSerializedList)
+                {
+                    referenceObject = new SerializedObject(propertyObject);
+                    setSerializedList = true;
+                }
+
                 SerializedProperty elements = referenceObject.FindProperty(propertyReference);
                 EditorGUILayout.PropertyField(elements, propertyReferenceLabel, true);
-                referenceObject.ApplyModifiedProperties();
+                if (referenceObject.ApplyModifiedProperties())
+                {
+                    setSerializedList = false;
+                }
             }
         }
     }


### PR DESCRIPTION
The Observable List Drawer has an issue in Unity 2021.2 where making
changes to a linked list will not save due to the way the serialized
object is obtained as new every frame, this means that the object
can be out of date and load in the old changes.

This also was a cause of an issue where having the linked list
component on the same component as the actual list meant it would not
save changes.

The fix is to only get the new version of the serialized list object
if any changes have been made and therefore it won't attempt to get
it every frame.