### PR TITLE
feat(Utility): allow pipeline shader to select material

### DIFF
--- a/Runtime/Data/Operation/Mutation/TransformEulerRotationMutator.cs
+++ b/Runtime/Data/Operation/Mutation/TransformEulerRotationMutator.cs
@@ -108,38 +108,40 @@
         /// <inheritdoc/>
         protected override float GetGlobalAxisValue(int axis)
         {
-            return Target.transform.eulerAngles[axis];
+            return Target != null ? Target.transform.eulerAngles[axis] : default;
         }
 
         /// <inheritdoc/>
         protected override float GetLocalAxisValue(int axis)
         {
-            return Target.transform.localEulerAngles[axis];
+            return Target != null ? Target.transform.localEulerAngles[axis] : default;
         }
 
         /// <inheritdoc/>
-        protected override Vector3 IncrementGlobal(Vector3 input)
+        protected override Vector3 GetNewSetValue(Vector3 input)
         {
-            Vector3 originPosition = GetOriginPosition();
-            Target.transform.rotation = Quaternion.Euler(Target.transform.eulerAngles + input);
-            ApplyRotationOriginPosition(originPosition);
-
-            return Target.transform.eulerAngles;
+            return input;
         }
 
         /// <inheritdoc/>
-        protected override Vector3 IncrementLocal(Vector3 input)
+        protected override Vector3 GetNewIncrementValue(Vector3 input)
         {
-            Vector3 originPosition = GetOriginPosition();
-            Target.transform.localRotation = Quaternion.Euler(Target.transform.localEulerAngles + input);
-            ApplyRotationOriginPosition(originPosition);
+            if (Target == null)
+            {
+                return default;
+            }
 
-            return Target.transform.localEulerAngles;
+            return (UseLocalValues ? Target.transform.localEulerAngles : Target.transform.eulerAngles) + input;
         }
 
         /// <inheritdoc/>
-        protected override Vector3 SetGlobal(Vector3 input)
+        protected override Vector3 SetGlobalTargetValue(Vector3 input)
         {
+            if (Target == null)
+            {
+                return default;
+            }
+
             Vector3 originPosition = GetOriginPosition();
             Target.transform.eulerAngles = input;
             ApplyRotationOriginPosition(originPosition);
@@ -148,8 +150,13 @@
         }
 
         /// <inheritdoc/>
