### PR TITLE
fix(Tracking): stop artificial velocity applier running when disabled

### DIFF
--- a/Runtime/Tracking/Velocity/ArtificialVelocityApplier.cs
+++ b/Runtime/Tracking/Velocity/ArtificialVelocityApplier.cs
@@ -2,6 +2,7 @@
 {
     using System.Collections;
     using UnityEngine;
+    using Zinnia.Extension;
 
     /// <summary>
     /// Derived from <see cref="ArtificialVelocityApplierProcess"/> to apply artificial velocities to the <see cref="Target"/> by changing the <see cref="Transform"/> properties.
@@ -19,6 +20,11 @@
         /// <inheritdoc />
         public override void Apply()
         {
+            if (!this.IsValidState())
+            {
+                return;
+            }
+
             CancelDeceleration();
             canProcess = true;
             decelerationRoutine = StartCoroutine(BeginDeceleration());
@@ -29,7 +35,7 @@
         /// </summary>
         public override void CancelDeceleration()
         {
-            canProcess = false;
+            base.CancelDeceleration();
             if (decelerationRoutine != null)
             {
                 StopCoroutine(decelerationRoutine);


### PR DESCRIPTION
The ArtificialVelocityApplier was still applying velocity via the `Apply` method even if the component was disabled.

This is because originally it used the `[RequiresBehaviourState]` Malimbe tag but when it was separated out from the process parent, this was not updated when malimbe was removed.

This has been fixed now by ensuring the valid state of the object is present before running the `Apply` method.