### PR TITLE
fix(Tracking): ensure velocity is not set on kinematic rigidbody

### DIFF
--- a/Runtime/Tracking/Follow/Modifier/Property/Position/RigidbodyVelocity.cs
+++ b/Runtime/Tracking/Follow/Modifier/Property/Position/RigidbodyVelocity.cs
@@ -71,7 +71,7 @@
             Vector3 velocityTarget = positionDelta / deltaTime;
             Vector3 calculatedVelocity = Vector3.MoveTowards(cachedTargetRigidbody.velocity, velocityTarget, MaxDistanceDelta / deltaTime);
 
-            if (calculatedVelocity.sqrMagnitude < VelocityLimit)
+            if (!cachedTargetRigidbody.isKinematic && calculatedVelocity.sqrMagnitude < VelocityLimit)
             {
                 cachedTargetRigidbody.velocity = calculatedVelocity;
             }

--- a/Runtime/Tracking/Velocity/VelocityApplier.cs
+++ b/Runtime/Tracking/Velocity/VelocityApplier.cs
@@ -74,7 +74,7 @@
         /// </summary>
         public virtual void Apply()
         {
-            if (!this.IsValidState() || Source == null || Target == null)
+            if (!this.IsValidState() || Source == null || Target == null || Target.isKinematic)
             {
                 return;
             }


### PR DESCRIPTION
Rigidbodies cannot have velocities set on them if they are kinematic as they are not actually part of the physics simulation when kinematic so this fix just ensures the kinematic state is checked before trying to apply a velocity to a rigidbody.