-        protected override Vector3 SetLocal(Vector3 input)
+        protected override Vector3 SetLocalTargetValue(Vector3 input)
         {
+            if (Target == null)
+            {
+                return default;
+            }
+
             Vector3 originPosition = GetOriginPosition();
             Target.transform.localEulerAngles = input;
             ApplyRotationOriginPosition(originPosition);

--- a/Runtime/Data/Operation/Mutation/TransformPositionMutator.cs
+++ b/Runtime/Data/Operation/Mutation/TransformPositionMutator.cs
@@ -103,37 +103,52 @@
         /// <inheritdoc/>
         protected override float GetGlobalAxisValue(int axis)
         {
-            return Target.transform.position[axis];
+            return Target != null ? Target.transform.position[axis] : default;
         }
 
         /// <inheritdoc/>
         protected override float GetLocalAxisValue(int axis)
         {
-            return Target.transform.localPosition[axis];
+            return Target != null ? Target.transform.localPosition[axis] : default;
         }
 
         /// <inheritdoc/>
-        protected override Vector3 IncrementGlobal(Vector3 input)
+        protected override Vector3 GetNewSetValue(Vector3 input)
         {
-            return Target.transform.position += LockIncrementInput(GetFacingDirection() * input);
+            return LockSetInput(GetFacingDirection() * input);
         }
 
         /// <inheritdoc/>
-        protected override Vector3 IncrementLocal(Vector3 input)
+        protected override Vector3 GetNewIncrementValue(Vector3 input)
         {
-            return Target.transform.localPosition += LockIncrementInput(GetFacingDirection() * input);
+            if (Target == null)
+            {
+                return default;
+            }
+
+            return (UseLocalValues ? Target.transform.localPosition : Target.transform.position) + LockIncrementInput(GetFacingDirection() * input);
         }
 
         /// <inheritdoc/>
-        protected override Vector3 SetGlobal(Vector3 input)
+        protected override Vector3 SetGlobalTargetValue(Vector3 input)
         {
-            return Target.transform.position = LockSetInput(GetFacingDirection() * input);
+            if (Target == null)
+            {
+                return default;
+            }
+
+            return Target.transform.position = input;
         }
 
         /// <inheritdoc/>
-        protected override Vector3 SetLocal(Vector3 input)
+        protected override Vector3 SetLocalTargetValue(Vector3 input)
         {
-            return Target.transform.localPosition = LockSetInput(GetFacingDirection() * input);
+            if (Target == null)
+            {
+                return default;
+            }
+
+            return Target.transform.localPosition = input;
         }
 
         /// <summary>

--- a/Runtime/Data/Operation/Mutation/TransformScaleMutator.cs
+++ b/Runtime/Data/Operation/Mutation/TransformScaleMutator.cs
@@ -11,39 +11,52 @@
         /// <inheritdoc/>
         protected override float GetGlobalAxisValue(int axis)
         {
-            return Target.transform.lossyScale[axis];
+            return Target != null ? Target.transform.lossyScale[axis] : default;
         }
 
         /// <inheritdoc/>
         protected override float GetLocalAxisValue(int axis)
         {
-            return Target.transform.localScale[axis];
+            return Target != null ? Target.transform.localScale[axis] : default;
         }
 
         /// <inheritdoc/>
-        protected override Vector3 IncrementGlobal(Vector3 input)
+        protected override Vector3 GetNewSetValue(Vector3 input)
         {
-            Vector3 globalScale = Target.transform.lossyScale + input;
-            Target.transform.SetGlobalScale(globalScale);
-            return globalScale;
+            return input;
         }
 
         /// <inheritdoc/>
-        protected override Vector3 IncrementLocal(Vector3 input)
+        protected override Vector3 GetNewIncrementValue(Vector3 input)
         {
-            return Target.transform.localScale += input;
+            if (Target == null)
+            {
+                return default;
+            }
+
+            return (UseLocalValues ? Target.transform.localScale : Target.transform.lossyScale) + input;
         }
 
         /// <inheritdoc/>
-        protected override Vector3 SetGlobal(Vector3 input)
+        protected override Vector3 SetGlobalTargetValue(Vector3 input)
         {
+            if (Target == null)
+            {
+                return default;
+            }
+
             Target.transform.SetGlobalScale(input);
             return input;
         }
 
         /// <inheritdoc/>
-        protected override Vector3 SetLocal(Vector3 input)
+        protected override Vector3 SetLocalTargetValue(Vector3 input)
         {
+            if (Target == null)
+            {
+                return default;
+            }
+
             return Target.transform.localScale = input;
         }
     }

--- a/Runtime/Utility/PipelineMaterialApplier.cs
+++ b/Runtime/Utility/PipelineMaterialApplier.cs
@@ -36,6 +36,23 @@
                     pipelineName = value;
                 }
             }
+            [Tooltip("The name of the pipeline shader to match the Material collection to.")]
+            [SerializeField]
+            private string pipelineShaderName = "";
+            /// <summary>
+            /// The name of the pipeline shader to match the <see cref="Material"/> collection to.
+            /// </summary>
+            public string PipelineShaderName
+            {
+                get
+                {
+                    return pipelineShaderName;
+                }
+                set
+                {
+                    pipelineShaderName = value;
+                }
+            }
 
             [Tooltip("The Material collection to set the Renderer materials to if using this render pipeline.")]
             [SerializeField]
@@ -105,7 +122,19 @@
 #if UNITY_2019_1_OR_NEWER && !ZINNIA_IGNORE_PIPELINE_MATERIALS
             foreach (PipelineMaterials pipeline in Pipelines)
             {
-                if (Regex.IsMatch(GraphicsSettings.currentRenderPipeline != null ? GraphicsSettings.currentRenderPipeline.name : "default", pipeline.PipelineName))
+                string nameMatch = "default";
+                string shaderMatch = "default";
+
+                if (GraphicsSettings.currentRenderPipeline != null)
+                {
+                    nameMatch = GraphicsSettings.currentRenderPipeline.name;
+                    shaderMatch = GraphicsSettings.currentRenderPipeline.defaultShader.ToString();
+                }
+
+                bool nameCheck = !string.IsNullOrEmpty(pipeline.PipelineName) && Regex.IsMatch(nameMatch, pipeline.PipelineName);
+                bool shaderCheck = !string.IsNullOrEmpty(pipeline.PipelineShaderName) && Regex.IsMatch(shaderMatch, pipeline.PipelineShaderName);
+
+                if (nameCheck || shaderCheck)
                 {
                     Target.sharedMaterials = pipeline.Materials;
                     break;

--- a/Tests/Editor/Data/Operation/Mutation/TransformPositionMutatorTest.cs
+++ b/Tests/Editor/Data/Operation/Mutation/TransformPositionMutatorTest.cs
@@ -4,6 +4,7 @@ using Zinnia.Data.Type;
 namespace Test.Zinnia.Data.Operation.Mutation
 {
     using NUnit.Framework;
+    using Test.Zinnia.Utility.Mock;
     using UnityEngine;
     using UnityEngine.TestTools.Utils;
 
@@ -28,6 +29,13 @@ namespace Test.Zinnia.Data.Operation.Mutation
         [Test]
         public void SetPropertyLocal()
         {
+            UnityEventListenerMock preMutatedMock = new UnityEventListenerMock();
+            UnityEventListenerMock postMutatedMock = new UnityEventListenerMock();
+            UnityEventListenerMock mutationSkippedMock = new UnityEventListenerMock();
+            subject.PreMutated.AddListener(preMutatedMock.Listen);
+            subject.PostMutated.AddListener(postMutatedMock.Listen);
+            subject.MutationSkipped.AddListener(mutationSkippedMock.Listen);
+
             Vector3EqualityComparer comparer = new Vector3EqualityComparer(0.1f);
             GameObject target = new GameObject("TransformPositionMutatorTest");
 
@@ -36,11 +44,50 @@ namespace Test.Zinnia.Data.Operation.Mutation
             subject.MutateOnAxis = Vector3State.True;
 
             Assert.That(target.transform.localPosition, Is.EqualTo(Vector3.zero).Using(comparer));
+            Assert.IsFalse(preMutatedMock.Received);
+            Assert.IsFalse(postMutatedMock.Received);
+            Assert.IsFalse(mutationSkippedMock.Received);
 
             Vector3 input = new Vector3(10f, 20f, 30f);
             subject.SetProperty(input);
 
             Assert.That(target.transform.localPosition, Is.EqualTo(input).Using(comparer));
+            Assert.IsTrue(preMutatedMock.Received);
+            Assert.IsTrue(postMutatedMock.Received);
+            Assert.IsFalse(mutationSkippedMock.Received);
+
+            preMutatedMock.Reset();
+            postMutatedMock.Reset();
+            mutationSkippedMock.Reset();
+
+            subject.AllowMutate = false;
+
+            Vector3 inputB = new Vector3(40f, 50f, 60f);
+            subject.SetProperty(inputB);
+
+            Assert.That(target.transform.localPosition, Is.EqualTo(input).Using(comparer));
+            Assert.IsTrue(preMutatedMock.Received);
+            Assert.IsFalse(postMutatedMock.Received);
+            Assert.IsTrue(mutationSkippedMock.Received);
+
+            Object.DestroyImmediate(target);
+        }
+
+        [Test]
+        public void SetPropertyLocalNoTarget()
+        {
+            Vector3EqualityComparer comparer = new Vector3EqualityComparer(0.1f);
+            GameObject target = new GameObject("TransformPositionMutatorTest");
+
+            subject.UseLocalValues = true;
+            subject.MutateOnAxis = Vector3State.True;
+
+            Assert.That(target.transform.localPosition, Is.EqualTo(Vector3.zero).Using(comparer));
+
+            Vector3 input = new Vector3(10f, 20f, 30f);
+            subject.SetProperty(input);
+
+            Assert.That(target.transform.localPosition, Is.EqualTo(Vector3.zero).Using(comparer));
 
             Object.DestroyImmediate(target);
         }
@@ -48,6 +95,13 @@ namespace Test.Zinnia.Data.Operation.Mutation
         [Test]
         public void SetPropertyGlobal()
         {
+            UnityEventListenerMock preMutatedMock = new UnityEventListenerMock();
+            UnityEventListenerMock postMutatedMock = new UnityEventListenerMock();
+            UnityEventListenerMock mutationSkippedMock = new UnityEventListenerMock();
+            subject.PreMutated.AddListener(preMutatedMock.Listen);
+            subject.PostMutated.AddListener(postMutatedMock.Listen);
+            subject.MutationSkipped.AddListener(mutationSkippedMock.Listen);
+
             Vector3EqualityComparer comparer = new Vector3EqualityComparer(0.1f);
             GameObject target = new GameObject("TransformPositionMutatorTest");
 
@@ -56,11 +110,49 @@ namespace Test.Zinnia.Data.Operation.Mutation
             subject.MutateOnAxis = Vector3State.True;
 
             Assert.That(target.transform.position, Is.EqualTo(Vector3.zero).Using(comparer));
+            Assert.IsFalse(preMutatedMock.Received);
+            Assert.IsFalse(postMutatedMock.Received);
+            Assert.IsFalse(mutationSkippedMock.Received);
 
             Vector3 input = new Vector3(10f, 20f, 30f);
             subject.SetProperty(input);
 
             Assert.That(target.transform.position, Is.EqualTo(input).Using(comparer));
+            Assert.IsTrue(preMutatedMock.Received);
+            Assert.IsTrue(postMutatedMock.Received);
+            Assert.IsFalse(mutationSkippedMock.Received);
+
+            subject.AllowMutate = false;
+            preMutatedMock.Reset();
+            postMutatedMock.Reset();
+            mutationSkippedMock.Reset();
+
+            Vector3 inputB = new Vector3(40f, 50f, 60f);
+            subject.SetProperty(inputB);
+
+            Assert.That(target.transform.localPosition, Is.EqualTo(input).Using(comparer));
+            Assert.IsTrue(preMutatedMock.Received);
+            Assert.IsFalse(postMutatedMock.Received);
+            Assert.IsTrue(mutationSkippedMock.Received);
+
+            Object.DestroyImmediate(target);
+        }
+
+        [Test]
+        public void SetPropertyGlobalNoTarget()
+        {
+            Vector3EqualityComparer comparer = new Vector3EqualityComparer(0.1f);
+            GameObject target = new GameObject("TransformPositionMutatorTest");
+
+            subject.UseLocalValues = false;
+            subject.MutateOnAxis = Vector3State.True;
+
+            Assert.That(target.transform.position, Is.EqualTo(Vector3.zero).Using(comparer));
+
+            Vector3 input = new Vector3(10f, 20f, 30f);
+            subject.SetProperty(input);
+
+            Assert.That(target.transform.position, Is.EqualTo(Vector3.zero).Using(comparer));
 
             Object.DestroyImmediate(target);
         }
@@ -112,6 +204,13 @@ namespace Test.Zinnia.Data.Operation.Mutation
         [Test]
         public void IncrementPropertyLocal()
         {
+            UnityEventListenerMock preMutatedMock = new UnityEventListenerMock();
+            UnityEventListenerMock postMutatedMock = new UnityEventListenerMock();
+            UnityEventListenerMock mutationSkippedMock = new UnityEventListenerMock();
+            subject.PreMutated.AddListener(preMutatedMock.Listen);
+            subject.PostMutated.AddListener(postMutatedMock.Listen);
+            subject.MutationSkipped.AddListener(mutationSkippedMock.Listen);
+
             Vector3EqualityComparer comparer = new Vector3EqualityComparer(0.1f);
             GameObject target = new GameObject("TransformPositionMutatorTest");
 
@@ -120,15 +219,40 @@ namespace Test.Zinnia.Data.Operation.Mutation
             subject.MutateOnAxis = Vector3State.True;
 
             Assert.That(target.transform.localPosition, Is.EqualTo(Vector3.zero).Using(comparer));
+            Assert.IsFalse(preMutatedMock.Received);
+            Assert.IsFalse(postMutatedMock.Received);
+            Assert.IsFalse(mutationSkippedMock.Received);
 
             Vector3 input = new Vector3(10f, 20f, 30f);
             subject.IncrementProperty(input);
 
             Assert.That(target.transform.localPosition, Is.EqualTo(input).Using(comparer));
+            Assert.IsTrue(preMutatedMock.Received);
+            Assert.IsTrue(postMutatedMock.Received);
+            Assert.IsFalse(mutationSkippedMock.Received);
 
+            preMutatedMock.Reset();
+            postMutatedMock.Reset();
+            mutationSkippedMock.Reset();
             subject.IncrementProperty(input);
 
             Assert.That(target.transform.localPosition, Is.EqualTo(input * 2f).Using(comparer));
+            Assert.IsTrue(preMutatedMock.Received);
+            Assert.IsTrue(postMutatedMock.Received);
+            Assert.IsFalse(mutationSkippedMock.Received);
+
+            subject.AllowMutate = false;
+            preMutatedMock.Reset();
+            postMutatedMock.Reset();
+            mutationSkippedMock.Reset();
+
+            Vector3 inputB = new Vector3(40f, 50f, 60f);
+            subject.IncrementProperty(inputB);
+
+            Assert.That(target.transform.localPosition, Is.EqualTo(input * 2f).Using(comparer));
+            Assert.IsTrue(preMutatedMock.Received);
+            Assert.IsFalse(postMutatedMock.Received);
+            Assert.IsTrue(mutationSkippedMock.Received);
 
             Object.DestroyImmediate(target);
         }
@@ -136,6 +260,13 @@ namespace Test.Zinnia.Data.Operation.Mutation
         [Test]
         public void IncrementPropertyGlobal()
         {
+            UnityEventListenerMock preMutatedMock = new UnityEventListenerMock();
+            UnityEventListenerMock postMutatedMock = new UnityEventListenerMock();
+            UnityEventListenerMock mutationSkippedMock = new UnityEventListenerMock();
+            subject.PreMutated.AddListener(preMutatedMock.Listen);
+            subject.PostMutated.AddListener(postMutatedMock.Listen);
+            subject.MutationSkipped.AddListener(mutationSkippedMock.Listen);
+
             Vector3EqualityComparer comparer = new Vector3EqualityComparer(0.1f);
             GameObject target = new GameObject("TransformPositionMutatorTest");
 
@@ -144,15 +275,37 @@ namespace Test.Zinnia.Data.Operation.Mutation
             subject.MutateOnAxis = Vector3State.True;
 
             Assert.That(target.transform.position, Is.EqualTo(Vector3.zero).Using(comparer));
+            Assert.IsFalse(preMutatedMock.Received);
+            Assert.IsFalse(postMutatedMock.Received);
+            Assert.IsFalse(mutationSkippedMock.Received);
 
             Vector3 input = new Vector3(10f, 20f, 30f);
             subject.IncrementProperty(input);
 
             Assert.That(target.transform.position, Is.EqualTo(input).Using(comparer));
+            Assert.IsTrue(preMutatedMock.Received);
+            Assert.IsTrue(postMutatedMock.Received);
+            Assert.IsFalse(mutationSkippedMock.Received);
 
             subject.IncrementProperty(input);
 
             Assert.That(target.transform.position, Is.EqualTo(input * 2f).Using(comparer));
+            Assert.IsTrue(preMutatedMock.Received);
+            Assert.IsTrue(postMutatedMock.Received);
+            Assert.IsFalse(mutationSkippedMock.Received);
+
+            subject.AllowMutate = false;
+            preMutatedMock.Reset();
+            postMutatedMock.Reset();
+            mutationSkippedMock.Reset();
+
+            Vector3 inputB = new Vector3(40f, 50f, 60f);
+            subject.IncrementProperty(inputB);
+
+            Assert.That(target.transform.localPosition, Is.EqualTo(input * 2f).Using(comparer));
+            Assert.IsTrue(preMutatedMock.Received);
+            Assert.IsFalse(postMutatedMock.Received);
+            Assert.IsTrue(mutationSkippedMock.Received);
 
             Object.DestroyImmediate(target);
         }


### PR DESCRIPTION
The PipelineMaterialApplier component now has another option to determine what render pipeline is being used. The default Pipeline Shader name can also be provided to determine which render pipeline is active as sometimes the name is not robust enough as it can be renamed in the settings.